### PR TITLE
Undo silent type conversion in values column

### DIFF
--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -785,9 +785,9 @@ class CellService:
         """
         raw_csv = self.extract_cellset_csv(cellset_id=cellset_id, delete_cellset=True)
         memory_file = StringIO(raw_csv)
-        # make sure all element names are strings and values are objects
+        # make sure all element names are strings and values column is derived from data
         if 'dtype' not in kwargs:
-            kwargs['dtype'] = {'Value': object, **{col: str for col in range(999)}}
+            kwargs['dtype'] = {'Value': None, **{col: str for col in range(999)}}
         return pd.read_csv(memory_file, sep=',', **kwargs)
 
     def extract_cellset_dataframe_pivot(self, cellset_id, dropna=False, fill_value=False, **kwargs):

--- a/Tests/Cell.py
+++ b/Tests/Cell.py
@@ -741,23 +741,26 @@ class TestDataMethods(unittest.TestCase):
               "NON EMPTY [" + DIMENSION_NAMES[0] + "].Members * [" + DIMENSION_NAMES[1] + "].Members ON ROWS," \
               "NON EMPTY [" + DIMENSION_NAMES[2] + "].MEMBERS ON COLUMNS " \
               "FROM [" + CUBE_NAME + "]"
-        df = self.tm1.cubes.cells.execute_mdx_dataframe(mdx, dtype={'Value': float})
+        df = self.tm1.cubes.cells.execute_mdx_dataframe(mdx)
 
         # check type
         self.assertIsInstance(df, pd.DataFrame)
 
         # check coordinates in df are equal to target coordinates
-        coordinates = {tuple(row)
-                       for row
-                       in df[[*DIMENSION_NAMES]].values}
-        self.assertEqual(len(coordinates),
-                         len(self.target_coordinates))
+        coordinates = {
+            tuple(row)
+            for row
+            in df[[*DIMENSION_NAMES]].values}
+        self.assertEqual(
+            len(coordinates),
+            len(self.target_coordinates))
         self.assertTrue(coordinates.issubset(self.target_coordinates))
 
         # check if total values are equal
         values = df[["Value"]].values
-        self.assertEqual(self.total_value,
-                         sum(values))
+        self.assertEqual(
+            self.total_value,
+            sum(values))
 
     def test_execute_mdx_dataframe_pivot(self):
         mdx = MDX_TEMPLATE.format(
@@ -1141,8 +1144,7 @@ class TestDataMethods(unittest.TestCase):
         df = self.tm1.cubes.cells.execute_view_dataframe(
             cube_name=CUBE_NAME,
             view_name=VIEW_NAME,
-            private=False,
-            dtype={'Value': float})
+            private=False)
 
         # check type
         self.assertIsInstance(df, pd.DataFrame)


### PR DESCRIPTION
now type of `Value` column in resulting dataframe from
`execute_mdx_dataframe`, `execute_view_dataframe` is derived
from data, unless specified otherwise through `dtype` argument.

Fixes backwards compatability issue that was introduced with MR #144