### PR TITLE
Alternate formats for extracting data from MDX query

### DIFF
--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -179,6 +179,111 @@ class CellService:
         finally:
             self.delete_cellset(cellset_id=cellset_id)
 
+    def get_data(self, mdx, format=None, cell_properites=None, dim_properties=None, top=None):
+        """ Execute an MDX query and return the results in the format specified
+
+        :param mdx_or_view: A string that is an MDX Query or view name
+        :param format: String specifying the format to return. Supported: 'celldict' (default), 'csv', 'raw', 'dataframe' (pandas), 'array', dygraph'
+        :param cell_properties: List of properties to be queried from the cell. E.g. ['Value', 'Ordinal', 'RuleDerived', ...]
+        :param dim_properties: List of properties to be queried from the dimension. E.g. ['UniqueName','Attributes', ...]
+        :param top: Integer limiting the number of cells and the number or rows returned
+        :return: Content in format specified above.
+        """
+        cellset_id = self.create_cellset(mdx=mdx)
+        try:
+            return self.extract_cellset(cellset_id=cellset_id, format=format, cell_properties=cell_properites, dim_properties=dim_properties, top=top)
+        finally:
+            self.delete_cellset(cellset_id=cellset_id)
+
+    def extract_cellset(self, cellset_id, format=None, cell_properties=None, dim_properties=None, top=None):
+        """ Extract data from an existing cellset and return the results in the format specified
+
+        :param cellset_id: String; ID of existing cellset
+        :param format: String specifying the format to return. Supported: 'celldict' (default), 'csv', 'raw', 'dataframe' (pandas), 'array', dygraph'
+        :param cell_properties: List of properties to be queried from the cell. E.g. ['Value', 'Ordinal', 'RuleDerived', ...]
+        :param dim_properties: List of properties to be queried from the dimension. E.g. ['UniqueName','Attributes', ...]
+        :param top: Integer limiting the number of cells and the number or rows returned
+        :return: Content in format specified above.
+        """        
+        if format == 'values':
+            data =  self.extract_cellset_values(cellset_id=cellset_id)
+            return (cell["Value"] for cell in data["Cells"])
+        elif format == 'csv':
+            return self.extract_cellset_csv(cellset_id=cellset_id)
+        elif format == 'dataframe':
+            raw_csv = self.extract_cellset_csv(cellset_id=cellset_id)
+            memory_file = StringIO(raw_csv)
+            return pd.read_csv(memory_file, sep=',')
+        else:
+            if not cell_properties:
+                cell_properties = ['Value', 'Ordinal']
+            elif 'Ordinal' not in cell_properties:
+                cell_properties.append('Ordinal')
+
+            data = self.extract_cellset_full(cellset_id=cellset_id, cell_properties=cell_properties, dim_properties=dim_properties, top=top)
+
+            if format == 'raw':
+                return data
+            elif format == 'array':
+                return Utils.build_arrays_from_cellset(raw_cellset_as_dict=data)
+            elif format == 'dygraph':
+                return Utils.build_dygraph_arrays_from_cellset(raw_cellset_as_dict=data)
+            else:
+                return Utils.build_content_from_cellset(raw_cellset_as_dict=data,
+                                                        cell_properties=cell_properties,
+                                                        top=top)
+
+    def extract_cellset_full(self, cellset_id, cell_properties=None, dim_properties=None, top=None):
+        """ Extract full Cellset data and return the raw data from TM1
+        
+        :param cellset_id: String; ID of existing cellset
+        :param cell_properties: List of properties to be queried from the cell. E.g. ['Value', 'Ordinal', 'RuleDerived', ...]
+        :param dim_properties: List of properties to be queried from the dimension. E.g. ['UniqueName','Attributes', ...]
+        :param top: Integer limiting the number of cells and the number or rows returned
+        :return: Raw format from TM1.
+        """
+        if not cell_properties:
+            cell_properties = ['Value', 'Ordinal']
+        elif 'Ordinal' not in cell_properties:
+            cell_properties.append('Ordinal')
+
+        if not dim_properties:
+            dim_properties = ['UniqueName']
+        elif 'UniqueName' not in dim_properties:
+            dim_properties.append('UniqueName')
+
+        request = "/api/v1/Cellsets('{cellset_id}')?$expand=" \
+                  "Cube($select=Name;$expand=Dimensions($select=Name))," \
+                  "Axes($expand=Tuples($expand=Members($select=Name;$expand=Element{dim_properties}){top_rows}))," \
+                  "Cells($select={cell_properties}{top_cells})" \
+            .format(cellset_id=cellset_id,
+                    top_rows=";$top={}".format(top) if top else "",
+                    cell_properties=",".join(cell_properties),
+                    dim_properties=("($select=" + ",".join(dim_properties) + ")") if len(dim_properties) > 0 else "",
+                    top_cells=";$top={}".format(top) if top else "")
+        response = self._rest.GET(request=request)
+        return response.json()
+
+    def extract_cellset_values(self, cellset_id):
+        """ Extract Cellset data and return only the cells and values
+        
+        :param cellset_id: String; ID of existing cellset
+        :return: Raw format from TM1.
+        """
+        request = "/api/v1/Cellsets('{}')?$expand=Cells($select=Value)".format(cellset_id)
+        response = self._rest.GET(request=request, data='')
+        return response.json()
+
+    def extract_cellset_csv(self, cellset_id):
+        """ Execute Cellset and return only the 'Content', in csv format
+        
+        :param cellset_id: String; ID of existing cellset
+        :return: Raw format from TM1.
+        """
+        request = "/api/v1/Cellsets('{}')/Content".format(cellset_id)
+        data = self._rest.GET(request)
+        return data.text
+
     def execute_cellset(self, cellset_id, cell_properties=None, top=None):
         """ Execute Cellset and return the cells with their properties
         

--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -179,38 +179,41 @@ class CellService:
         finally:
             self.delete_cellset(cellset_id=cellset_id)
 
-    def get_data(self, mdx, format=None, cell_properites=None, dim_properties=None, top=None):
+    def get_data(self, mdx, result_format=None, cell_properties=None, elem_properties=None, top=None, value_precision=None):
         """ Execute an MDX query and return the results in the format specified
 
