### PR TITLE
Refactoring get_data function

### DIFF
--- a/TM1py/Objects/Process.py
+++ b/TM1py/Objects/Process.py
@@ -321,8 +321,8 @@ class Process(TM1Object):
         self._variables.append(variable)
         # 2. handle UI info
         var_type = 33 if type == 'Numeric' else 32
-        # '\r' !
-        variable_ui_data = 'VarType=' + str(var_type) + '\r' + 'ColType=' + str(827) + '\r'
+        # '\f' !
+        variable_ui_data = 'VarType=' + str(var_type) + '\f' + 'ColType=' + str(827) + '\f'
         """
         mapping VariableUIData:
             VarType 33 -> Numeric

--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -179,6 +179,111 @@ class CellService:
         finally:
             self.delete_cellset(cellset_id=cellset_id)
 
+    def get_data(self, mdx, format=None, cell_properites=None, dim_properties=None, top=None):
+        """ Execute an MDX query and return the results in the format specified
+
+        :param mdx_or_view: A string that is an MDX Query or view name
+        :param format: String specifying the format to return. Supported: 'celldict' (default), 'csv', 'raw', 'dataframe' (pandas), 'array', dygraph'
+        :param cell_properties: List of properties to be queried from the cell. E.g. ['Value', 'Ordinal', 'RuleDerived', ...]
+        :param dim_properties: List of properties to be queried from the dimension. E.g. ['UniqueName','Attributes', ...]
+        :param top: Integer limiting the number of cells and the number or rows returned
+        :return: Content in format specified above.
+        """
+        cellset_id = self.create_cellset(mdx=mdx)
+        try:
+            return self.extract_cellset(cellset_id=cellset_id, format=format, cell_properties=cell_properites, dim_properties=dim_properties, top=top)
+        finally:
+            self.delete_cellset(cellset_id=cellset_id)
+
+    def extract_cellset(self, cellset_id, format=None, cell_properties=None, dim_properties=None, top=None):
+        """ Extract data from an existing cellset and return the results in the format specified
+
+        :param cellset_id: String; ID of existing cellset
+        :param format: String specifying the format to return. Supported: 'celldict' (default), 'csv', 'raw', 'dataframe' (pandas), 'array', dygraph'
+        :param cell_properties: List of properties to be queried from the cell. E.g. ['Value', 'Ordinal', 'RuleDerived', ...]
+        :param dim_properties: List of properties to be queried from the dimension. E.g. ['UniqueName','Attributes', ...]
+        :param top: Integer limiting the number of cells and the number or rows returned
+        :return: Content in format specified above.
+        """        
+        if format == 'values':
+            data =  self.extract_cellset_values(cellset_id=cellset_id)
+            return (cell["Value"] for cell in data["Cells"])
+        elif format == 'csv':
+            return self.extract_cellset_csv(cellset_id=cellset_id)
+        elif format == 'dataframe':
+            raw_csv = self.extract_cellset_csv(cellset_id=cellset_id)
+            memory_file = StringIO(raw_csv)
+            return pd.read_csv(memory_file, sep=',')
+        else:
+            if not cell_properties:
+                cell_properties = ['Value', 'Ordinal']
+            elif 'Ordinal' not in cell_properties:
+                cell_properties.append('Ordinal')
+
+            data = self.extract_cellset_full(cellset_id=cellset_id, cell_properties=cell_properties, dim_properties=dim_properties, top=top)
+
+            if format == 'raw':
+                return data
+            elif format == 'array':
+                return Utils.build_arrays_from_cellset(raw_cellset_as_dict=data)
+            elif format == 'dygraph':
+                return Utils.build_dygraph_arrays_from_cellset(raw_cellset_as_dict=data)
+            else:
+                return Utils.build_content_from_cellset(raw_cellset_as_dict=data,
+                                                        cell_properties=cell_properties,
+                                                        top=top)
+
+    def extract_cellset_full(self, cellset_id, cell_properties=None, dim_properties=None, top=None):
+        """ Extract full Cellset data and return the raw data from TM1
+        
+        :param cellset_id: String; ID of existing cellset
+        :param cell_properties: List of properties to be queried from the cell. E.g. ['Value', 'Ordinal', 'RuleDerived', ...]
+        :param dim_properties: List of properties to be queried from the dimension. E.g. ['UniqueName','Attributes', ...]
+        :param top: Integer limiting the number of cells and the number or rows returned
+        :return: Raw format from TM1.
+        """
+        if not cell_properties:
+            cell_properties = ['Value', 'Ordinal']
+        elif 'Ordinal' not in cell_properties:
+            cell_properties.append('Ordinal')
+
+        if not dim_properties:
+            dim_properties = ['UniqueName']
+        elif 'UniqueName' not in dim_properties:
+            dim_properties.append('UniqueName')
+
+        request = "/api/v1/Cellsets('{cellset_id}')?$expand=" \
+                  "Cube($select=Name;$expand=Dimensions($select=Name))," \
+                  "Axes($expand=Tuples($expand=Members($select=Name;$expand=Element{dim_properties}){top_rows}))," \
+                  "Cells($select={cell_properties}{top_cells})" \
+            .format(cellset_id=cellset_id,
+                    top_rows=";$top={}".format(top) if top else "",
+                    cell_properties=",".join(cell_properties),
+                    dim_properties=("($select=" + ",".join(dim_properties) + ")") if len(dim_properties) > 0 else "",
+                    top_cells=";$top={}".format(top) if top else "")
+        response = self._rest.GET(request=request)
+        return response.json()
+
+    def extract_cellset_values(self, cellset_id):
+        """ Extract Cellset data and return only the cells and values
+        
+        :param cellset_id: String; ID of existing cellset
+        :return: Raw format from TM1.
+        """
+        request = "/api/v1/Cellsets('{}')?$expand=Cells($select=Value)".format(cellset_id)
+        response = self._rest.GET(request=request, data='')
+        return response.json()
+
+    def extract_cellset_csv(self, cellset_id):
+        """ Execute Cellset and return only the 'Content', in csv format
+        
+        :param cellset_id: String; ID of existing cellset
+        :return: Raw format from TM1.
+        """
+        request = "/api/v1/Cellsets('{}')/Content".format(cellset_id)
+        data = self._rest.GET(request)
+        return data.text
+
     def execute_cellset(self, cellset_id, cell_properties=None, top=None):
         """ Execute Cellset and return the cells with their properties
         

