### PR TITLE
Feature/cam passport auth

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     license='MIT',
     author='Marius Wirtz',
     author_email='MWirtz@cubewise.com',
-    url='https://github.com/cubewise-code/TM1py',
+    url='https://github.com/cubewise-code/tm1py',
     download_url=SCHEDULE_DOWNLOAD_URL,
     keywords=[
         'TM1', 'IBM Cognos TM1', 'Planning Analytics', 'PA', 'Cognos'
@@ -38,6 +38,6 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Natural Language :: English',
     ],
-    install_requires=['requests', 'pandas', 'pytz'],
+    install_requires=['requests', 'pandas', 'pytz', 'requests_negotiate_sspi'],
     python_requires='>=3.5',
 )


### PR DESCRIPTION
Added functionality to _build_authorization_token function to take gateway as an argument where gateway is the Cognos dispatcher used for CAM security. will use negotiated login attempt to get passport cookie for authorization header instead of taking username & password