### PR TITLE
Issue/75

### DIFF
--- a/TM1py/Objects/NativeView.py
+++ b/TM1py/Objects/NativeView.py
@@ -2,9 +2,9 @@
 
 import json
 
+from TM1py.Objects.Axis import ViewAxisSelection, ViewTitleSelection
 from TM1py.Objects.Subset import Subset, AnonymousSubset
 from TM1py.Objects.View import View
-from TM1py.Objects.Axis import ViewAxisSelection, ViewTitleSelection
 
 
 class NativeView(View):
@@ -13,6 +13,7 @@ class NativeView(View):
         :Notes:
             Complete, functional and tested
     """
+
     def __init__(self,
                  cube_name,
                  view_name,
@@ -33,6 +34,14 @@ class NativeView(View):
     @property
     def body(self):
         return self._construct_body()
+
+    @property
+    def rows(self):
+        return self._rows
+
+    @property
+    def columns(self):
+        return self._columns
 
     @property
     def MDX(self):

--- a/TM1py/Services/RESTService.py
+++ b/TM1py/Services/RESTService.py
@@ -3,7 +3,6 @@ import functools
 import sys
 from base64 import b64encode, b64decode
 
-
 import requests
 
 from TM1py.Exceptions import TM1pyException

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -286,15 +286,23 @@ def element_names_from_element_unqiue_names(element_unique_names):
     return element_names_from_element_unique_names(element_unique_names)
 
 
+def dimension_name_from_element_unique_name(element_unique_name):
+    return element_unique_name[1:element_unique_name.find('].[')]
+
+
+def element_name_from_element_unique_name(element_unique_name):
+    return element_unique_name[element_unique_name.rfind('].[') + 3:-1]
+
+
 def element_names_from_element_unique_names(element_unique_names):
     """ Get tuple of simple element names from the full element unique names
 
     :param element_unique_names: tuple of element unique names ([dim1].[hier1].[elem1], ... )
     :return: tuple of element names: (elem1, elem2, ... )
     """
-    return tuple([unique_name[unique_name.rfind('].[') + 3:-1]
-                  for unique_name
-                  in element_unique_names])
+    return tuple(element_name_from_element_unique_name(unique_name)
+                 for unique_name
+                 in element_unique_names)
 
 
 def build_element_unique_names(dimension_names, element_names, hierarchy_names=None):
@@ -344,8 +352,10 @@ def build_pandas_dataframe_from_cellset(cellset, multiindex=True, sort_values=Tr
                 df.sort_values(inplace=True, by=list(dimension_names))
         return df
     except UnboundLocalError:
-        message = "Can't build Dataframe from empty cellset. " \
-                  "Make sure the underlying MDX / View is not fully zero suppressed."
+        message = """
+            Can't build DataFrame from empty cellset. 
+            Make sure the underlying MDX / View is not fully zero suppressed.
+        """
         raise ValueError(message)
 
 
@@ -367,7 +377,7 @@ def build_cellset_from_pandas_dataframe(df):
 def load_bedrock_from_github(bedrock_process_name):
     """ Load bedrock from GitHub as TM1py.Process instance
     
-    :param name_bedrock_process: 
+    :param bedrock_process_name:
     :return: 
     """
     import requests
@@ -582,4 +592,3 @@ class CaseAndSpaceInsensitiveSet(collections.MutableSet):
             return NotImplemented
         # Compare insensitively
         return set(self._store.keys()) == set(other._store.keys())
-

--- a/Tests/Server.py
+++ b/Tests/Server.py
@@ -63,6 +63,64 @@ class TestServerMethods(unittest.TestCase):
         cls.process2 = Process(name=cls.process_name2, prolog_procedure="sText = 'text';")
         cls.tm1.processes.create(cls.process2)
 
+    def test_get_server_name(self):
+        server_name = self.tm1.server.get_server_name()
+        self.assertIsInstance(server_name, str)
+        self.assertGreater(len(server_name), 0)
+
+        active_configuration = self.tm1.server.get_active_configuration()
+        self.assertEqual(server_name, active_configuration["ServerName"])
+
+    def test_get_product_version(self):
+        product_version = self.tm1.server.get_product_version()
+        self.assertIsInstance(product_version, str)
+        self.assertGreater(len(product_version), 0)
+        self.assertGreaterEqual(int(product_version[0:2]), 10)
+
+    def test_get_admin_host(self):
+        admin_host = self.tm1.server.get_admin_host()
+        self.assertIsInstance(admin_host, str)
+
+    def test_get_data_directory(self):
+        data_directory = self.tm1.server.get_data_directory()
+        self.assertIsInstance(data_directory, str)
+        self.assertGreater(len(data_directory), 0)
+
+        active_configuration = self.tm1.server.get_active_configuration()
+        self.assertEqual(data_directory, active_configuration["Administration"]["DataBaseDirectory"])
+
+    def test_get_static_configuration(self):
+        static_configuration = self.tm1.server.get_static_configuration()
+        self.assertIsInstance(static_configuration, dict)
+        self.assertIn("ServerName", static_configuration)
+        self.assertIn("Access", static_configuration)
+        self.assertIn("Administration", static_configuration)
+        self.assertIn("Modelling", static_configuration)
+        self.assertIn("Performance", static_configuration)
+
+    def test_get_active_configuration(self):
+        active_configuration = self.tm1.server.get_active_configuration()
+        self.assertEqual(
+            int(self.tm1._tm1_rest._port),
+            int(active_configuration["Access"]["HTTP"]["Port"]))
+
+    def test_update_static_configuration(self):
+        for new_mtq_threads in (4, 8):
+            config_changes = {
+                "Performance": {
+                    "MTQ": {
+                        "NumberOfThreadsToUse": new_mtq_threads
+                    }
+                }
+            }
+            response = self.tm1.server.update_static_configuration(config_changes)
+            self.assertTrue(response.ok)
+
+            active_config = self.tm1.server.get_active_configuration()
+            self.assertEqual(
+                active_config["Performance"]["MTQ"]["NumberOfThreadsToUse"],
+                new_mtq_threads - 1)
+
     @unittest.skip("Doesn't work sometimes")
     def test_get_last_process_message_from_message_log(self):
         try:

--- a/Tests/config.ini
+++ b/Tests/config.ini
@@ -1,5 +1,5 @@
 [tm1srv01]
-address=10.77.19.10
+address=10.77.19.60
 port=12354
 user=Admin
 password=apple

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,6 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Natural Language :: English',
     ],
-    install_requires=['requests', 'pandas', 'dateutil'],
+    install_requires=['requests', 'pandas', 'dateutil', 'pytz'],
     python_requires='>=3.5',
 )


### PR DESCRIPTION
Fix Issue [75](https://github.com/cubewise-code/TM1py/issues/75)

get TM1 config-parameters with `get_active_configuration` or `get_static_configuration` function
update dynamic config parameters through `update_static_configuration`

Sample:
```
from TM1py import TM1Service

with TM1Service(address='10.77.19.60', port=12354, user='admin', password='apple', ssl=True) as tm1:
    config = {
        "Performance": {
            "MTQ": {
                "NumberOfThreadsToUse": 7,
                "MTFeeders": False
            }
        }
    }
    # effectively update the .cfg file (and triggers TM1 to re-read the file)
    tm1.server.update_static_configuration(config)
    # ask TM1 Server about the currently applied config parameters
    config = tm1.server.get_active_configuration()

    print(config["Performance"]["MTQ"]["NumberOfThreadsToUse"])

```