-        :param mdx_or_view: A string that is an MDX Query or view name
-        :param format: String specifying the format to return. Supported: 'celldict' (default), 'csv', 'raw', 'dataframe' (pandas), 'array', dygraph'
+        :param mdx: A string that is an MDX Query
+        :param result_format: String specifying the format to return. Supported: 'celldict' (default), 'csv', 'raw', 'dataframe' (pandas), 'array', dygraph'
         :param cell_properties: List of properties to be queried from the cell. E.g. ['Value', 'Ordinal', 'RuleDerived', ...]
-        :param dim_properties: List of properties to be queried from the dimension. E.g. ['UniqueName','Attributes', ...]
+        :param elem_properties: List of properties to be queried from the elements. E.g. ['UniqueName','Attributes', ...]
         :param top: Integer limiting the number of cells and the number or rows returned
+        :param value_precision: Integer (optional) specifying number of decimal places to return
+
         :return: Content in format specified above.
         """
         cellset_id = self.create_cellset(mdx=mdx)
         try:
-            return self.extract_cellset(cellset_id=cellset_id, format=format, cell_properties=cell_properites, dim_properties=dim_properties, top=top)
+            return self.extract_cellset(cellset_id=cellset_id, result_format=result_format, cell_properties=cell_properties, elem_properties=elem_properties, top=top, value_precision=value_precision)
         finally:
             self.delete_cellset(cellset_id=cellset_id)
 
-    def extract_cellset(self, cellset_id, format=None, cell_properties=None, dim_properties=None, top=None):
+    def extract_cellset(self, cellset_id, result_format=None, cell_properties=None, elem_properties=None, top=None, value_precision=None):
         """ Extract data from an existing cellset and return the results in the format specified
 
         :param cellset_id: String; ID of existing cellset
-        :param format: String specifying the format to return. Supported: 'celldict' (default), 'csv', 'raw', 'dataframe' (pandas), 'array', dygraph'
+        :param result_format: String specifying the format to return. Supported: 'celldict' (default), 'csv', 'raw', 'dataframe' (pandas), 'array', dygraph'
         :param cell_properties: List of properties to be queried from the cell. E.g. ['Value', 'Ordinal', 'RuleDerived', ...]
-        :param dim_properties: List of properties to be queried from the dimension. E.g. ['UniqueName','Attributes', ...]
+        :param elem_properties: List of properties to be queried from the elements. E.g. ['UniqueName','Attributes', ...]
         :param top: Integer limiting the number of cells and the number or rows returned