--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -179,38 +179,41 @@ class CellService:
         finally:
             self.delete_cellset(cellset_id=cellset_id)
 
-    def get_data(self, mdx, format=None, cell_properites=None, dim_properties=None, top=None):
+    def get_data(self, mdx, result_format=None, cell_properties=None, elem_properties=None, top=None, value_precision=None):
         """ Execute an MDX query and return the results in the format specified
 
-        :param mdx_or_view: A string that is an MDX Query or view name
-        :param format: String specifying the format to return. Supported: 'celldict' (default), 'csv', 'raw', 'dataframe' (pandas), 'array', dygraph'
+        :param mdx: A string that is an MDX Query
+        :param result_format: String specifying the format to return. Supported: 'celldict' (default), 'csv', 'raw', 'dataframe' (pandas), 'array', dygraph'
         :param cell_properties: List of properties to be queried from the cell. E.g. ['Value', 'Ordinal', 'RuleDerived', ...]
-        :param dim_properties: List of properties to be queried from the dimension. E.g. ['UniqueName','Attributes', ...]
+        :param elem_properties: List of properties to be queried from the elements. E.g. ['UniqueName','Attributes', ...]
         :param top: Integer limiting the number of cells and the number or rows returned
+        :param value_precision: Integer (optional) specifying number of decimal places to return
+
         :return: Content in format specified above.
         """
         cellset_id = self.create_cellset(mdx=mdx)
         try:
-            return self.extract_cellset(cellset_id=cellset_id, format=format, cell_properties=cell_properites, dim_properties=dim_properties, top=top)
+            return self.extract_cellset(cellset_id=cellset_id, result_format=result_format, cell_properties=cell_properties, elem_properties=elem_properties, top=top, value_precision=value_precision)
         finally:
             self.delete_cellset(cellset_id=cellset_id)
 
-    def extract_cellset(self, cellset_id, format=None, cell_properties=None, dim_properties=None, top=None):
+    def extract_cellset(self, cellset_id, result_format=None, cell_properties=None, elem_properties=None, top=None, value_precision=None):
         """ Extract data from an existing cellset and return the results in the format specified
 
         :param cellset_id: String; ID of existing cellset
-        :param format: String specifying the format to return. Supported: 'celldict' (default), 'csv', 'raw', 'dataframe' (pandas), 'array', dygraph'
+        :param result_format: String specifying the format to return. Supported: 'celldict' (default), 'csv', 'raw', 'dataframe' (pandas), 'array', dygraph'
         :param cell_properties: List of properties to be queried from the cell. E.g. ['Value', 'Ordinal', 'RuleDerived', ...]
-        :param dim_properties: List of properties to be queried from the dimension. E.g. ['UniqueName','Attributes', ...]
+        :param elem_properties: List of properties to be queried from the elements. E.g. ['UniqueName','Attributes', ...]
         :param top: Integer limiting the number of cells and the number or rows returned
+        :param value_precision: Integer (optional) specifying number of decimal places to return
         :return: Content in format specified above.
         """        
-        if format == 'values':
+        if result_format == 'values':
             data =  self.extract_cellset_values(cellset_id=cellset_id)
             return (cell["Value"] for cell in data["Cells"])
-        elif format == 'csv':
+        elif result_format == 'csv':
             return self.extract_cellset_csv(cellset_id=cellset_id)
-        elif format == 'dataframe':
+        elif result_format == 'dataframe':
             raw_csv = self.extract_cellset_csv(cellset_id=cellset_id)
             memory_file = StringIO(raw_csv)
             return pd.read_csv(memory_file, sep=',')
@@ -220,25 +223,25 @@ class CellService:
             elif 'Ordinal' not in cell_properties:
                 cell_properties.append('Ordinal')
 
-            data = self.extract_cellset_full(cellset_id=cellset_id, cell_properties=cell_properties, dim_properties=dim_properties, top=top)
+            data = self.extract_cellset_full(cellset_id=cellset_id, cell_properties=cell_properties, elem_properties=elem_properties, top=top)
 
-            if format == 'raw':
+            if result_format == 'raw':
                 return data
-            elif format == 'array':
-                return Utils.build_arrays_from_cellset(raw_cellset_as_dict=data)
-            elif format == 'dygraph':
-                return Utils.build_dygraph_arrays_from_cellset(raw_cellset_as_dict=data)
+            elif result_format == 'array':
+                return Utils.build_arrays_from_cellset(raw_cellset_as_dict=data, value_precision=value_precision)
+            elif result_format == 'dygraph':
+                return Utils.build_dygraph_arrays_from_cellset(raw_cellset_as_dict=data, value_precision=value_precision)
             else:
                 return Utils.build_content_from_cellset(raw_cellset_as_dict=data,
                                                         cell_properties=cell_properties,
                                                         top=top)
 
-    def extract_cellset_full(self, cellset_id, cell_properties=None, dim_properties=None, top=None):
+    def extract_cellset_full(self, cellset_id, cell_properties=None, elem_properties=None, top=None):
         """ Extract full Cellset data and return the raw data from TM1
         
         :param cellset_id: String; ID of existing cellset
         :param cell_properties: List of properties to be queried from the cell. E.g. ['Value', 'Ordinal', 'RuleDerived', ...]
-        :param dim_properties: List of properties to be queried from the dimension. E.g. ['UniqueName','Attributes', ...]
+        :param elem_properties: List of properties to be queried from the elements. E.g. ['UniqueName','Attributes', ...]
         :param top: Integer limiting the number of cells and the number or rows returned
         :return: Raw format from TM1.
         """
