### PR TITLE
New get and update methods for dimension storage order

### DIFF
--- a/TM1py/Services/CubeService.py
+++ b/TM1py/Services/CubeService.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+import json
 import random
 
 from TM1py.Objects.Cube import Cube
@@ -116,6 +116,30 @@ class CubeService(ObjectService):
         response = self._rest.GET(request, '')
         dimension_names = [element['Name'] for element in response.json()['value']]
         return dimension_names
+
+    def get_storage_dimension_order(self, cube_name):
+        """ Get the storage dimension order of a cube
+
+        :param cube_name:
+        :return: List of dimension names
+        """
+        url = "/api/v1/Cubes('{}')/tm1.DimensionsStorageOrder()?$select=Name".format(cube_name)
+        response = self._rest.GET(url)
+        return [dimension["Name"] for dimension in response.json()["value"]]
+
+    def update_storage_dimension_order(self, cube_name, dimension_names):
+        """ Update the storage dimension order of a cube
+
+        :param cube_name:
+        :param dimension_names:
+        :return:
+        """
+        url = "/api/v1/Cubes('{}')/tm1.ReorderDimensions".format(cube_name)
+        payload = dict()
+        payload['Dimensions@odata.bind'] = ["Dimensions('{}')".format(dimension)
+                                            for dimension
+                                            in dimension_names]
+        return self._rest.POST(request=url, data=json.dumps(payload))
 
     def get_random_intersection(self, cube_name, unique_names=False):
         """ Get a random Intersection in a cube

--- a/Tests/Cube.py
+++ b/Tests/Cube.py
@@ -112,6 +112,19 @@ class TestCubeMethods(unittest.TestCase):
         all_cubes_after = self.tm1.cubes.get_all_names()
         self.assertEqual(len(all_cubes_before) - 1, len(all_cubes_after))
 
+    def test_get_storage_dimension_order(self):
+        dimensions = self.tm1.cubes.get_storage_dimension_order(cube_name=self.cube_name)
+        self.assertEqual(dimensions, self.dimension_names)
+
+    def test_update_storage_dimension_order(self):
+        self.tm1.cubes.update_storage_dimension_order(
+            cube_name=self.cube_name,
+            dimension_names=reversed(self.dimension_names))
+        dimensions = self.tm1.cubes.get_storage_dimension_order(self.cube_name)
+        self.assertEqual(
+            list(reversed(dimensions)),
+            self.dimension_names)
+
     @classmethod
     def tearDownClass(cls):
         cls.tm1.cubes.delete(cls.cube_name)


### PR DESCRIPTION
New methods in CubeService:
- `get_storage_dimension_order(self, cube_name)`
- `update_storage_dimension_order(self, cube_name, dimension_names)`

Fixes #81 


Sample:
``` python

import configparser

from TM1py import TM1Service

config = configparser.ConfigParser()
config.read(r'config.ini')

with TM1Service(**config['tm1srv01']) as tm1:
    dimensions = tm1.cubes.get_storage_dimension_order("c1")
    print(dimensions)

    tm1.cubes.update_storage_dimension_order("c1", reversed(dimensions))

    dimensions = tm1.cubes.get_storage_dimension_order("c1")
    print(dimensions)

```