+        :param value_precision: Integer (optional) specifying number of decimal places to return
         :return: Content in format specified above.
         """        
-        if format == 'values':
+        if result_format == 'values':
             data =  self.extract_cellset_values(cellset_id=cellset_id)
             return (cell["Value"] for cell in data["Cells"])
-        elif format == 'csv':
+        elif result_format == 'csv':
             return self.extract_cellset_csv(cellset_id=cellset_id)
-        elif format == 'dataframe':
+        elif result_format == 'dataframe':
             raw_csv = self.extract_cellset_csv(cellset_id=cellset_id)
             memory_file = StringIO(raw_csv)
             return pd.read_csv(memory_file, sep=',')
@@ -220,25 +223,25 @@ class CellService:
             elif 'Ordinal' not in cell_properties:
                 cell_properties.append('Ordinal')
 
-            data = self.extract_cellset_full(cellset_id=cellset_id, cell_properties=cell_properties, dim_properties=dim_properties, top=top)
+            data = self.extract_cellset_full(cellset_id=cellset_id, cell_properties=cell_properties, elem_properties=elem_properties, top=top)
 
-            if format == 'raw':
+            if result_format == 'raw':
                 return data
-            elif format == 'array':
-                return Utils.build_arrays_from_cellset(raw_cellset_as_dict=data)
-            elif format == 'dygraph':
-                return Utils.build_dygraph_arrays_from_cellset(raw_cellset_as_dict=data)
+            elif result_format == 'array':
+                return Utils.build_arrays_from_cellset(raw_cellset_as_dict=data, value_precision=value_precision)
+            elif result_format == 'dygraph':
+                return Utils.build_dygraph_arrays_from_cellset(raw_cellset_as_dict=data, value_precision=value_precision)
             else:
                 return Utils.build_content_from_cellset(raw_cellset_as_dict=data,
                                                         cell_properties=cell_properties,
                                                         top=top)
 
-    def extract_cellset_full(self, cellset_id, cell_properties=None, dim_properties=None, top=None):
+    def extract_cellset_full(self, cellset_id, cell_properties=None, elem_properties=None, top=None):
         """ Extract full Cellset data and return the raw data from TM1
         
         :param cellset_id: String; ID of existing cellset
         :param cell_properties: List of properties to be queried from the cell. E.g. ['Value', 'Ordinal', 'RuleDerived', ...]
-        :param dim_properties: List of properties to be queried from the dimension. E.g. ['UniqueName','Attributes', ...]
+        :param elem_properties: List of properties to be queried from the elements. E.g. ['UniqueName','Attributes', ...]
         :param top: Integer limiting the number of cells and the number or rows returned
         :return: Raw format from TM1.
         """
@@ -247,19 +250,19 @@ class CellService:
         elif 'Ordinal' not in cell_properties:
             cell_properties.append('Ordinal')
 
-        if not dim_properties:
-            dim_properties = ['UniqueName']
-        elif 'UniqueName' not in dim_properties:
-            dim_properties.append('UniqueName')
+        if not elem_properties:
+            elem_properties = ['UniqueName']
+        elif 'UniqueName' not in elem_properties:
+            elem_properties.append('UniqueName')
 
         request = "/api/v1/Cellsets('{cellset_id}')?$expand=" \
                   "Cube($select=Name;$expand=Dimensions($select=Name))," \
-                  "Axes($expand=Tuples($expand=Members($select=Name;$expand=Element{dim_properties}){top_rows}))," \
+                  "Axes($expand=Tuples($expand=Members($select=Name;$expand=Element{elem_properties}){top_rows}))," \
                   "Cells($select={cell_properties}{top_cells})" \
             .format(cellset_id=cellset_id,
                     top_rows=";$top={}".format(top) if top else "",
                     cell_properties=",".join(cell_properties),
-                    dim_properties=("($select=" + ",".join(dim_properties) + ")") if len(dim_properties) > 0 else "",
+                    elem_properties=("($select=" + ",".join(elem_properties) + ")") if len(elem_properties) > 0 else "",
                     top_cells=";$top={}".format(top) if top else "")
         response = self._rest.GET(request=request)
         return response.json()

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -111,26 +111,46 @@ def build_content_from_cellset(raw_cellset_as_dict, cell_properties, top=None):
     return content_as_dict
 
 
-def build_arrays_from_cellset(raw_cellset_as_dict):
+def build_arrays_from_cellset(raw_cellset_as_dict, value_precision=None):
     """ Transform raw 1,2 or 3-dimension cellset data into concise dictionary
 