@@ -247,19 +250,19 @@ class CellService:
         elif 'Ordinal' not in cell_properties:
             cell_properties.append('Ordinal')
 
-        if not dim_properties:
-            dim_properties = ['UniqueName']
-        elif 'UniqueName' not in dim_properties:
-            dim_properties.append('UniqueName')
+        if not elem_properties:
+            elem_properties = ['UniqueName']
+        elif 'UniqueName' not in elem_properties:
+            elem_properties.append('UniqueName')
 
         request = "/api/v1/Cellsets('{cellset_id}')?$expand=" \
                   "Cube($select=Name;$expand=Dimensions($select=Name))," \
-                  "Axes($expand=Tuples($expand=Members($select=Name;$expand=Element{dim_properties}){top_rows}))," \
+                  "Axes($expand=Tuples($expand=Members($select=Name;$expand=Element{elem_properties}){top_rows}))," \
                   "Cells($select={cell_properties}{top_cells})" \
             .format(cellset_id=cellset_id,
                     top_rows=";$top={}".format(top) if top else "",
                     cell_properties=",".join(cell_properties),
-                    dim_properties=("($select=" + ",".join(dim_properties) + ")") if len(dim_properties) > 0 else "",
+                    elem_properties=("($select=" + ",".join(elem_properties) + ")") if len(elem_properties) > 0 else "",
                     top_cells=";$top={}".format(top) if top else "")
         response = self._rest.GET(request=request)
         return response.json()

--- a/TM1py/Services/ProcessService.py
+++ b/TM1py/Services/ProcessService.py
@@ -154,18 +154,15 @@ class ProcessService(ObjectService):
         :param parameters: Deprecated! dictionary, for instance {"Parameters": [ { "Name": "pLegalEntity", "Value": "UK01" }] }
         :return:
         """
+        request = "/api/v1/Processes('{}')/tm1.Execute".format(process_name)
         if not parameters:
             if kwargs:
                 parameters = {"Parameters": []}
                 for parameter_name, parameter_value in kwargs.items():
-                    print(parameter_name, parameter_value)
                     parameters["Parameters"].append({"Name": parameter_name, "Value": parameter_value})
             else:
                 parameters = {}
-
-        body = {"Process@odata.bind": "Processes('{}')".format(process_name),
-                **parameters}
-        return self._rest.POST("/api/v1/ExecuteProcess", data=json.dumps(body, ensure_ascii=False))
+        return self._rest.POST(request=request, data=json.dumps(parameters, ensure_ascii=False))
 
     def execute_ti_code(self, lines_prolog, lines_epilog=None):
         """ Execute lines of code on the TM1 Server

--- a/TM1py/Services/RESTService.py
+++ b/TM1py/Services/RESTService.py
@@ -156,10 +156,10 @@ class RESTService:
         try:
             # ProductVersion >= TM1 10.2.2 FP 6
             self.POST('/api/v1/ActiveSession/tm1.Close', '')
-
         except TM1pyException:
             # ProductVersion < TM1 10.2.2 FP 6
             self.POST('/api/logout', '')
+        self._s.close()
 
     def _start_session(self):
         """ perform a simple GET request (Ask for the TM1 Version) to start a session

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -111,7 +111,7 @@ def build_content_from_cellset(raw_cellset_as_dict, cell_properties, top=None):
     return content_as_dict
 
 
-def build_arrays_from_cellset(raw_cellset_as_dict, value_precision=None):
+def build_ui_arrays_from_cellset(raw_cellset_as_dict, value_precision):
     """ Transform raw 1,2 or 3-dimension cellset data into concise dictionary
 
     * Useful for grids or charting libraries that want an array of cell values per row
@@ -170,9 +170,10 @@ def build_arrays_from_cellset(raw_cellset_as_dict, value_precision=None):
             pages[yHeader] = row
         cells[zHeader] = pages
 
-    return {'titles':titles, 'headers':headers, 'cells':cells}
+    return {'titles': titles, 'headers': headers, 'cells': cells}
 
-def build_dygraph_arrays_from_cellset(raw_cellset_as_dict, value_precision=None):
+
+def build_ui_dygraph_arrays_from_cellset(raw_cellset_as_dict, value_precision=None):
     """ Transform raw 1,2 or 3-dimension cellset data into dygraph-friendly format
 
     * Useful for grids or charting libraries that want an array of cell values per column

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -111,26 +111,46 @@ def build_content_from_cellset(raw_cellset_as_dict, cell_properties, top=None):
     return content_as_dict
 
 
-def build_arrays_from_cellset(raw_cellset_as_dict):
+def build_arrays_from_cellset(raw_cellset_as_dict, value_precision=None):
     """ Transform raw 1,2 or 3-dimension cellset data into concise dictionary
 
+    * Useful for grids or charting libraries that want an array of cell values per row
+    * Returns 3-dimensional cell structure for tabbed grids or multiple charts
+    * Rows and pages are dicts, addressable by their name. Proper order of rows can be obtained in headers[1]
+    * Example 'cells' return format:
+        'cells': { 
+            '10100': { 
+                'Net Operating Income': [ 19832724.72429739,
+                                          20365654.788303416,
+                                          20729201.329183243,
+                                          20480205.20121749],
+                'Revenue': [ 28981046.50724231,
+                             29512482.207418434,
+                             29913730.038971487,
+                             29563345.9542385]},
+            '10200': { 
+                'Net Operating Income': [ 9853293.623709997,
+                                           10277650.763958748,
+                                           10466934.096533755,
+                                           10333095.839474997],
+                'Revenue': [ 13888143.710000003,
+                             14300216.43,
+                             14502421.63,
+                             14321501.940000001]}
+        },
+
+
     :param raw_cellset_as_dict: raw data from TM1
