### PR TITLE
Properly escape ' in object names in url

### DIFF
--- a/TM1py/Objects/Subset.py
+++ b/TM1py/Objects/Subset.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 
-import json
 import collections
+import json
 
 from TM1py.Objects.TM1Object import TM1Object
+from TM1py.Utils.Utils import odata_escape_single_quotes_in_object_names
 
 
 class Subset(TM1Object):
@@ -11,6 +12,7 @@ class Subset(TM1Object):
 
         Done and tested. unittests available.
     """
+
     def __init__(self, subset_name, dimension_name, hierarchy_name=None, alias=None, expression=None, elements=None):
         """
 
@@ -137,8 +139,9 @@ class Subset(TM1Object):
         body_as_dict['Name'] = self._subset_name
         if self.alias:
             body_as_dict['Alias'] = self._alias
-        body_as_dict['Hierarchy@odata.bind'] = 'Dimensions(\'{}\')/Hierarchies(\'{}\')'\
-            .format(self._dimension_name, self._hierarchy_name)
+        body_as_dict['Hierarchy@odata.bind'] = "Dimensions('{}')/Hierarchies('{}')".format(
+            self._dimension_name,
+            self._hierarchy_name)
         body_as_dict['Expression'] = self._expression
         return body_as_dict
 
@@ -147,14 +150,16 @@ class Subset(TM1Object):
         body_as_dict['Name'] = self._subset_name
         if self.alias:
             body_as_dict['Alias'] = self._alias
-        body_as_dict['Hierarchy@odata.bind'] = 'Dimensions(\'{}\')/Hierarchies(\'{}\')'\
-            .format(self._dimension_name, self.hierarchy_name)
+        body_as_dict['Hierarchy@odata.bind'] = "Dimensions('{}')/Hierarchies('{}')".format(
+            self._dimension_name,
+            self.hierarchy_name)
         if self.elements and len(self.elements) > 0:
-            body_as_dict['Elements@odata.bind'] = \
-                ['Dimensions(\'{}\')/Hierarchies(\'{}\')/Elements(\'{}\')'.format(
-                    self.dimension_name, self.hierarchy_name, element.replace('\'', '\'\''))
-                    for element
-                    in self.elements]
+            body_as_dict['Elements@odata.bind'] = [
+                odata_escape_single_quotes_in_object_names(
+                    "Dimensions('{}')/Hierarchies('{}')/Elements('{}')".format(
+                        self.dimension_name, self.hierarchy_name, element))
+                for element
+                in self.elements]
         return body_as_dict
 
 
@@ -162,6 +167,7 @@ class AnonymousSubset(Subset):
     """ Abstraction of unregistered Subsets used in NativeViews (Check TM1py.ViewAxisSelection)
 
     """