+    * Useful for grids or charting libraries that want an array of cell values per row
+    * Returns 3-dimensional cell structure for tabbed grids or multiple charts
+    * Rows and pages are dicts, addressable by their name. Proper order of rows can be obtained in headers[1]
+    * Example 'cells' return format:
+        'cells': { 
+            '10100': { 
+                'Net Operating Income': [ 19832724.72429739,
+                                          20365654.788303416,
+                                          20729201.329183243,
+                                          20480205.20121749],
+                'Revenue': [ 28981046.50724231,
+                             29512482.207418434,
+                             29913730.038971487,
+                             29563345.9542385]},
+            '10200': { 
+                'Net Operating Income': [ 9853293.623709997,
+                                           10277650.763958748,
+                                           10466934.096533755,
+                                           10333095.839474997],
+                'Revenue': [ 13888143.710000003,
+                             14300216.43,
+                             14502421.63,
+                             14321501.940000001]}
+        },
+
+
     :param raw_cellset_as_dict: raw data from TM1
+    :param value_precision: Integer (optional) specifying number of decimal places to return
     :return: dict : { titles: [], headers: [axis][], cells: { Page0: { Row0: { [row values], Row1: [], ...}, ...}, ...} }
     """
-    dimensionality = len(raw_cellset_as_dict['Axes'])
-    cardinality = [raw_cellset_as_dict['Axes'][axis]['Cardinality'] for axis in range(dimensionality)]
+    header_map = build_headers_from_cellset(raw_cellset_as_dict, force_header_dimensionality=3)
+    titles = header_map['titles']
+    headers = header_map['headers']
+    cardinality = header_map['cardinality']
 
-    headerMap = build_headers_from_cellset(raw_cellset_as_dict)
-    titles = headerMap['titles']
-    headers = headerMap['headers']
-
-    # Handle 1, 2 and 3-dimensional cellsets. Use dummy row/page headers when missing
-    if len(headers) == 1:
-        headers += [[{'name':'Row'}]]
-        cardinality.insert(1,1)
-    if len(headers) == 2:
-        headers += [[{'name':'Page'}]]
-        cardinality.insert(2,1)
+    if value_precision:
+        value_format_string = "{{0:.{}f}}".format(value_precision)
 
     cells = {}
     ordinal_cells = 0
@@ -141,33 +161,47 @@ def build_arrays_from_cellset(raw_cellset_as_dict):
             yHeader = headers[1][y]['name']
             row = []
             for x in range(cardinality[0]):
-                row.append(raw_cellset_as_dict['Cells'][ordinal_cells]['Value'] or 0)
+                raw_value = raw_cellset_as_dict['Cells'][ordinal_cells]['Value'] or 0
+                if value_precision:
+                    row.append(float(value_format_string.format(raw_value)))
+                else:
+                    row.append(raw_value)
                 ordinal_cells += 1
             pages[yHeader] = row
         cells[zHeader] = pages
 
     return {'titles':titles, 'headers':headers, 'cells':cells}
 
-def build_dygraph_arrays_from_cellset(raw_cellset_as_dict):
+def build_dygraph_arrays_from_cellset(raw_cellset_as_dict, value_precision=None):
     """ Transform raw 1,2 or 3-dimension cellset data into dygraph-friendly format
 
+    * Useful for grids or charting libraries that want an array of cell values per column
+    * Returns 3-dimensional cell structure for tabbed grids or multiple charts
+    * Example 'cells' return format:
+        'cells': { 
+            '10100': [ 
+                ['Q1-2004', 28981046.50724231, 19832724.72429739],
+                ['Q2-2004', 29512482.207418434, 20365654.788303416],
+                ['Q3-2004', 29913730.038971487, 20729201.329183243],
+                ['Q4-2004', 29563345.9542385, 20480205.20121749]],
+            '10200': [ 
+                ['Q1-2004', 13888143.710000003, 9853293.623709997],
+                ['Q2-2004', 14300216.43, 10277650.763958748],
+                ['Q3-2004', 14502421.63, 10466934.096533755],
+                ['Q4-2004', 14321501.940000001, 10333095.839474997]]
+        },
+    
     :param raw_cellset_as_dict: raw data from TM1
