### PR TITLE
Added 'clear' data spread method

### DIFF
--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -122,6 +122,33 @@ class CellService:
                     *Utils.dimension_hierarchy_element_tuple_from_unique_name(unique_element_name))))
 
         self._post_against_cellset(cellset_id=cellset_id, payload=payload, delete_cellset=True)
+        
+    def clear_spread(
+            self,
+            cube,
+            unique_element_names):
+        """ Execute clear spread
+        :param cube: name of the cube
+        :param unique_element_names: target cell coordinates as unique element names (e.g. ["[d1].[c1]","[d2].[e3]"])
+        :return:
+        """
+        mdx = """
+        SELECT
+        {{ {rows} }} ON 0
+        FROM [{cube}]
+        """.format(rows="}*{".join(unique_element_names), cube=cube)
+        cellset_id = self.create_cellset(mdx=mdx)
+
+        payload = {
+            "BeginOrdinal": 0,
+            "Value": "C",
+            "ReferenceCell@odata.bind": list()}
+        for unique_element_name in unique_element_names:
+            payload["ReferenceCell@odata.bind"].append(
+                odata_escape_single_quotes_in_object_names("Dimensions('{}')/Hierarchies('{}')/Elements('{}')".format(
+                    *Utils.dimension_hierarchy_element_tuple_from_unique_name(unique_element_name))))
+
+        self._post_against_cellset(cellset_id=cellset_id, payload=payload, delete_cellset=True)
 
     @tidy_cellset
     def _post_against_cellset(self, cellset_id, payload, **kwargs):

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -11,7 +11,7 @@ if sys.version[0] == '2':
 else:
     import http.client as http_client
 
-REGEX_OBJECT_NAMES = re.compile(r"(?<=[a-zA-Z0-9_])'(?=[a-zA-Z0-9_])")
+REGEX_OBJECT_NAMES = re.compile(r"(?<!\()(?<!eq )'(?!\)|\Z)")
 
 
 def get_all_servers_from_adminhost(adminhost='localhost'):

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -11,7 +11,7 @@ if sys.version[0] == '2':
 else:
     import http.client as http_client
 
-REGEX_OBJECT_NAMES = re.compile(r"(?<=\(').*?(?='\))")
+REGEX_OBJECT_NAMES = re.compile(r"(?<=[A-Za-z])'(?=[A-Za-z])")
 
 
 def get_all_servers_from_adminhost(adminhost='localhost'):

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -11,7 +11,7 @@ if sys.version[0] == '2':
 else:
     import http.client as http_client
 
-REGEX_OBJECT_NAMES = re.compile(r"(?<=[A-Za-z])'(?=[A-Za-z])")
+REGEX_OBJECT_NAMES = re.compile(r"(?<=[a-zA-Z0-9_])'(?=[a-zA-Z0-9_])")
 
 
 def get_all_servers_from_adminhost(adminhost='localhost'):

--- a/Tests/Utils.py
+++ b/Tests/Utils.py
@@ -660,10 +660,35 @@ class TestMDXUtils(unittest.TestCase):
 
     def test_odata_escape_single_quotes_in_object_names(self):
         url = "https://localhost:8099/api/v1/Dimensions('dime'nsion')/Hierarchies('hier'archy')/Elements('elem'ent')"
+        url1 = "https://localhost:915/api/v1/TransactionLogEntries?$orderby=TimeStamp desc &$filter=Cube eq 'Test C'ase cube'"
+        url2 = "https://localhost:915/api/v1/TransactionLogEntries?$orderby=TimeStamp desc &$filter=Cube eq 'TestC_'ase cube'"
+        ulr3 = "https://localhost:915/api/v1/TransactionLogEntries?$orderby=TimeStamp desc &$filter=Cube eq 'Test C9'ase cube'"
+        ulr4 = "https://localhost:915/api/v1/TransactionLogEntries?$orderby=TimeStamp desc &$filter=Cube eq 'Test C9'_ase cube'"
+        ulr5 = "https://localhost:915/api/v1/TransactionLogEntries?$orderby=TimeStamp desc &$filter=Cube eq 'Test Case cube'"
         escaped_url = Utils.odata_escape_single_quotes_in_object_names(url)
+        escaped_url1 = Utils.odata_escape_single_quotes_in_object_names(url1)
+        escaped_url2 = Utils.odata_escape_single_quotes_in_object_names(url2)
+        escaped_url3 = Utils.odata_escape_single_quotes_in_object_names(ulr3)
+        escaped_url4 = Utils.odata_escape_single_quotes_in_object_names(ulr4)
+        escaped_url5 = Utils.odata_escape_single_quotes_in_object_names(ulr5)
         self.assertEqual(
             escaped_url,
             "https://localhost:8099/api/v1/Dimensions('dime''nsion')/Hierarchies('hier''archy')/Elements('elem''ent')")
+        self.assertEqual(
+            escaped_url1,
+            "https://localhost:915/api/v1/TransactionLogEntries?$orderby=TimeStamp desc &$filter=Cube eq 'Test C''ase cube'")
+        self.assertEqual(
+            escaped_url2,
+            "https://localhost:915/api/v1/TransactionLogEntries?$orderby=TimeStamp desc &$filter=Cube eq 'TestC_''ase cube'")
+        self.assertEqual(
+            escaped_url3,
+            "https://localhost:915/api/v1/TransactionLogEntries?$orderby=TimeStamp desc &$filter=Cube eq 'Test C9''ase cube'")
+        self.assertEqual(
+            escaped_url4,
+            "https://localhost:915/api/v1/TransactionLogEntries?$orderby=TimeStamp desc &$filter=Cube eq 'Test C9''_ase cube'")
+        self.assertEqual(
+            escaped_url5,
+            "https://localhost:915/api/v1/TransactionLogEntries?$orderby=TimeStamp desc &$filter=Cube eq 'Test Case cube'")
 
     def test_odata_escape_single_quotes_in_object_names_group(self):
         url = "https://localhost:8099/api/v1/Groups('Gro'up')"