+
     def __init__(self, dimension_name, hierarchy_name=None, expression=None, elements=None):
         Subset.__init__(self,
                         dimension_name=dimension_name,
@@ -199,17 +205,19 @@ class AnonymousSubset(Subset):
 
     def _construct_body_dynamic(self):
         body_as_dict = collections.OrderedDict()
-        body_as_dict['Hierarchy@odata.bind'] = 'Dimensions(\'{}\')/Hierarchies(\'{}\')'\
+        body_as_dict['Hierarchy@odata.bind'] = "Dimensions('{}')/Hierarchies('{}')" \
             .format(self._dimension_name, self.hierarchy_name)
         body_as_dict['Expression'] = self._expression
         return body_as_dict
 
     def _construct_body_static(self):
         body_as_dict = collections.OrderedDict()
-        body_as_dict['Hierarchy@odata.bind'] = 'Dimensions(\'{}\')/Hierarchies(\'{}\')'\
-            .format(self._dimension_name, self.hierarchy_name)
-        body_as_dict['Elements@odata.bind'] = ['Dimensions(\'{}\')/Hierarchies(\'{}\')/Elements(\'{}\')'.format(
+        body_as_dict['Hierarchy@odata.bind'] = "Dimensions('{}')/Hierarchies('{}')".format(
+            self._dimension_name,
+            self.hierarchy_name)
+        body_as_dict['Elements@odata.bind'] = [
+            odata_escape_single_quotes_in_object_names("Dimensions('{}')/Hierarchies('{}')/Elements('{}')".format(
                 self.dimension_name,
                 self.hierarchy_name,
-                element.replace('\'', '\'\'')) for element in self.elements]
+                element)) for element in self.elements]
         return body_as_dict

--- a/TM1py/Objects/User.py
+++ b/TM1py/Objects/User.py
@@ -1,17 +1,17 @@
 # -*- coding: utf-8 -*-
 
-import json
 import collections
-from base64 import b64encode
+import json
 
 from TM1py.Objects.TM1Object import TM1Object
-from TM1py.Utils.Utils import CaseAndSpaceInsensitiveSet
+from TM1py.Utils.Utils import CaseAndSpaceInsensitiveSet, odata_escape_single_quotes_in_object_names
 
 
 class User(TM1Object):
     """ Abstraction of a TM1 User
     
     """
+
     def __init__(self, name, groups, friendly_name=None, password=None):
         self._name = name
         self._groups = CaseAndSpaceInsensitiveSet(*groups)
@@ -92,5 +92,8 @@ class User(TM1Object):
         body_as_dict['FriendlyName'] = self.friendly_name or self.name
         if self.password:
             body_as_dict['Password'] = self._password
-        body_as_dict['Groups@odata.bind'] = ['Groups(\'{}\')'.format(group) for group in self.groups]
+        body_as_dict['Groups@odata.bind'] = [
+            odata_escape_single_quotes_in_object_names("Groups('{}')".format(group))
+            for group
+            in self.groups]
         return json.dumps(body_as_dict, ensure_ascii=False)

--- a/TM1py/Services/CubeService.py
+++ b/TM1py/Services/CubeService.py
@@ -12,6 +12,7 @@ class CubeService(ObjectService):
     """ Service to handle Object Updates for TM1 Cubes
 
     """
+
     def __init__(self, rest):
         # to avoid Circular dependency of modules
         from TM1py.Services.AnnotationService import AnnotationService

--- a/TM1py/Services/ElementService.py
+++ b/TM1py/Services/ElementService.py
@@ -19,22 +19,30 @@ class ElementService(ObjectService):
         return Element.from_dict(response.json())
 
     def create(self, dimension_name, hierarchy_name, element):
-        request = "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements".format(dimension_name, hierarchy_name)
+        request = "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements".format(
+            dimension_name,
+            hierarchy_name)
         return self._rest.POST(request, element.body)
 
     def update(self, dimension_name, hierarchy_name, element):
-        request = "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements('{}')".format(dimension_name, hierarchy_name,
-                                                                                     element.name)
+        request = "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements('{}')".format(
+            dimension_name,
+            hierarchy_name,
+            element.name)
         return self._rest.PATCH(request, element.body)
 
     def exists(self, dimension_name, hierarchy_name, element_name):
-        request = "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements('{}')".format(dimension_name, hierarchy_name,
-                                                                                     element_name)
+        request = "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements('{}')".format(
+            dimension_name,
+            hierarchy_name,
+            element_name)
         return self._exists(request)
 
     def delete(self, dimension_name, hierarchy_name, element_name):
-        request = "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements('{}')".format(dimension_name, hierarchy_name,
-                                                                                     element_name)
+        request = "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements('{}')".format(
+            dimension_name,
+            hierarchy_name,
+            element_name)
         return self._rest.DELETE(request)
 
     def get_elements(self, dimension_name, hierarchy_name):
@@ -63,8 +71,9 @@ class ElementService(ObjectService):
         :param hierarchy_name: 
         :return: Generator of element-names
         """
-        request = '/api/v1/Dimensions(\'{}\')/Hierarchies(\'{}\')/Elements?$select=Name'.format(dimension_name,
-                                                                                                hierarchy_name)
+        request = '/api/v1/Dimensions(\'{}\')/Hierarchies(\'{}\')/Elements?$select=Name'.format(
+            dimension_name,
+            hierarchy_name)
         response = self._rest.GET(request, '')
         return (e["Name"] for e in response.json()['value'])
 
@@ -75,8 +84,9 @@ class ElementService(ObjectService):
         :param hierarchy_name:
         :return:
         """
-        request = '/api/v1/Dimensions(\'{}\')/Hierarchies(\'{}\')/ElementAttributes'.format(dimension_name,
-                                                                                            hierarchy_name)
+        request = '/api/v1/Dimensions(\'{}\')/Hierarchies(\'{}\')/ElementAttributes'.format(
+            dimension_name,
+            hierarchy_name)
         response = self._rest.GET(request, '')
         element_attributes = [ElementAttribute.from_dict(ea) for ea in response.json()['value']]
         return element_attributes
@@ -99,7 +109,7 @@ class ElementService(ObjectService):
             request = "/api/v1/Dimensions('{}')/Hierarchies('{}')" \
                       "?$expand=Elements($filter = Attributes/{} eq {};$select=Name)" \
                 .format(dimension_name, hierarchy_name, attribute_name, attribute_value)
-        response = self._rest.GET(request)
+        response = self._rest.GET(request, odata_escape_single_quotes_in_object_names=False)
         return [elem['Name'] for elem in response.json()['Elements']]
 
     def create_element_attribute(self, dimension_name, hierarchy_name, element_attribute):

--- a/TM1py/Services/ObjectService.py
+++ b/TM1py/Services/ObjectService.py
@@ -17,8 +17,8 @@ class ObjectService:
     def determine_actual_object_name(self, object_class, object_name):
         request = "/api/v1/{}?$filter=tolower(replace(Name, ' ', '')) eq '{}'".format(
             object_class,
-            object_name.replace(" ", "").lower())
-        response = self._rest.GET(request)
+            object_name.replace(" ", "").lower().replace("'", "''"))
+        response = self._rest.GET(request, odata_escape_single_quotes_in_object_names=False)
         if len(response.json()["value"]) == 0:
             raise ValueError("Object '{}' of type '{}' doesn't exist".format(object_name, object_class))
         return response.json()["value"][0]["Name"]