+    :param value_precision: Integer (optional) specifying number of decimal places to return
     :return: dict : { titles: [], headers: [axis][], cells: { Page0: [  [column name, column values], [], ... ], ...} }
     """
-    dimensionality = len(raw_cellset_as_dict['Axes'])
-    cardinality = [raw_cellset_as_dict['Axes'][axis]['Cardinality'] for axis in range(dimensionality)]
+    header_map = build_headers_from_cellset(raw_cellset_as_dict, force_header_dimensionality=3)
+    titles = header_map['titles']
+    headers = header_map['headers']
+    cardinality = header_map['cardinality']
 
-    headerMap = build_headers_from_cellset(raw_cellset_as_dict)
-    titles = headerMap['titles']
-    headers = headerMap['headers']
-
-    # Handle 1, 2 and 3-dimensional cellsets. Use dummy row/page headers when missing
-    if len(headers) == 1:
-        headers += [[{'name':'Row'}]]
-        cardinality.insert(1,1)
-    if len(headers) == 2:
-        headers += [[{'name':'Page'}]]
-        cardinality.insert(2,1)
+    if value_precision:
+        value_format_string = "{{0:.{}f}}".format(value_precision)
 
     cells = {}
     for z in range(cardinality[2]):
@@ -178,13 +212,17 @@ def build_dygraph_arrays_from_cellset(raw_cellset_as_dict):
             row = [xHeader]
             for y in range(cardinality[1]):
                 cell_addr = (x + cardinality[0] * y + cardinality[0] * cardinality[1] * z)
-                row.append(float("{0:.1f}".format(raw_cellset_as_dict['Cells'][cell_addr]['Value'] or 0)))
+                raw_value = raw_cellset_as_dict['Cells'][cell_addr]['Value'] or 0
+                if value_precision:
+                    row.append(float(value_format_string.format(raw_value)))
+                else:
+                    row.append(raw_value)
             page.append(row)
         cells[zHeader] = page
 
     return {'titles':titles, 'headers':headers, 'cells':cells}
 
-def build_headers_from_cellset(raw_cellset_as_dict):
+def build_headers_from_cellset(raw_cellset_as_dict, force_header_dimensionality=1):
     """ Extract dimension headers from cellset into dictionary of titles (slicers) and headers (row,column,page)
     * Title dimensions are in a single list of dicts 
     * Header dimensions are a 2-dimensional list of the element dicts
@@ -198,6 +236,7 @@ def build_headers_from_cellset(raw_cellset_as_dict):
       * Stacked headers will each be listed in the 'memebers' list; Single-element headers will only have one element in list
 
     :param raw_cellset_as_dict: raw data from TM1
+    :param force_header_dimensionality: An optional integer (1,2 or 3) to force headers array to be at least that long
     :return: dict : { titles: [ { 'name': 'xx', 'members': {} } ], headers: [axis][ { 'name': 'xx', 'members': {} } ] }
     """
     dimensionality = len(raw_cellset_as_dict['Axes'])
@@ -224,7 +263,21 @@ def build_headers_from_cellset(raw_cellset_as_dict):
         else:
             headers.append(members)
 
-    return {'titles':titles, 'headers':headers}
+
+    dimensionality = len(headers)
+    cardinality = [len(headers[axis]) for axis in range(dimensionality)]
+
+    # Handle 1, 2 and 3-dimensional cellsets. Use dummy row/page headers when missing
+    if dimensionality == 1 and force_header_dimensionality > 1:
+        headers += [[{'name':'Row'}]]
+        cardinality.insert(1,1)
+        dimensionality += 1
+    if dimensionality == 2 and force_header_dimensionality > 2:
+        headers += [[{'name':'Page'}]]
+        cardinality.insert(2,1)
+        dimensionality += 1
+
+    return {'titles':titles, 'headers':headers, 'dimensionality':dimensionality, 'cardinality':cardinality}
 
 
 def element_names_from_element_unqiue_names(element_unique_names):


### PR DESCRIPTION
Hello!
First, thank you for the really useful TM1py project!
I wanted to pull data in a different format than what your normal execute_mdx gives so I added a couple of additional formats.  I am driving multiple synched Dygraphs from a single query with these new methods. I added a get_data method that works like execute_mdx, but could also be used as a template for a similar get_data_from_view, allowing data to be returned in any format. The get_data could be used as a drop-in replacement for execute_mdx since the additional arguments are optional and default is how execute_mdx works. (If you want to do this, I can change the order of the arguments so calls with positional arguments will still work).

Let me know what you think. I can give you some sample code so you can see the different formats in action. I have one that queries the default "Planning Sample" server from TM1 so it should work for everyone.
Thanks!