--- a/Tests/Utils.py
+++ b/Tests/Utils.py
@@ -660,29 +660,29 @@ class TestMDXUtils(unittest.TestCase):
 
     def test_odata_escape_single_quotes_in_object_names(self):
         url = "https://localhost:8099/api/v1/Dimensions('dime'nsion')/Hierarchies('hier'archy')/Elements('elem'ent')"
-        url1 = "https://localhost:915/api/v1/TransactionLogEntries?$orderby=TimeStamp desc &$filter=Cube eq 'Test C'ase cube'"
-        url2 = "https://localhost:915/api/v1/TransactionLogEntries?$orderby=TimeStamp desc &$filter=Cube eq 'TestC_'ase cube'"
-        ulr3 = "https://localhost:915/api/v1/TransactionLogEntries?$orderby=TimeStamp desc &$filter=Cube eq 'Test C9'ase cube'"
-        ulr4 = "https://localhost:915/api/v1/TransactionLogEntries?$orderby=TimeStamp desc &$filter=Cube eq 'Test C9'_ase cube'"
-        ulr5 = "https://localhost:915/api/v1/TransactionLogEntries?$orderby=TimeStamp desc &$filter=Cube eq 'Test Case cube'"
+        url1 = "https://localhost:915/api/v1/TransactionLogEntries?$orderby=TimeStamp desc &$filter=Cube eq 'Test 'Case' cube*'"
+        url2 = "https://localhost:915/api/v1/TransactionLogEntries?$orderby=TimeStamp desc &$filter=Cube eq 'Test C_'ase cube'"
+        url3 = "https://localhost:915/api/v1/TransactionLogEntries?$orderby=TimeStamp desc &$filter=Cube eq 'Test C9'as*'&e cube'"
+        url4 = "https://localhost:915/api/v1/TransactionLogEntries?$orderby=TimeStamp desc &$filter=Cube eq 'Test C9'_ase cube'"
+        url5 = "https://localhost:915/api/v1/TransactionLogEntries?$orderby=TimeStamp desc &$filter=Cube eq 'Test Case cube'"
         escaped_url = Utils.odata_escape_single_quotes_in_object_names(url)
         escaped_url1 = Utils.odata_escape_single_quotes_in_object_names(url1)
         escaped_url2 = Utils.odata_escape_single_quotes_in_object_names(url2)
-        escaped_url3 = Utils.odata_escape_single_quotes_in_object_names(ulr3)
-        escaped_url4 = Utils.odata_escape_single_quotes_in_object_names(ulr4)
-        escaped_url5 = Utils.odata_escape_single_quotes_in_object_names(ulr5)
+        escaped_url3 = Utils.odata_escape_single_quotes_in_object_names(url3)
+        escaped_url4 = Utils.odata_escape_single_quotes_in_object_names(url4)
+        escaped_url5 = Utils.odata_escape_single_quotes_in_object_names(url5)
         self.assertEqual(
             escaped_url,
             "https://localhost:8099/api/v1/Dimensions('dime''nsion')/Hierarchies('hier''archy')/Elements('elem''ent')")
         self.assertEqual(
             escaped_url1,
-            "https://localhost:915/api/v1/TransactionLogEntries?$orderby=TimeStamp desc &$filter=Cube eq 'Test C''ase cube'")
+            "https://localhost:915/api/v1/TransactionLogEntries?$orderby=TimeStamp desc &$filter=Cube eq 'Test ''Case'' cube*'")
         self.assertEqual(
             escaped_url2,
-            "https://localhost:915/api/v1/TransactionLogEntries?$orderby=TimeStamp desc &$filter=Cube eq 'TestC_''ase cube'")
+            "https://localhost:915/api/v1/TransactionLogEntries?$orderby=TimeStamp desc &$filter=Cube eq 'Test C_''ase cube'")
         self.assertEqual(
             escaped_url3,
-            "https://localhost:915/api/v1/TransactionLogEntries?$orderby=TimeStamp desc &$filter=Cube eq 'Test C9''ase cube'")
+            "https://localhost:915/api/v1/TransactionLogEntries?$orderby=TimeStamp desc &$filter=Cube eq 'Test C9''as*''&e cube'")
         self.assertEqual(
             escaped_url4,
             "https://localhost:915/api/v1/TransactionLogEntries?$orderby=TimeStamp desc &$filter=Cube eq 'Test C9''_ase cube'")


### PR DESCRIPTION
1. A new method in `CellService`: `relative_proportional_spread`

**Sample:**

```
import configparser

from TM1py import TM1Service

config = configparser.ConfigParser()
config.read(r'config.ini')

with TM1Service(**config['tm1srv01']) as tm1:
    tm1.cubes.cells.relative_proportional_spread(
        cube="c1",
        unique_element_names=("[d1].[c1]", "[d2].[e3]"))
```

2. Updated the `Utils` module to fix https://github.com/cubewise-code/tm1py/issues/202#issue-543913984 . Replaced the `re` pattern in line **14**