### PR TITLE
Retry Authentication with b64 decoded password

### DIFF
--- a/TM1py/Exceptions/Exceptions.py
+++ b/TM1py/Exceptions/Exceptions.py
@@ -12,5 +12,17 @@ class TM1pyException(Exception):
         self._status_code = status_code
         self._reason = reason
 
+    @property
+    def status_code(self):
+        return self._status_code
+
+    @property
+    def reason(self):
+        return self.reason
+
+    @property
+    def response(self):
+        return self._response
+
     def __str__(self):
         return "Text: {} Status Code: {} Reason: {}".format(self._response, self._status_code, self._reason)

--- a/TM1py/Objects/User.py
+++ b/TM1py/Objects/User.py
@@ -28,7 +28,7 @@ class User(TM1Object):
     @property
     def password(self):
         if self._password:
-            return b64encode(str.encode(self._password))
+            return self._password
 
     @property
     def is_admin(self):


### PR DESCRIPTION
Now retry Authentication in RestService with b64decoded password, if authentication with plain password fails.

https://github.com/cubewise-code/TM1py/issues/62
