### PR TITLE
Fix bug in execute_mdx_rows_and_cells method and rename it

### DIFF
--- a/TM1py/Services/ProcessService.py
+++ b/TM1py/Services/ProcessService.py
@@ -204,7 +204,6 @@ class ProcessService(ObjectService):
         self.create(p)
         try:
             return self.execute(process_name)
-            pass
         except TM1pyException as e:
             raise e
         finally:


### PR DESCRIPTION
- Now also works for 1 x 1 cellset
- Now called `execute_mdx_rows_and_values`
- New boolean argument `element_unique_names` to control if keys in returned map are simple member names or member unique names.