+    :param value_precision: Integer (optional) specifying number of decimal places to return
     :return: dict : { titles: [], headers: [axis][], cells: { Page0: { Row0: { [row values], Row1: [], ...}, ...}, ...} }
     """
-    dimensionality = len(raw_cellset_as_dict['Axes'])
-    cardinality = [raw_cellset_as_dict['Axes'][axis]['Cardinality'] for axis in range(dimensionality)]
+    header_map = build_headers_from_cellset(raw_cellset_as_dict, force_header_dimensionality=3)
+    titles = header_map['titles']
+    headers = header_map['headers']
+    cardinality = header_map['cardinality']
 
-    headerMap = build_headers_from_cellset(raw_cellset_as_dict)
-    titles = headerMap['titles']
-    headers = headerMap['headers']
-
-    # Handle 1, 2 and 3-dimensional cellsets. Use dummy row/page headers when missing
-    if len(headers) == 1:
-        headers += [[{'name':'Row'}]]
-        cardinality.insert(1,1)
-    if len(headers) == 2:
-        headers += [[{'name':'Page'}]]
-        cardinality.insert(2,1)
+    if value_precision:
+        value_format_string = "{{0:.{}f}}".format(value_precision)
 
     cells = {}
     ordinal_cells = 0
@@ -141,33 +161,47 @@ def build_arrays_from_cellset(raw_cellset_as_dict):
             yHeader = headers[1][y]['name']
             row = []
             for x in range(cardinality[0]):
-                row.append(raw_cellset_as_dict['Cells'][ordinal_cells]['Value'] or 0)
+                raw_value = raw_cellset_as_dict['Cells'][ordinal_cells]['Value'] or 0
+                if value_precision:
+                    row.append(float(value_format_string.format(raw_value)))
+                else:
+                    row.append(raw_value)
                 ordinal_cells += 1
             pages[yHeader] = row
         cells[zHeader] = pages
 
     return {'titles':titles, 'headers':headers, 'cells':cells}
 
-def build_dygraph_arrays_from_cellset(raw_cellset_as_dict):
+def build_dygraph_arrays_from_cellset(raw_cellset_as_dict, value_precision=None):
     """ Transform raw 1,2 or 3-dimension cellset data into dygraph-friendly format
 
+    * Useful for grids or charting libraries that want an array of cell values per column
+    * Returns 3-dimensional cell structure for tabbed grids or multiple charts
+    * Example 'cells' return format:
+        'cells': { 
+            '10100': [ 
+                ['Q1-2004', 28981046.50724231, 19832724.72429739],
+                ['Q2-2004', 29512482.207418434, 20365654.788303416],
+                ['Q3-2004', 29913730.038971487, 20729201.329183243],
+                ['Q4-2004', 29563345.9542385, 20480205.20121749]],
+            '10200': [ 
+                ['Q1-2004', 13888143.710000003, 9853293.623709997],
+                ['Q2-2004', 14300216.43, 10277650.763958748],
+                ['Q3-2004', 14502421.63, 10466934.096533755],
+                ['Q4-2004', 14321501.940000001, 10333095.839474997]]
+        },
+    
     :param raw_cellset_as_dict: raw data from TM1
+    :param value_precision: Integer (optional) specifying number of decimal places to return
     :return: dict : { titles: [], headers: [axis][], cells: { Page0: [  [column name, column values], [], ... ], ...} }
     """
-    dimensionality = len(raw_cellset_as_dict['Axes'])
-    cardinality = [raw_cellset_as_dict['Axes'][axis]['Cardinality'] for axis in range(dimensionality)]
+    header_map = build_headers_from_cellset(raw_cellset_as_dict, force_header_dimensionality=3)
+    titles = header_map['titles']
+    headers = header_map['headers']
+    cardinality = header_map['cardinality']
 
-    headerMap = build_headers_from_cellset(raw_cellset_as_dict)
-    titles = headerMap['titles']
-    headers = headerMap['headers']
-
-    # Handle 1, 2 and 3-dimensional cellsets. Use dummy row/page headers when missing
-    if len(headers) == 1:
-        headers += [[{'name':'Row'}]]
-        cardinality.insert(1,1)
-    if len(headers) == 2:
-        headers += [[{'name':'Page'}]]
-        cardinality.insert(2,1)
+    if value_precision:
+        value_format_string = "{{0:.{}f}}".format(value_precision)
 
     cells = {}
     for z in range(cardinality[2]):
@@ -178,13 +212,17 @@ def build_dygraph_arrays_from_cellset(raw_cellset_as_dict):
             row = [xHeader]
             for y in range(cardinality[1]):
                 cell_addr = (x + cardinality[0] * y + cardinality[0] * cardinality[1] * z)
-                row.append(float("{0:.1f}".format(raw_cellset_as_dict['Cells'][cell_addr]['Value'] or 0)))
+                raw_value = raw_cellset_as_dict['Cells'][cell_addr]['Value'] or 0
+                if value_precision:
+                    row.append(float(value_format_string.format(raw_value)))
+                else:
+                    row.append(raw_value)
             page.append(row)
         cells[zHeader] = page
 
     return {'titles':titles, 'headers':headers, 'cells':cells}
 
-def build_headers_from_cellset(raw_cellset_as_dict):
+def build_headers_from_cellset(raw_cellset_as_dict, force_header_dimensionality=1):
     """ Extract dimension headers from cellset into dictionary of titles (slicers) and headers (row,column,page)
     * Title dimensions are in a single list of dicts 
     * Header dimensions are a 2-dimensional list of the element dicts