--- a/TM1py/Services/RESTService.py
+++ b/TM1py/Services/RESTService.py
@@ -14,6 +14,7 @@ except ImportError:
     warnings.warn("requests_negotiate_sspi failed to import. SSO will not work", ImportWarning)
 
 from TM1py.Exceptions import TM1pyException
+from TM1py.Utils import Utils
 
 # import Http-Client depending on python version
 if sys.version[0] == '2':
@@ -30,9 +31,12 @@ def httpmethod(func):
     """
 
     @functools.wraps(func)
-    def wrapper(self, request, data=''):
+    def wrapper(self, request, data='', odata_escape_single_quotes_in_object_names=True):
         # Encoding
-        request, data = self._url_and_body(request=request, data=data)
+        request, data = self._url_and_body(
+            request=request,
+            data=data,
+            odata_escape_single_quotes_in_object_names=odata_escape_single_quotes_in_object_names)
         # Do Request
         response = func(self, request, data)
         # Verify
@@ -211,11 +215,13 @@ class RESTService:
             # After we have session cookie, drop the Authorization Header
             self.remove_http_header('Authorization')
 
-    def _url_and_body(self, request, data):
+    def _url_and_body(self, request, data, odata_escape_single_quotes_in_object_names=True):
         """ create proper url and payload
         """
         url = self._base_url + request
         url = url.replace(' ', '%20').replace('#', '%23')
+        if odata_escape_single_quotes_in_object_names:
+            url = Utils.odata_escape_single_quotes_in_object_names(url)
         data = data.encode('utf-8')
         return url, data
 

--- a/TM1py/Services/SecurityService.py
+++ b/TM1py/Services/SecurityService.py
@@ -4,6 +4,7 @@ import json
 
 from TM1py.Objects.User import User
 from TM1py.Services.ObjectService import ObjectService
+from TM1py.Utils.Utils import odata_escape_single_quotes_in_object_names
 
 
 class SecurityService(ObjectService):
@@ -117,7 +118,7 @@ class SecurityService(ObjectService):
         :param group_name:
         :return: List of TM1py.User instances
         """
-        request = '/api/v1/Groups(\'{}\')?$expand=Users($expand=Groups)'.format(group_name)
+        request = "/api/v1/Groups('{}')?$expand=Users($expand=Groups)".format(group_name)
         response = self._rest.GET(request)
         users = [User.from_dict(user) for user in response.json()['Users']]
         return users
@@ -128,7 +129,7 @@ class SecurityService(ObjectService):
         :param group_name:
         :return: List of strings
         """
-        request = '/api/v1/Groups(\'{}\')?$expand=Users($expand=Groups)'.format(group_name)
+        request = "/api/v1/Groups('{}')?$expand=Users($expand=Groups)".format(group_name)
         response = self._rest.GET(request)
         users = [user["Name"] for user in response.json()['Users']]
         return users
@@ -155,9 +156,11 @@ class SecurityService(ObjectService):
         request = "/api/v1/Users('{}')".format(user_name)
         body = {
             "Name": user_name,
-            "Groups@odata.bind": ["Groups('{}')".format(self.determine_actual_group_name(group))
-                                  for group
-                                  in groups]
+            "Groups@odata.bind": [
+                odata_escape_single_quotes_in_object_names("Groups('{}')".format(
+                    self.determine_actual_group_name(group)))
+                for group
+                in groups]
         }
         return self._rest.PATCH(request, json.dumps(body))
 
@@ -170,7 +173,7 @@ class SecurityService(ObjectService):
         """
         user_name = self.determine_actual_user_name(user_name)
         group_name = self.determine_actual_group_name(group_name)
