### PR TITLE
CAMPassport authorization

### DIFF
--- a/TM1py/Services/RESTService.py
+++ b/TM1py/Services/RESTService.py
@@ -4,7 +4,7 @@ import sys
 from base64 import b64encode, b64decode
 
 import requests
-
+from requests_negotiate_sspi import HttpNegotiateAuth
 from TM1py.Exceptions import TM1pyException
 
 # import Http-Client depending on python version
@@ -16,7 +16,6 @@ else:
 
 def httpmethod(func):
     """ Higher Order Function to wrap the GET, POST, PATCH, PUT, DELETE methods
-
         Takes care of:
         - encoding of url and payload
         - verifying response. Throws TM1pyException if StatusCode of Response is not OK
@@ -42,16 +41,13 @@ class RESTService:
             - POST
             - PATCH
             - DELETE
-
-        Takes Care of 
+        Takes Care of
             - Encodings
             - TM1 User-Login
             - HTTP Headers
             - HTTP Session Management
             - Response Handling
-
         Based on requests module
-
     """
 
     HEADERS = {'Connection': 'keep-alive',
@@ -62,7 +58,6 @@ class RESTService:
 
     def __init__(self, **kwargs):
         """ Create an instance of RESTService
-
         :param address: String - address of the TM1 instance
         :param port: Int - HTTPPortNumber as specified in the tm1s.cfg
         :param base_url - base url e.g. https://localhost:12354/api/v1
@@ -107,6 +102,7 @@ class RESTService:
                 user=kwargs["user"],
                 password=kwargs["password"],
                 namespace=kwargs.get("namespace", None),
+                gateway=kwargs.get("gateway", None),
                 decode_b64=self.translate_to_boolean(kwargs.get("decode_b64", False)))
         # Logging
         if 'logging' in kwargs:
@@ -122,7 +118,6 @@ class RESTService:
     @httpmethod
     def GET(self, request, data=''):
         """ Perform a GET request against TM1 instance
-
         :param request: String, for instance : /api/v1/Cubes?$top=1
         :param data: String, empty
         :return: String, the response as text
@@ -132,7 +127,6 @@ class RESTService:
     @httpmethod
     def POST(self, request, data):
         """ POST request against the TM1 instance
-
         :param request: String, /api/v1/Cubes
         :param data: String, the payload (json)
         :return:  String, the response as text
@@ -142,7 +136,6 @@ class RESTService:
     @httpmethod
     def PATCH(self, request, data):
         """ PATCH request against the TM1 instance
-
         :param request: String, for instance : /api/v1/Dimensions('plan_business_unit')
         :param data: String, the payload (json)
         :return: String, the response as text
@@ -152,7 +145,6 @@ class RESTService:
     @httpmethod
     def DELETE(self, request, data=''):
         """ Delete request against TM1 instance
-
         :param request:  String, for instance : /api/v1/Dimensions('plan_business_unit')
         :param data: String, empty
         :return: String, the response in text
@@ -161,7 +153,6 @@ class RESTService:
 
     def logout(self):
         """ End TM1 Session and HTTP session
-
         """
         self._headers["Connection"] = "close"
         # Easier to ask for forgiveness than permission
@@ -173,15 +164,15 @@ class RESTService:
             self.POST('/api/logout', '')
         self._s.close()
 
-    def _start_session(self, user, password, decode_b64=False, namespace=None):
+    def _start_session(self, user, password, decode_b64=False, namespace=None, gateway=None):
         """ perform a simple GET request (Ask for the TM1 Version) to start a session
-
         """
         # Authorization [Basic, CAM] through Headers
         token = self._build_authorization_token(
             user,
             self.b64_decode_password(password) if decode_b64 else password,
-            namespace)
+            namespace
+            ,gateway)
         self.add_http_header('Authorization', token)
         request = '/api/v1/Configuration/ProductVersion/$value'
         try:
@@ -193,7 +184,6 @@ class RESTService:
 
     def _url_and_body(self, request, data):
         """ create proper url and payload
-
         """
         url = self._base_url + request
         url = url.replace(' ', '%20').replace('#', '%23')
@@ -202,7 +192,6 @@ class RESTService:
 
     def is_connected(self):
         """ Check if Connection to TM1 Server is established.
-
         :Returns:
             Boolean
         """
@@ -228,7 +217,6 @@ class RESTService:
     @staticmethod
     def translate_to_boolean(value):
         """ Takes a boolean or string (eg. true, True, FALSE, etc.) value and returns (boolean) True or False
-
         :param value: True, 'true', 'false' or 'False' ...
         :return:
         """
@@ -242,7 +230,6 @@ class RESTService:
     @staticmethod
     def b64_decode_password(encrypted_password):
         """ b64 decoding
-
         :param encrypted_password: encrypted password with b64
         :return: password in plain text
         """
@@ -251,11 +238,9 @@ class RESTService:
     @staticmethod
     def verify_response(response):
         """ check if Status Code is OK
-
         :Parameters:
             `response`: String
                 the response that is returned from a method call
-
         :Exceptions:
             TM1pyException, raises TM1pyException when Code is not 200, 204 etc.
         """
@@ -263,13 +248,20 @@ class RESTService:
             raise TM1pyException(response.text, status_code=response.status_code, reason=response.reason)
 
     @staticmethod
-    def _build_authorization_token(user, password, namespace=None, **kwargs):
+    def _build_authorization_token(user, password, namespace=None, gateway=None, **kwargs):
         """ Build the Authorization Header for CAM and Native Security
-
         """
         if namespace:
-            token = 'CAMNamespace ' + b64encode(
-                str.encode("{}:{}:{}".format(user, password, namespace))).decode("ascii")
+            if gateway:
+                vResp1 = requests.get(gateway, auth=HttpNegotiateAuth())
+                if vResp1.status_code == 200:
+                    token = 'CAMPassport ' + vResp1.cookies['cam_passport']
+                else:
+                    token = 'CAMNamespace ' + b64encode(
+                        str.encode("{}:{}:{}".format(user, password, namespace))).decode("ascii")
+            else:
+                token = 'CAMNamespace ' + b64encode(
+                    str.encode("{}:{}:{}".format(user, password, namespace))).decode("ascii")
         else:
             token = 'Basic ' + b64encode(
                 str.encode("{}:{}".format(user, password))).decode("ascii")


### PR DESCRIPTION
added functionality to _build_authorization_token function in RestService.py to take gateway as an argument where gateway is the Cognos dispatcher used for CAM security. will use negotiated login attempt to get passport cookie for authorization header instead of taking username & password. If the negotiated login fails, it will set the token to use the username and password, provided they were supplied. Attached is example of config.ini file for on premise installation with gateway parameter defined.

I did this modification because i didnt want to save the base64 password in a config file and am lucky to have cognos CAM with windows integrated authentication set up in our TM1 environment. My python skills are not great, my edits might not be the best way to accomplish what I set out to do.



![image](https://user-images.githubusercontent.com/31583660/54370279-5688bb80-4645-11e9-96f6-9744d116634f.png)