@@ -198,6 +236,7 @@ def build_headers_from_cellset(raw_cellset_as_dict):
       * Stacked headers will each be listed in the 'memebers' list; Single-element headers will only have one element in list
 
     :param raw_cellset_as_dict: raw data from TM1
+    :param force_header_dimensionality: An optional integer (1,2 or 3) to force headers array to be at least that long
     :return: dict : { titles: [ { 'name': 'xx', 'members': {} } ], headers: [axis][ { 'name': 'xx', 'members': {} } ] }
     """
     dimensionality = len(raw_cellset_as_dict['Axes'])
@@ -224,7 +263,21 @@ def build_headers_from_cellset(raw_cellset_as_dict):
         else:
             headers.append(members)
 
-    return {'titles':titles, 'headers':headers}
+
+    dimensionality = len(headers)
+    cardinality = [len(headers[axis]) for axis in range(dimensionality)]
+
+    # Handle 1, 2 and 3-dimensional cellsets. Use dummy row/page headers when missing
+    if dimensionality == 1 and force_header_dimensionality > 1:
+        headers += [[{'name':'Row'}]]
+        cardinality.insert(1,1)
+        dimensionality += 1
+    if dimensionality == 2 and force_header_dimensionality > 2:
+        headers += [[{'name':'Page'}]]
+        cardinality.insert(2,1)
+        dimensionality += 1
+
+    return {'titles':titles, 'headers':headers, 'dimensionality':dimensionality, 'cardinality':cardinality}
 
 
 def element_names_from_element_unqiue_names(element_unique_names):

--- a/Tests/Cell.py
+++ b/Tests/Cell.py
@@ -100,7 +100,7 @@ class TestDataMethods(unittest.TestCase):
         # Define MDX Query with calculated MEMBER
         mdx = "WITH MEMBER[{}].[{}] AS 2 " \
               "SELECT[{}].MEMBERS ON ROWS, " \
-              "NON EMPTY {{[{}].[{}]}} ON COLUMNS " \
+              "{{[{}].[{}]}} ON COLUMNS " \
               "FROM[{}] " \
               "WHERE([{}].DefaultMember)".format(dimension_names[1], "Calculated Member", dimension_names[0],
                                                  dimension_names[1], "Calculated Member", cube_name, dimension_names[2])
@@ -128,7 +128,7 @@ class TestDataMethods(unittest.TestCase):
         # Define MDX Query with calculated MEMBER
         mdx = "WITH MEMBER[{}].[{}] AS 2 " \
               "SELECT[{}].MEMBERS ON ROWS, " \
-              "NON EMPTY {{[{}].[{}]}} ON COLUMNS " \
+              "{{[{}].[{}]}} ON COLUMNS " \
               "FROM[{}] " \
               "WHERE([{}].DefaultMember)".format(dimension_names[1], "Calculated Member", dimension_names[0],
                                                  dimension_names[1], "Calculated Member", cube_name, dimension_names[2])

--- a/Tests/Cell.py
+++ b/Tests/Cell.py
@@ -2,9 +2,12 @@ import random
 import os
 import unittest
 import uuid
+import types
 import configparser
 
-from TM1py.Objects import Cube, Dimension, Element, Hierarchy, NativeView, AnonymousSubset
+import pandas as pd
+
+from TM1py.Objects import Cube, Dimension, Element, Hierarchy, NativeView, AnonymousSubset, ElementAttribute
 from TM1py.Services import TM1Service
 from TM1py.Utils import Utils
 
@@ -34,12 +37,25 @@ class TestDataMethods(unittest.TestCase):
                                           ('Element ' + str(random.randint(1, 1000)) for _ in range(100))))
 
         # Build Dimensions
-        for i in range(3):
+        for dimension_name in dimension_names:
             elements = [Element('Element {}'.format(str(j)), 'Numeric') for j in range(1, 1001)]
-            hierarchy = Hierarchy(dimension_names[i], dimension_names[i], elements)
-            dimension = Dimension(dimension_names[i], [hierarchy])
+            element_attributes = [ElementAttribute("Attr1", "String"),
+                                  ElementAttribute("Attr2", "Numeric"),
+                                  ElementAttribute("Attr3", "Numeric")]
+            hierarchy = Hierarchy(dimension_name=dimension_name,
+                                  name=dimension_name,
+                                  elements=elements,
+                                  element_attributes=element_attributes)
+            dimension = Dimension(dimension_name, [hierarchy])
             if not cls.tm1.dimensions.exists(dimension.name):
                 cls.tm1.dimensions.create(dimension)
+            attribute_cube = "}ElementAttributes_" + dimension_name
+            attribute_values = dict()
+            for element in elements:
+                attribute_values[(element.name, "Attr1")] = "TM1py"
+                attribute_values[(element.name, "Attr2")] = "2"
+                attribute_values[(element.name, "Attr3")] = "3"
+            cls.tm1.cubes.cells.write_values(attribute_cube, attribute_values)
 
         # Build Cube
         cube = Cube(cube_name, dimension_names)
@@ -87,7 +103,7 @@ class TestDataMethods(unittest.TestCase):
         self.tm1.cubes.cells.write_values(cube_name, self.cellset)
 
     def test04_execute_mdx(self):
-        # Define MDX Query that gets full cube content
+        # MDX Query that gets full cube content with zero suppression
         mdx = "SELECT " \
               "NON EMPTY [" + dimension_names[0] + "].Members * [" + dimension_names[1] + "].Members ON ROWS," \
               "NON EMPTY [" + dimension_names[2] + "].MEMBERS ON COLUMNS " \
@@ -97,7 +113,16 @@ class TestDataMethods(unittest.TestCase):
         self.assertEqual(self.total_value,
                          sum([v["Value"] for v in data.values() if v["Value"]]))
 
-        # Define MDX Query with calculated MEMBER
+        # MDX with top
+        mdx = "SELECT " \
+              "NON EMPTY [" + dimension_names[0] + "].Members * [" + dimension_names[1] + "].Members ON ROWS," \
+              "NON EMPTY [" + dimension_names[2] + "].MEMBERS ON COLUMNS " \
+              "FROM [" + cube_name + "]"
+        data = self.tm1.cubes.cells.execute_mdx(mdx, top=5)
+        # Check if total value is the same AND coordinates are the same. Handle None
+        self.assertEqual(len(data), 5)
+
+        # MDX Query with calculated MEMBER
         mdx = "WITH MEMBER[{}].[{}] AS 2 " \
               "SELECT[{}].MEMBERS ON ROWS, " \
               "{{[{}].[{}]}} ON COLUMNS " \
@@ -107,24 +132,56 @@ class TestDataMethods(unittest.TestCase):
 
         data = self.tm1.cubes.cells.execute_mdx(mdx)
         self.assertEqual(1000, len(data))
-        data = self.tm1.cubes.cells.execute_mdx(mdx)
         self.assertEqual(2000, sum(v["Value"] for v in data.values()))
         self.assertEqual(
             sum(range(0, 1000)),
             sum(v["Ordinal"] for v in data.values()))
 
-    def test05_execute_mdx_cell_values_only(self):
+    def test05_execute_mdx_raw(self):
         mdx = "SELECT " \
               "NON EMPTY [" + dimension_names[0] + "].Members * [" + dimension_names[1] + "].Members ON ROWS," \
               "NON EMPTY [" + dimension_names[2] + "].MEMBERS ON COLUMNS " \
               "FROM [" + cube_name + "]"
+        raw = self.tm1.cubes.cells.execute_mdx_raw(
+            mdx=mdx,
+            cell_properties=["Value", "RuleDerived"],
+            elem_properties=["Name", "UniqueName", "Attributes/Attr1", "Attributes/Attr2"])
+        cells = raw["Cells"]
+        for cell in cells:
+            self.assertIn("Value", cell)
+            if cell["Value"]:
+                self.assertGreater(cell["Value"], 0)
+                self.assertLess(cell["Value"], 1001)
+            self.assertIn("RuleDerived", cell)
+            self.assertFalse(cell["RuleDerived"])
+            self.assertNotIn("Updateable", cell)
+        axes = raw["Axes"]
+        for axis in axes:
+            for tuple in axis["Tuples"]:
+                for member in tuple["Members"]:
+                    element = member["Element"]
+                    self.assertIn("Name", element)
+                    self.assertIn("UniqueName", element)
+                    self.assertNotIn("Type", element)
+                    self.assertIn("Attr1", element["Attributes"])
+                    self.assertIn("Attr2", element["Attributes"])
+                    self.assertNotIn("Attr3", element["Attributes"])
+                    self.assertEqual(element["Attributes"]["Attr1"], "TM1py")
+                    self.assertEqual(element["Attributes"]["Attr2"], 2)
 
-        cell_values = self.tm1.cubes.cells.execute_mdx_get_values_only(mdx)
-
+    def test06_execute_mdx_values(self):
+        mdx = "SELECT " \
+              "NON EMPTY [" + dimension_names[0] + "].Members * [" + dimension_names[1] + "].Members ON ROWS," \
+              "NON EMPTY [" + dimension_names[2] + "].MEMBERS ON COLUMNS " \
+              "FROM [" + cube_name + "]"
+        cell_values = self.tm1.cubes.cells.execute_mdx_values(mdx)
+        self.assertIsInstance(
+            cell_values,
+            types.GeneratorType)
         # Check if total value is the same AND coordinates are the same. Handle None.
-        self.assertEqual(self.total_value,
-                         sum([v for v in cell_values if v]))
-
+        self.assertEqual(
+            self.total_value,
+            sum([v for v in cell_values if v]))
         # Define MDX Query with calculated MEMBER
         mdx = "WITH MEMBER[{}].[{}] AS 2 " \
               "SELECT[{}].MEMBERS ON ROWS, " \
@@ -133,44 +190,110 @@ class TestDataMethods(unittest.TestCase):
               "WHERE([{}].DefaultMember)".format(dimension_names[1], "Calculated Member", dimension_names[0],
                                                  dimension_names[1], "Calculated Member", cube_name, dimension_names[2])
 
-        data = self.tm1.cubes.cells.execute_mdx_get_values_only(mdx)
-        self.assertEqual(1000, len(list(data)))
-        data = self.tm1.cubes.cells.execute_mdx_get_values_only(mdx)
-        self.assertEqual(2000, sum(data))
+        data = self.tm1.cubes.cells.execute_mdx_values(mdx)
+        self.assertEqual(
+            1000,
+            len(list(data)))
+        data = self.tm1.cubes.cells.execute_mdx_values(mdx)
+        self.assertEqual(
+            2000,
+            sum(data))
 
-    def test06_execute_mdx_get_csv(self):
+    def test07_execute_mdx_csv(self):
+        # Simple MDX
         mdx = "SELECT " \
               "NON EMPTY [" + dimension_names[0] + "].Members * [" + dimension_names[1] + "].Members ON ROWS," \
               "NON EMPTY [" + dimension_names[2] + "].MEMBERS ON COLUMNS " \
               "FROM [" + cube_name + "]"
-        content = self.tm1.cubes.cells.execute_mdx_get_csv(mdx)
+        csv = self.tm1.cubes.cells.execute_mdx_csv(mdx)
 
-        records = content.split('\r\n')[1:]
-        coordinates = {tuple(record.split(',')[0:3]) for record in records if record != '' and records[4] != 0}
-        self.assertEqual(len(coordinates), len(self.target_coordinates))
+        # check type
+        self.assertIsInstance(csv, str)
+        records = csv.split('\r\n')[1:]
+        coordinates = {tuple(record.split(',')[0:3])
+                       for record
+                       in records if record != '' and records[4] != 0}
+
+        # check number of coordinates (with values)
+        self.assertEqual(
+            len(coordinates),
+            len(self.target_coordinates))
+
+        # check if coordinates are the same
         self.assertTrue(coordinates.issubset(self.target_coordinates))
+        values = [float(record.split(',')[3])
+                  for record
+                  in records if record != '']
 
-        values = [float(record.split(',')[3]) for record in records if record != '']
-        self.assertEqual(self.total_value, sum(values))
+        # check if sum of retrieved values is sum of written values
+        self.assertEqual(
+            self.total_value,
+            sum(values))
 
-    def test07_execute_mdx_get_dataframe(self):
+        # MDX Query with calculated MEMBER
+        mdx = "WITH MEMBER[{dim1}].[{calculated_member}] AS [{attribute_cube}].({attribute}) " \
+              "SELECT[{dim0}].MEMBERS ON ROWS, " \
+              "{{[{dim1}].[{calculated_member}]}} ON COLUMNS " \
+              "FROM[{cube_name}] " \
+              "WHERE([{dim2}].DefaultMember)".format(cube_name=cube_name,
+                                                     dim0=dimension_names[0],
+                                                     dim1=dimension_names[1],
+                                                     dim2=dimension_names[2],
+                                                     calculated_member="Calculated Member",
+                                                     attribute_cube="}ElementAttributes_" + dimension_names[0],
+                                                     attribute="[}ElementAttributes_" + dimension_names[0] + "].[Attr3]")
+        csv = self.tm1.cubes.cells.execute_mdx_csv(mdx)
+
+        # check type
+        records = csv.split('\r\n')[1:]
+        coordinates = {tuple(record.split(',')[0:2])
+                       for record
+                       in records if record != '' and records[4] != 0}
+
+        # check number of coordinates (with values)
+        self.assertEqual(len(coordinates), 1000)
+
+        # Check if retrieved values are equal to attribute value
+        values = [float(record.split(',')[2])
+                  for record
+                  in records if record != ""]
+        for value in values:
+            self.assertEqual(value, 3)
+
+    def test08_execute_mdx_dataframe(self):
         mdx = "SELECT " \
               "NON EMPTY [" + dimension_names[0] + "].Members * [" + dimension_names[1] + "].Members ON ROWS," \
               "NON EMPTY [" + dimension_names[2] + "].MEMBERS ON COLUMNS " \
               "FROM [" + cube_name + "]"
-        df = self.tm1.cubes.cells.execute_mdx_get_dataframe(mdx)
+        df = self.tm1.cubes.cells.execute_mdx_dataframe(mdx)
 
+        # check type
+        self.assertIsInstance(df, pd.DataFrame)
+
+        # check coordinates in df are equal to target coordinates
         coordinates = {tuple(row)
                        for row
                        in df[[*dimension_names]].values}
-        self.assertEqual(len(coordinates), len(self.target_coordinates))
+        self.assertEqual(len(coordinates),
+                         len(self.target_coordinates))
         self.assertTrue(coordinates.issubset(self.target_coordinates))
 
+        # check if total values are equal
         values = df[["Value"]].values
-        self.assertEqual(self.total_value, sum(values))
+        self.assertEqual(self.total_value,
+                         sum(values))
 
-    def test08_execute_view(self):
-        data = self.tm1.cubes.cells.execute_view(cube_name, view_name, private=False)
+    def test09_execute_mdx_cellcount(self):
+        mdx = "SELECT " \
+              "NON EMPTY [" + dimension_names[0] + "].Members * [" + dimension_names[1] + "].Members ON ROWS," \
+              "NON EMPTY [" + dimension_names[2] + "].MEMBERS ON COLUMNS " \
+              "FROM [" + cube_name + "]"
+        cell_count = self.tm1.cubes.cells.execute_mdx_cellcount(mdx)
+        self.assertGreater(cell_count, 1000)
+
+    def test10_execute_view(self):
+        data = self.tm1.cubes.cells.execute_view(cube_name=cube_name, view_name=view_name, private=False)
+
         # Check if total value is the same AND coordinates are the same
         check_value = 0
         for coordinates, value in data.items():
@@ -180,31 +303,136 @@ class TestDataMethods(unittest.TestCase):
                 element_names = Utils.element_names_from_element_unqiue_names(coordinates)
                 self.assertIn(element_names, self.target_coordinates)
                 check_value += value['Value']
+
         # Check the check-sum
         self.assertEqual(check_value, self.total_value)
 
-    def test09_execute_view(self):
-        data = self.tm1.cubes.cells.execute_view(cube_name, view_name, private=False, top=3)
+        # execute view with top
+        data = self.tm1.cubes.cells.execute_view(cube_name=cube_name, view_name=view_name, private=False, top=3)
         self.assertEqual(len(data.keys()), 3)
 
-    def test10_write_values_through_cellset(self):
-        mdx_skeleton = "SELECT {} ON ROWS, {} ON COLUMNS FROM {} WHERE ({})"
+    def test11_execute_view_raw(self):
+        raw = self.tm1.cubes.cells.execute_view_raw(
+            cube_name=cube_name,
+            view_name=view_name,
+            private=False,
+            cell_properties=["Value", "RuleDerived"],
+            elem_properties=["Name", "UniqueName", "Attributes/Attr1", "Attributes/Attr2"])
+        cells = raw["Cells"]
+
+        # check if cell_property selection works
+        for cell in cells:
+            self.assertIn("Value", cell)
+            if cell["Value"]:
+                self.assertGreater(cell["Value"], 0)
+                self.assertLess(cell["Value"], 1001)
+            self.assertIn("RuleDerived", cell)
+            self.assertFalse(cell["RuleDerived"])
+            self.assertNotIn("Updateable", cell)
+            self.assertNotIn("Consolidated", cell)
+
+        # check if elem property selection works
+        axes = raw["Axes"]
+        for axis in axes:
+            for tuple in axis["Tuples"]:
+                for member in tuple["Members"]:
+                    element = member["Element"]
+                    self.assertIn("Name", element)
+                    self.assertIn("UniqueName", element)
+                    self.assertNotIn("Type", element)
+                    self.assertIn("Attr1", element["Attributes"])
+                    self.assertIn("Attr2", element["Attributes"])
+                    self.assertNotIn("Attr3", element["Attributes"])
+                    self.assertEqual(element["Attributes"]["Attr1"], "TM1py")
+                    self.assertEqual(element["Attributes"]["Attr2"], 2)
+
+        # check if top works
+        raw = self.tm1.cubes.cells.execute_view_raw(
+            cube_name=cube_name,
+            view_name=view_name,
+            private=False,
+            cell_properties=["Value", "RuleDerived"],
+            elem_properties=["Name", "UniqueName", "Attributes/Attr1", "Attributes/Attr2"],
+            top=5)
+        self.assertEqual(len(raw["Cells"]), 5)
+
+    def test12_execute_view_values(self):
+        cell_values = self.tm1.cubes.cells.execute_view_values(cube_name=cube_name, view_name=view_name, private=False)
+
+        # check type
+        self.assertIsInstance(cell_values, types.GeneratorType)
+
+        # Check if total value is the same AND coordinates are the same. Handle None.
+        self.assertEqual(self.total_value,
+                         sum([v for v in cell_values if v]))
+
+    def test13_execute_view_csv(self):
+        csv = self.tm1.cubes.cells.execute_view_csv(cube_name=cube_name, view_name=view_name, private=False)
+
+        # check type
+        self.assertIsInstance(csv, str)
+        records = csv.split('\r\n')[1:]
+        coordinates = {tuple(record.split(',')[0:3]) for record in records if record != '' and records[4] != 0}
+
+        # check number of coordinates (with values)
+        self.assertEqual(len(coordinates), len(self.target_coordinates))
+
+        # check if coordinates are the same
+        self.assertTrue(coordinates.issubset(self.target_coordinates))
+        values = [float(record.split(',')[3]) for record in records if record != '']
+
+        # check if sum of retrieved values is sum of written values
+        self.assertEqual(self.total_value, sum(values))
+
+    def test14_execute_view_dataframe(self):
+        df = self.tm1.cubes.cells.execute_view_dataframe(cube_name=cube_name, view_name=view_name, private=False)
+
+        # check type
+        self.assertIsInstance(df, pd.DataFrame)
+
+        # check coordinates
+        coordinates = {tuple(row)
+                       for row
+                       in df[[*dimension_names]].values}
+        self.assertEqual(len(coordinates), len(self.target_coordinates))
+        self.assertTrue(coordinates.issubset(self.target_coordinates))
+
+        # check values
+        values = df[["Value"]].values
+        self.assertEqual(self.total_value, sum(values))
+
+    def test15_execute_view_cellcount(self):
+        cell_count = self.tm1.cubes.cells.execute_view_cellcount(
+            cube_name=cube_name,
+            view_name=view_name,
+            private=False)
+        self.assertGreater(cell_count, 1000)
+
+    def test16_write_values_through_cellset(self):
+        mdx_skeleton = "SELECT {} " \
+                       "ON ROWS, {} " \
+                       "ON COLUMNS " \
+                       "FROM {} " \
+                       "WHERE ({})"
         mdx = mdx_skeleton.format(
             "{{[{}].[{}]}}".format(dimension_names[0], "element2"),
             "{{[{}].[{}]}}".format(dimension_names[1], "element2"),
             cube_name,
-            "[{}].[{}]".format(dimension_names[2], "element2"),
-        )
-        self.tm1.cubes.cells.write_values_through_cellset(mdx, (1,))
+            "[{}].[{}]".format(dimension_names[2], "element2"))
+        self.tm1.cubes.cells.write_values_through_cellset(mdx, (1.5,))
 
-    def test11_deactivate_transaction_log(self):
+        # check value on coordinate in cube
+        values = self.tm1.cubes.cells.execute_mdx_values(mdx)
+        self.assertEqual(next(values), 1.5)
+
+    def test17_deactivate_transaction_log(self):
         self.tm1.cubes.cells.write_value(value="YES", cube_name="}CubeProperties",
                                          element_tuple=(cube_name, "Logging"))
         self.tm1.cubes.cells.deactivate_transactionlog(cube_name)
         value = self.tm1.cubes.cells.get_value("}CubeProperties", "{},LOGGING".format(cube_name))
         self.assertEqual("NO", value.upper())
 
-    def test12_activate_transaction_log(self):
+    def test18_activate_transaction_log(self):
         self.tm1.cubes.cells.write_value(value="NO", cube_name="}CubeProperties",
                                          element_tuple=(cube_name, "Logging"))
         self.tm1.cubes.cells.activate_transactionlog(cube_name)

--- a/Tests/Server.py
+++ b/Tests/Server.py
@@ -112,7 +112,7 @@ class TestServerMethods(unittest.TestCase):
         self.tm1.cubes.cells.write_values(self.cube_name, cellset)
 
         # Digest time in TM1
-        time.sleep(1)
+        time.sleep(8)
 
         user = config['tm1srv01']['user']
         cube = self.cube_name


### PR DESCRIPTION
- breakdown get_data funcion into small execute_mdx methods in CellService
- Tests for new execute_mdx methods
- Prettify execute_process function. Now takes **kwargs arguments
(dynamic arguments with same name as the TI Parameters). Rename of name_process argument to process_name.
- Adapt Tests for ProcessService
- oursource cellset deletion into higher order function: tidy_cellset
- Creation of execute_view_* functions
- Rename build_dygraph_arrays_from_cellset to
build_ui_dygraph_arrays_from_cellset and build_arrays_from_cellset to build_ui_arrays_from_cellset