### PR TITLE
issue/53

### DIFF
--- a/TM1py/Objects/NativeView.py
+++ b/TM1py/Objects/NativeView.py
@@ -2,9 +2,9 @@
 
 import json
 
+from TM1py.Objects.Axis import ViewAxisSelection, ViewTitleSelection
 from TM1py.Objects.Subset import Subset, AnonymousSubset
 from TM1py.Objects.View import View
-from TM1py.Objects.Axis import ViewAxisSelection, ViewTitleSelection
 
 
 class NativeView(View):
@@ -13,6 +13,7 @@ class NativeView(View):
         :Notes:
             Complete, functional and tested
     """
+
     def __init__(self,
                  cube_name,
                  view_name,
@@ -33,6 +34,14 @@ class NativeView(View):
     @property
     def body(self):
         return self._construct_body()
+
+    @property
+    def rows(self):
+        return self._rows
+
+    @property
+    def columns(self):
+        return self._columns
 
     @property
     def MDX(self):

--- a/TM1py/Services/RESTService.py
+++ b/TM1py/Services/RESTService.py
@@ -3,7 +3,6 @@ import functools
 import sys
 from base64 import b64encode, b64decode
 
-
 import requests
 
 from TM1py.Exceptions import TM1pyException

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -286,15 +286,23 @@ def element_names_from_element_unqiue_names(element_unique_names):
     return element_names_from_element_unique_names(element_unique_names)
 
 
+def dimension_name_from_element_unique_name(element_unique_name):
+    return element_unique_name[1:element_unique_name.find('].[')]
+
+
+def element_name_from_element_unique_name(element_unique_name):
+    return element_unique_name[element_unique_name.rfind('].[') + 3:-1]
+
+
 def element_names_from_element_unique_names(element_unique_names):
     """ Get tuple of simple element names from the full element unique names
 
     :param element_unique_names: tuple of element unique names ([dim1].[hier1].[elem1], ... )
     :return: tuple of element names: (elem1, elem2, ... )
     """
-    return tuple([unique_name[unique_name.rfind('].[') + 3:-1]
-                  for unique_name
-                  in element_unique_names])
+    return tuple(element_name_from_element_unique_name(unique_name)
+                 for unique_name
+                 in element_unique_names)
 
 
 def build_element_unique_names(dimension_names, element_names, hierarchy_names=None):
@@ -344,8 +352,10 @@ def build_pandas_dataframe_from_cellset(cellset, multiindex=True, sort_values=Tr
                 df.sort_values(inplace=True, by=list(dimension_names))
         return df
     except UnboundLocalError:
-        message = "Can't build Dataframe from empty cellset. " \
-                  "Make sure the underlying MDX / View is not fully zero suppressed."
+        message = """
+            Can't build DataFrame from empty cellset. 
+            Make sure the underlying MDX / View is not fully zero suppressed.
+        """
         raise ValueError(message)
 
 
@@ -367,7 +377,7 @@ def build_cellset_from_pandas_dataframe(df):
 def load_bedrock_from_github(bedrock_process_name):
     """ Load bedrock from GitHub as TM1py.Process instance
     
-    :param name_bedrock_process: 
+    :param bedrock_process_name:
     :return: 
     """
     import requests
@@ -582,4 +592,3 @@ class CaseAndSpaceInsensitiveSet(collections.MutableSet):
             return NotImplemented
         # Compare insensitively
         return set(self._store.keys()) == set(other._store.keys())
-

--- a/Tests/config.ini
+++ b/Tests/config.ini
@@ -1,5 +1,5 @@
 [tm1srv01]
-address=10.77.19.10
+address=10.77.19.60
 port=12354
 user=Admin
 password=apple


### PR DESCRIPTION
- New execute_* functions to extract (pandas) pivot tables from a cube view or mdx query: execute_view_dataframe_pivot and execute_mdx_dataframe_pivot. Solves: https://github.com/cubewise-code/TM1py/issues/53
- Minor test improvements
- New mdx parser to extract dimension-composition from mdx query
- New delete_cellset argument in tidy_cellset function allows to overrule default behaviour regarding the deletion of cellsets in the extract_cellset_* functions