### PR TITLE
Expand exception detail

### DIFF
--- a/TM1py/Exceptions/Exceptions.py
+++ b/TM1py/Exceptions/Exceptions.py
@@ -30,7 +30,7 @@ class TM1pyException(Exception):
         return self._headers
 
     def __str__(self):
-        return "Text: {} Status Code: {} Reason: {} Headers {}".format(self._response,
+        return "Text: {} Status Code: {} Reason: {} Headers: {}".format(self._response,
                                                                 self._status_code,
                                                                 self._reason,
                                                                 self._headers)

--- a/TM1py/Exceptions/Exceptions.py
+++ b/TM1py/Exceptions/Exceptions.py
@@ -30,4 +30,7 @@ class TM1pyException(Exception):
         return self._headers
 
     def __str__(self):
-        return "Text: {} Status Code: {} Reason: {}".format(self._response, self._status_code, self._reason)
+        return "Text: {} Status Code: {} Reason: {} Headers {}".format(self._response,
+                                                                self._status_code,
+                                                                self._reason,
+                                                                self._headers)

--- a/TM1py/Exceptions/Exceptions.py
+++ b/TM1py/Exceptions/Exceptions.py
@@ -7,10 +7,11 @@ class TM1pyException(Exception):
     """ The default exception for TM1py
 
     """
-    def __init__(self, response, status_code, reason):
+    def __init__(self, response, status_code, reason, headers):
         self._response = response
         self._status_code = status_code
         self._reason = reason
+        self._headers = headers
 
     @property
     def status_code(self):
@@ -23,6 +24,10 @@ class TM1pyException(Exception):
     @property
     def response(self):
         return self._response
+
+    @property
+    def headers(self):
+        return self._headers
 
     def __str__(self):
         return "Text: {} Status Code: {} Reason: {}".format(self._response, self._status_code, self._reason)

--- a/TM1py/Services/RESTService.py
+++ b/TM1py/Services/RESTService.py
@@ -280,7 +280,10 @@ class RESTService:
             TM1pyException, raises TM1pyException when Code is not 200, 204 etc.
         """
         if not response.ok:
-            raise TM1pyException(response.text, status_code=response.status_code, reason=response.reason)
+            raise TM1pyException(response.text,
+                                 status_code=response.status_code,
+                                 reason=response.reason,
+                                 headers=response.headers)
 
     @staticmethod
     def _build_authorization_token(user, password, namespace=None, gateway=None, verify=False, **kwargs):


### PR DESCRIPTION
Expanded TM1Py  Exception to include the returned headers. Returning the headers allow for easier trouble shooting and auto-detection of the CAM Gateway. This will allow for easier roll out to users using SSO. 

` try:
        response = TM1Service(**kwargs)
  except TM1pyException as e:
        response_headers = e.headers
        authenticate_header = response_headers.get("WWW-Authenticate", "No Gateway Found")
        if authenticate_header is not "No Gateway Found":
            gateway = authenticate_header.split("CAMPassport")[1].strip().split(",")[0]
            return gateway
        else:
            raise authenticate_header`