-        request = '/api/v1/Users(\'{}\')/Groups?$id=Groups(\'{}\')'.format(user_name, group_name)
+        request = "/api/v1/Users('{}')/Groups?$id=Groups('{}')".format(user_name, group_name)
         return self._rest.DELETE(request)
 
     def get_all_groups(self):

--- a/TM1py/Utils/__init__.py
+++ b/TM1py/Utils/__init__.py
@@ -1,1 +1,3 @@
-
+from TM1py.Utils.Utils import *
+from TM1py.Utils.MDXUtils import *
+from TM1py.Utils.TIObfuscator import *

--- a/Tests/Cell.py
+++ b/Tests/Cell.py
@@ -4,6 +4,7 @@ import random
 import types
 import unittest
 
+import numpy as np
 import pandas as pd
 
 from TM1py.Objects import MDXView, Cube, Dimension, Element, Hierarchy, NativeView, AnonymousSubset, ElementAttribute
@@ -740,7 +741,7 @@ class TestDataMethods(unittest.TestCase):
               "NON EMPTY [" + DIMENSION_NAMES[0] + "].Members * [" + DIMENSION_NAMES[1] + "].Members ON ROWS," \
               "NON EMPTY [" + DIMENSION_NAMES[2] + "].MEMBERS ON COLUMNS " \
               "FROM [" + CUBE_NAME + "]"
-        df = self.tm1.cubes.cells.execute_mdx_dataframe(mdx)
+        df = self.tm1.cubes.cells.execute_mdx_dataframe(mdx, dtype={'Value': float})
 
         # check type
         self.assertIsInstance(df, pd.DataFrame)
@@ -1137,7 +1138,11 @@ class TestDataMethods(unittest.TestCase):
         self.assertEqual(self.total_value, sum(values))
 
     def test_execute_view_dataframe(self):
-        df = self.tm1.cubes.cells.execute_view_dataframe(cube_name=CUBE_NAME, view_name=VIEW_NAME, private=False)
+        df = self.tm1.cubes.cells.execute_view_dataframe(
+            cube_name=CUBE_NAME,
+            view_name=VIEW_NAME,
+            private=False,
+            dtype={'Value': float})
 
         # check type
         self.assertIsInstance(df, pd.DataFrame)

--- a/Tests/Security.py
+++ b/Tests/Security.py
@@ -18,9 +18,9 @@ class TestSecurityMethods(unittest.TestCase):
     @classmethod
     def setup_class(cls):
         cls.tm1 = TM1Service(**config['tm1srv01'])
-        cls.user_name = PREFIX + "User1"
+        cls.user_name = PREFIX + "Us'er1"
         cls.user = User(name=cls.user_name, groups=[], password='TM1py')
-        cls.group_name1 = PREFIX + "Group1"
+        cls.group_name1 = PREFIX + "Gro'up1"
         cls.group_name2 = PREFIX + "Group2"
         cls.user.add_group(cls.group_name1)
 
@@ -105,7 +105,8 @@ class TestSecurityMethods(unittest.TestCase):
 
     def test_get_user_names_from_group(self):
         users = self.tm1.security.get_user_names_from_group(self.group_name1)
-        mdx = "{ FILTER ( { [}Clients].Members } , [}ClientGroups].([}Groups].[" + self.group_name1 + "]) = '" + self.group_name1 + "' ) }"
+        mdx = "{ FILTER ( { [}Clients].Members } , [}ClientGroups].([}Groups].[" + self.group_name1 + "]) = '" + \
+              self.group_name1.replace("'", "''") + "' ) }"
         clients = self.tm1.dimensions.execute_mdx("}Clients", mdx)
         self.assertGreater(len(users), 0)
         self.assertGreater(len(clients), 0)


### PR DESCRIPTION
- new method to escape ' in object names in odata reference
- centralized call in httpmethod for escaping of ' in object names
- minor reformating and test enhancements

Fixes #145