### PR TITLE
Enable platform independency

### DIFF
--- a/Tests/config.ini
+++ b/Tests/config.ini
@@ -1,11 +1,11 @@
-[tm1srv02]
+[tm1srv01]
 address=10.77.19.60
 port=12354
 user=Admin
 password=apple
 ssl=True
 
-[tm1srv01]
+[tm1srv02]
 address=10.77.19.60
 port=9699
 user=Admin

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import codecs
 
 from setuptools import setup
 
-SCHEDULE_VERSION = '1.3.0'
+SCHEDULE_VERSION = '1.3.1'
 SCHEDULE_DOWNLOAD_URL = (
         'https://github.com/Cubewise-code/TM1py/tarball/' + SCHEDULE_VERSION
 )
@@ -35,6 +35,10 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Natural Language :: English',
     ],
-    install_requires=['requests', 'pandas', 'pytz', 'requests_negotiate_sspi'],
+    install_requires=[
+        'requests',
+        'pandas',
+        'pytz',
+        'requests_negotiate_sspi;platform_system=="Windows"'],
     python_requires='>=3.5',
 )


### PR DESCRIPTION
- Fail-safe import of (windows-only) dependecy `requests_negotiate_sspi`
- Optional dependency to `requests_negotiate_sspi `in `setup.py` only in
windows os

Fixes #127