### PR TITLE
Support relative proportional spread

### DIFF
--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -277,8 +277,27 @@ def element_names_from_element_unqiue_names(element_unique_names):
     return element_names_from_element_unique_names(element_unique_names)
 
 
+def dimension_hierarchy_element_tuple_from_unique_name(element_unique_name):
+    """ Extract dimension name, hierarchy name and element name from element unique name.
+    Works with explicit and implicit hierarchy references.
+
+    :param element_unique_name: e.g. [d1].[e1] or [d1].[leaves].[e1]
+    :return: tuple of dimension name, hierarchy name, element name
+    """
+    dimension = dimension_name_from_element_unique_name(element_unique_name)
+    element = element_name_from_element_unique_name(element_unique_name)
+    if element_unique_name.count("].[") == 1:
+        return dimension, dimension, element
+    hierarchy = hierarchy_name_from_element_unique_name(element_unique_name)
+    return dimension, hierarchy, element
+
+
 def dimension_name_from_element_unique_name(element_unique_name):
     return element_unique_name[1:element_unique_name.find('].[')]
+
+
+def hierarchy_name_from_element_unique_name(element_unique_name):
+    return element_unique_name[element_unique_name.find('].[') + 3:element_unique_name.rfind('].[')]
 
 
 def element_name_from_element_unique_name(element_unique_name):

--- a/Tests/Utils.py
+++ b/Tests/Utils.py
@@ -14,6 +14,7 @@ from TM1py.Utils import Utils, MDXUtils
 from TM1py.Utils.MDXUtils import DimensionSelection, read_dimension_composition_from_mdx, \
     read_dimension_composition_from_mdx_set_or_tuple, read_dimension_composition_from_mdx_set, \
     read_dimension_composition_from_mdx_tuple, split_mdx, _find_case_and_space_insensitive_first_occurrence
+from TM1py.Utils.Utils import dimension_hierarchy_element_tuple_from_unique_name
 
 config = configparser.ConfigParser()
 config.read(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'config.ini'))
@@ -294,6 +295,25 @@ class TestMDXUtils(unittest.TestCase):
                 self.assertEquals(
                     cube_name.upper().replace(" ", ""),
                     MDXUtils.read_cube_name_from_mdx(mdx))
+
+    def test_dimension_hierarchy_element_tuple_from_unique_name(self):
+        unique_element_name = "[d1].[e1]"
+        dimension, hierarchy, element = dimension_hierarchy_element_tuple_from_unique_name(unique_element_name)
+        self.assertEqual(dimension, "d1")
+        self.assertEqual(hierarchy, "d1")
+        self.assertEqual(element, "e1")
+
+        unique_element_name = "[d1].[d1].[e1]"
+        dimension, hierarchy, element = dimension_hierarchy_element_tuple_from_unique_name(unique_element_name)
+        self.assertEqual(dimension, "d1")
+        self.assertEqual(hierarchy, "d1")
+        self.assertEqual(element, "e1")
+
+        unique_element_name = "[d1].[leaves].[e1]"
+        dimension, hierarchy, element = dimension_hierarchy_element_tuple_from_unique_name(unique_element_name)
+        self.assertEqual(dimension, "d1")
+        self.assertEqual(hierarchy, "leaves")
+        self.assertEqual(element, "e1")
 
     def test_read_dimension_composition_from_mdx_simple1(self):
         mdx = MDX_TEMPLATE.format(


### PR DESCRIPTION
- New method in `CellService`: `relative_proportional_spread`
- New utility function to parse dimension, hierarchy, element from
  unique-element-name: `dimension_hierarchy_element_tuple_from_unique_name`

Fixes #108 

Sample:
``` python

import configparser

from TM1py import TM1Service

config = configparser.ConfigParser()
config.read(r'config.ini')

with TM1Service(**config['tm1srv01']) as tm1:
    tm1.cubes.cells.relative_proportional_spread(
        value=12,
        cube="c1",
        unique_element_names=("[d1].[c1]", "[d2].[e3]"),
        reference_cube="c1",
        reference_unique_element_names=("[d1].[c1]", "[d2].[c1]"))

```
