### PR TITLE
Refactor tm1 object name encoding in url

### DIFF
--- a/TM1py/Exceptions/Exceptions.py
+++ b/TM1py/Exceptions/Exceptions.py
@@ -3,6 +3,16 @@
 # TM1py Exceptions are defined here
 
 
+class TM1pyTimeout(Exception):
+    def __init__(self, method, url, timeout):
+        self.method = method
+        self.url = url
+        self.timeout = timeout
+
+    def __str__(self):
+        return f"Timeout after {self.timeout} seconds for '{self.method}' request with url :'{self.url}'"
+
+
 class TM1pyException(Exception):
     """ The default exception for TM1py
 
@@ -30,7 +40,8 @@ class TM1pyException(Exception):
         return self._headers
 
     def __str__(self):
-        return "Text: {} Status Code: {} Reason: {} Headers: {}".format(self._response,
-                                                                self._status_code,
-                                                                self._reason,
-                                                                self._headers)
+        return "Text: {} Status Code: {} Reason: {} Headers: {}".format(
+            self._response,
+            self._status_code,
+            self._reason,
+            self._headers)

--- a/TM1py/Exceptions/Exceptions.py
+++ b/TM1py/Exceptions/Exceptions.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 
 # TM1py Exceptions are defined here
+from typing import Mapping
 
 
 class TM1pyTimeout(Exception):
-    def __init__(self, method, url, timeout):
+    def __init__(self, method: str, url: str, timeout: float):
         self.method = method
         self.url = url
         self.timeout = timeout
@@ -17,7 +18,8 @@ class TM1pyException(Exception):
     """ The default exception for TM1py
 
     """
-    def __init__(self, response, status_code, reason, headers):
+
+    def __init__(self, response: str, status_code: int, reason: str, headers: Mapping):
         self._response = response
         self._status_code = status_code
         self._reason = reason

--- a/TM1py/Objects/Annotation.py
+++ b/TM1py/Objects/Annotation.py
@@ -31,7 +31,7 @@ class Annotation(TM1Object):
         self._object_name = object_name
 
     @classmethod
-    def from_json(cls, annotation_as_json: Dict) -> 'Annotation':
+    def from_json(cls, annotation_as_json: str) -> 'Annotation':
         """ Alternative constructor
 
             :param annotation_as_json: String, JSON
@@ -53,7 +53,7 @@ class Annotation(TM1Object):
                    last_updated_by=last_updated_by, last_updated=last_updated)
 
     @property
-    def body(self) -> Dict:
+    def body(self) -> str:
         return self._construct_body()
 
     @property
@@ -106,7 +106,7 @@ class Annotation(TM1Object):
                 if not source_element or self._dimensional_context[i] == source_element:
                     self._dimensional_context[i] = target_element
 
-    def _construct_body(self) -> Dict:
+    def _construct_body(self) -> str:
         """ construct the ODATA conform JSON represenation for the Annotation entity.
 
             :return: string, the valid JSON

--- a/TM1py/Objects/Annotation.py
+++ b/TM1py/Objects/Annotation.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 
-import json
 import collections
+import json
+from typing import Iterable, Dict, List
 
 from TM1py.Objects.TM1Object import TM1Object
 
@@ -13,21 +14,24 @@ class Annotation(TM1Object):
             - Class complete, functional and tested.
             - doesn't cover Attachments though
     """
-    def __init__(self, comment_value, object_name, dimensional_context, comment_type='ANNOTATION', annotation_id=None,
-                 text='', creator=None, created=None, last_updated_by=None, last_updated=None):
+
+    def __init__(self, comment_value: str, object_name: str, dimensional_context: Iterable[str],
+                 comment_type: str = 'ANNOTATION', annotation_id: str = None,
+                 text: str = '', creator: str = None, created: str = None, last_updated_by: str = None,
+                 last_updated: str = None):
         self._id = annotation_id
         self._text = text
         self._creator = creator
         self._created = created
         self._last_updated_by = last_updated_by
         self._last_updated = last_updated
-        self._dimensional_context = dimensional_context
+        self._dimensional_context = list(dimensional_context)
         self._comment_type = comment_type
         self._comment_value = comment_value
         self._object_name = object_name
 
     @classmethod
-    def from_json(cls, annotation_as_json):
+    def from_json(cls, annotation_as_json: Dict) -> 'Annotation':
         """ Alternative constructor
 
             :param annotation_as_json: String, JSON
@@ -49,46 +53,46 @@ class Annotation(TM1Object):
                    last_updated_by=last_updated_by, last_updated=last_updated)
 
     @property
-    def body(self):
+    def body(self) -> Dict:
         return self._construct_body()
 
     @property
-    def comment_value(self):
+    def comment_value(self) -> str:
         return self._comment_value
 
     @property
-    def text(self):
+    def text(self) -> str:
         return self._text
 
     @property
-    def dimensional_context(self):
+    def dimensional_context(self) -> List[str]:
         return self._dimensional_context
 
     @property
-    def created(self):
+    def created(self) -> str:
         return self._created
 
     @property
-    def object_name(self):
+    def object_name(self) -> str:
         return self._object_name
 
     @property
-    def last_updated(self):
+    def last_updated(self) -> str:
         return self._last_updated
 
     @property
-    def last_updated_by(self):
+    def last_updated_by(self) -> str:
         return self._last_updated_by
 
     @comment_value.setter
-    def comment_value(self, value):
+    def comment_value(self, value: str):
         self._comment_value = value
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._id
 
-    def move(self, dimension_order, dimension, target_element, source_element=None):
+    def move(self, dimension_order: Iterable[str], dimension: str, target_element: str, source_element: str = None):
         """ Move annotation on given dimension from source_element to target_element
         
             :param dimension_order: List, order of the dimensions in the cube
@@ -102,7 +106,7 @@ class Annotation(TM1Object):
                 if not source_element or self._dimensional_context[i] == source_element:
                     self._dimensional_context[i] = target_element
 
-    def _construct_body(self):
+    def _construct_body(self) -> Dict:
         """ construct the ODATA conform JSON represenation for the Annotation entity.
 
             :return: string, the valid JSON

--- a/TM1py/Objects/Application.py
+++ b/TM1py/Objects/Application.py
@@ -2,141 +2,10 @@
 import json
 from collections import namedtuple, OrderedDict
 from enum import Enum
+from typing import Union, Dict
 
 from TM1py.Objects.TM1Object import TM1Object
-
-
-class Application(TM1Object):
-
-    def __init__(self, path, name, application_type):
-        self.path = path
-        # remove suffix from name
-        if application_type.suffix and name.endswith(application_type.suffix):
-            self.name = name[: - len(application_type.suffix)]
-        else:
-            self.name = name
-        # raise ValueError if not a valid type
-        self.application_type = ApplicationTypes(application_type)
-
-    @property
-    def application_id(self):
-        return self.path + self.name + self.application_type.suffix
-
-    @property
-    def body_as_dict(self):
-        body_as_dict = OrderedDict()
-        body_as_dict["@odata.type"] = self.application_type.odata_type
-        body_as_dict["Name"] = self.name
-        return body_as_dict
-
-    @property
-    def body(self):
-        body_as_dict = self.body_as_dict
-        return json.dumps(body_as_dict, ensure_ascii=False)
-
-
-class ChoreApplication(Application):
-    def __init__(self, path, name, chore_name):
-        super().__init__(path, name, ApplicationTypes.CHORE)
-        self.chore_name = chore_name
-
-    @property
-    def body(self):
-        body_as_dict = self.body_as_dict
-        body_as_dict["Chore@odata.bind"] = "Chores('{}')".format(self.chore_name)
-        return json.dumps(body_as_dict, ensure_ascii=False)
-
-
-class CubeApplication(Application):
-    def __init__(self, path, name, cube_name):
-        super().__init__(path, name, ApplicationTypes.CUBE)
-        self.cube_name = cube_name
-
-    @property
-    def body(self):
-        body_as_dict = self.body_as_dict
-        body_as_dict["Cube@odata.bind"] = "Cubes('{}')".format(self.cube_name)
-        return json.dumps(body_as_dict, ensure_ascii=False)
-
-
-class DimensionApplication(Application):
-    def __init__(self, path, name, dimension_name):
-        super().__init__(path, name, ApplicationTypes.DIMENSION)
-        self.dimension_name = dimension_name
-
-    @property
-    def body(self):
-        body_as_dict = self.body_as_dict
-        body_as_dict["Dimension@odata.bind"] = "Dimensions('{}')".format(self.dimension_name)
-        return json.dumps(body_as_dict, ensure_ascii=False)
-
-
-class DocumentApplication(Application):
-    def __init__(self, path, name, content):
-        super().__init__(path, name, ApplicationTypes.DOCUMENT)
-        self.content = content
-
-    def to_xlsx(self, path_to_file):
-        with open(path_to_file, "wb") as file:
-            file.write(self.content)
-
-
-class FolderApplication(Application):
-    def __init__(self, path, name):
-        super().__init__(path, name, ApplicationTypes.FOLDER)
-
-
-class LinkApplication(Application):
-    def __init__(self, path, name, url):
-        super().__init__(path, name, ApplicationTypes.LINK)
-        self.url = url
-
-    @property
-    def body(self):
-        body_as_dict = self.body_as_dict
-        body_as_dict["URL"] = self.url
-        return json.dumps(body_as_dict, ensure_ascii=False)
-
-
-class ProcessApplication(Application):
-    def __init__(self, path, name, process_name):
-        super().__init__(path, name, ApplicationTypes.PROCESS)
-        self.process_name = process_name
-
-    @property
-    def body(self):
-        body_as_dict = self.body_as_dict
-        body_as_dict["Process@odata.bind"] = "Processes('{}')".format(self.process_name)
-        return json.dumps(body_as_dict, ensure_ascii=False)
-
-
-class SubsetApplication(Application):
-    def __init__(self, path, name, dimension_name, hierarchy_name, subset_name):
-        super().__init__(path, name, ApplicationTypes.SUBSET)
-        self.dimension_name = dimension_name
-        self.hierarchy_name = hierarchy_name
-        self.subset_name = subset_name
-
-    @property
-    def body(self):
-        body_as_dict = self.body_as_dict
-        body_as_dict["Subset@odata.bind"] = "Dimensions('{}')/Hierarchies('{}')/Subsets('{}')".format(
-            self.dimension_name, self.hierarchy_name, self.subset_name)
-        return json.dumps(body_as_dict, ensure_ascii=False)
-
-
-class ViewApplication(Application):
-    def __init__(self, path, name, cube_name, view_name):
-        super().__init__(path, name, ApplicationTypes.VIEW)
-        self.cube_name = cube_name
-        self.view_name = view_name
-
-    @property
-    def body(self):
-        body_as_dict = self.body_as_dict
-        body_as_dict["View@odata.bind"] = "Cubes('{}')/Views('{}')".format(self.cube_name, self.view_name)
-        return json.dumps(body_as_dict, ensure_ascii=False)
-
+from TM1py.Utils import format_url
 
 ApplicationType = namedtuple('ApplicationType', ['value', 'suffix', 'odata_type'])
 
@@ -153,15 +22,148 @@ class ApplicationTypes(Enum):
     VIEW = ApplicationType(9, ".view", "tm1.ViewReference")
 
     @classmethod
-    def _missing_(cls, value):
+    def _missing_(cls, value: str) -> ApplicationType:
         for member in cls:
             if member.name.lower() == value.lower():
                 return member
 
     @property
-    def suffix(self):
+    def suffix(self) -> str:
         return self.value.suffix
 
     @property
-    def odata_type(self):
+    def odata_type(self) -> str:
         return self.value.odata_type
+
+
+class Application(TM1Object):
+
+    def __init__(self, path: str, name: str, application_type: Union[ApplicationTypes, str]):
+        self.path = path
+        # remove suffix from name
+        if application_type.suffix and name.endswith(application_type.suffix):
+            self.name = name[: - len(application_type.suffix)]
+        else:
+            self.name = name
+        # raise ValueError if not a valid type
+        self.application_type = ApplicationTypes(application_type)
+
+    @property
+    def application_id(self) -> str:
+        return self.path + self.name + self.application_type.suffix
+
+    @property
+    def body_as_dict(self) -> Dict:
+        body_as_dict = OrderedDict()
+        body_as_dict["@odata.type"] = self.application_type.odata_type
+        body_as_dict["Name"] = self.name
+        return body_as_dict
+
+    @property
+    def body(self) -> str:
+        body_as_dict = self.body_as_dict
+        return json.dumps(body_as_dict, ensure_ascii=False)
+
+
+class ChoreApplication(Application):
+    def __init__(self, path: str, name: str, chore_name: str):
+        super().__init__(path, name, ApplicationTypes.CHORE)
+        self.chore_name = chore_name
+
+    @property
+    def body(self) -> str:
+        body_as_dict = self.body_as_dict
+        body_as_dict["Chore@odata.bind"] = format_url("Chores('{}')", self.chore_name)
+        return json.dumps(body_as_dict, ensure_ascii=False)
+
+
+class CubeApplication(Application):
+    def __init__(self, path: str, name: str, cube_name: str):
+        super().__init__(path, name, ApplicationTypes.CUBE)
+        self.cube_name = cube_name
+
+    @property
+    def body(self) -> str:
+        body_as_dict = self.body_as_dict
+        body_as_dict["Cube@odata.bind"] = format_url("Cubes('{}')", self.cube_name)
+        return json.dumps(body_as_dict, ensure_ascii=False)
+
+
+class DimensionApplication(Application):
+    def __init__(self, path: str, name: str, dimension_name: str):
+        super().__init__(path, name, ApplicationTypes.DIMENSION)
+        self.dimension_name = dimension_name
+
+    @property
+    def body(self) -> str:
+        body_as_dict = self.body_as_dict
+        body_as_dict["Dimension@odata.bind"] = format("Dimensions('{}')", self.dimension_name)
+        return json.dumps(body_as_dict, ensure_ascii=False)
+
+
+class DocumentApplication(Application):
+    def __init__(self, path: str, name: str, content: bytes):
+        super().__init__(path, name, ApplicationTypes.DOCUMENT)
+        self.content = content
+
+    def to_xlsx(self, path_to_file: str):
+        with open(path_to_file, "wb") as file:
+            file.write(self.content)
+
+
+class FolderApplication(Application):
+    def __init__(self, path: str, name: str):
+        super().__init__(path, name, ApplicationTypes.FOLDER)
+
+
+class LinkApplication(Application):
+    def __init__(self, path: str, name: str, url: str):
+        super().__init__(path, name, ApplicationTypes.LINK)
+        self.url = url
+
+    @property
+    def body(self) -> str:
+        body_as_dict = self.body_as_dict
+        body_as_dict["URL"] = self.url
+        return json.dumps(body_as_dict, ensure_ascii=False)
+
+
+class ProcessApplication(Application):
+    def __init__(self, path: str, name: str, process_name: str):
+        super().__init__(path, name, ApplicationTypes.PROCESS)
+        self.process_name = process_name
+
+    @property
+    def body(self) -> str:
+        body_as_dict = self.body_as_dict
+        body_as_dict["Process@odata.bind"] = format_url("Processes('{}')", self.process_name)
+        return json.dumps(body_as_dict, ensure_ascii=False)
+
+
+class SubsetApplication(Application):
+    def __init__(self, path: str, name: str, dimension_name: str, hierarchy_name: str, subset_name: str):
+        super().__init__(path, name, ApplicationTypes.SUBSET)
+        self.dimension_name = dimension_name
+        self.hierarchy_name = hierarchy_name
+        self.subset_name = subset_name
+
+    @property
+    def body(self) -> str:
+        body_as_dict = self.body_as_dict
+        body_as_dict["Subset@odata.bind"] = format_url(
+            "Dimensions('{}')/Hierarchies('{}')/Subsets('{}')",
+            self.dimension_name, self.hierarchy_name, self.subset_name)
+        return json.dumps(body_as_dict, ensure_ascii=False)
+
+
+class ViewApplication(Application):
+    def __init__(self, path: str, name: str, cube_name: str, view_name: str):
+        super().__init__(path, name, ApplicationTypes.VIEW)
+        self.cube_name = cube_name
+        self.view_name = view_name
+
+    @property
+    def body(self) -> str:
+        body_as_dict = self.body_as_dict
+        body_as_dict["View@odata.bind"] = format_url("Cubes('{}')/Views('{}')", self.cube_name, self.view_name)
+        return json.dumps(body_as_dict, ensure_ascii=False)

--- a/TM1py/Objects/Application.py
+++ b/TM1py/Objects/Application.py
@@ -97,7 +97,7 @@ class DimensionApplication(Application):
     @property
     def body(self) -> str:
         body_as_dict = self.body_as_dict
-        body_as_dict["Dimension@odata.bind"] = format("Dimensions('{}')", self.dimension_name)
+        body_as_dict["Dimension@odata.bind"] = format_url("Dimensions('{}')", self.dimension_name)
         return json.dumps(body_as_dict, ensure_ascii=False)
 
 

--- a/TM1py/Objects/Axis.py
+++ b/TM1py/Objects/Axis.py
@@ -2,9 +2,11 @@
 
 import collections
 import json
+from typing import Dict, Union
 
 from TM1py.Objects.Subset import Subset, AnonymousSubset
 from TM1py.Objects.TM1Object import TM1Object
+from TM1py.Utils import format_url
 
 
 class ViewAxisSelection(TM1Object):
@@ -12,7 +14,7 @@ class ViewAxisSelection(TM1Object):
 
     """
 
-    def __init__(self, dimension_name, subset):
+    def __init__(self, dimension_name: str, subset: Union[Subset, AnonymousSubset]):
         """
             :Parameters:
                 `dimension_name` : String
@@ -23,26 +25,26 @@ class ViewAxisSelection(TM1Object):
         self._hierarchy_name = dimension_name
 
     @property
-    def subset(self):
+    def subset(self) -> Union[Subset, AnonymousSubset]:
         return self._subset
 
     @property
-    def dimension_name(self):
+    def dimension_name(self) -> str:
         return self._dimension_name
 
     @property
-    def hierarchy_name(self):
+    def hierarchy_name(self) -> str:
         return self._hierarchy_name
 
     @property
-    def body(self):
+    def body(self) -> str:
         return json.dumps(self._construct_body(), ensure_ascii=False)
 
     @property
-    def body_as_dict(self):
+    def body_as_dict(self) -> Dict:
         return self._construct_body()
 
-    def _construct_body(self):
+    def _construct_body(self) -> Dict:
         """ construct the ODATA conform JSON represenation for the ViewAxisSelection entity.
 
         :return: dictionary
@@ -51,9 +53,10 @@ class ViewAxisSelection(TM1Object):
         if isinstance(self._subset, AnonymousSubset):
             body_as_dict['Subset'] = json.loads(self._subset.body)
         elif isinstance(self._subset, Subset):
-            path = 'Dimensions(\'{}\')/Hierarchies(\'{}\')/Subsets(\'{}\')'.format(
+            subset_path = format_url(
+                "Dimensions('{}')/Hierarchies('{}')/Subsets('{}')",
                 self._dimension_name, self._hierarchy_name, self._subset.name)
-            body_as_dict['Subset@odata.bind'] = path
+            body_as_dict['Subset@odata.bind'] = subset_path
         return body_as_dict
 
 
@@ -63,33 +66,33 @@ class ViewTitleSelection:
 
     """
 
-    def __init__(self, dimension_name, subset, selected):
+    def __init__(self, dimension_name: str, subset: Union[AnonymousSubset, Subset], selected: str):
         self._dimension_name = dimension_name
         self._hierarchy_name = dimension_name
         self._subset = subset
         self._selected = selected
 
     @property
-    def subset(self):
+    def subset(self) -> Union[Subset, AnonymousSubset]:
         return self._subset
 
     @property
-    def dimension_name(self):
+    def dimension_name(self) -> str:
         return self._dimension_name
 
     @property
-    def hierarchy_name(self):
+    def hierarchy_name(self) -> str:
         return self._hierarchy_name
 
     @property
-    def selected(self):
+    def selected(self) -> str:
         return self._selected
 
     @property
-    def body(self):
+    def body(self) -> str:
         return json.dumps(self._construct_body(), ensure_ascii=False)
 
-    def _construct_body(self):
+    def _construct_body(self) -> Dict:
         """ construct the ODATA conform JSON represenation for the ViewTitleSelection entity.
 
         :return: string, the valid JSON
@@ -98,10 +101,12 @@ class ViewTitleSelection:
         if isinstance(self._subset, AnonymousSubset):
             body_as_dict['Subset'] = json.loads(self._subset.body)
         elif isinstance(self._subset, Subset):
-            path = "Dimensions('{}')/Hierarchies('{}')/Subsets('{}')".format(
+            subset_path = format_url(
+                "Dimensions('{}')/Hierarchies('{}')/Subsets('{}')",
                 self._dimension_name, self._hierarchy_name, self._subset.name)
-            body_as_dict['Subset@odata.bind'] = path
-        selected = "Dimensions('{}')/Hierarchies('{}')/Elements('{}')".format(
+            body_as_dict['Subset@odata.bind'] = subset_path
+        element_path = format_url(
+            "Dimensions('{}')/Hierarchies('{}')/Elements('{}')",
             self._dimension_name, self._hierarchy_name, self._selected)
-        body_as_dict['Selected@odata.bind'] = selected
+        body_as_dict['Selected@odata.bind'] = element_path
         return body_as_dict

--- a/TM1py/Objects/Chore.py
+++ b/TM1py/Objects/Chore.py
@@ -2,6 +2,7 @@
 
 import collections
 import json
+from typing import Dict, List, Iterable
 
 from TM1py.Objects.ChoreFrequency import ChoreFrequency
 from TM1py.Objects.ChoreStartTime import ChoreStartTime
@@ -16,17 +17,18 @@ class Chore(TM1Object):
     SINGLE_COMMIT = 'SingleCommit'
     MULTIPLE_COMMIT = 'MultipleCommit'
 
-    def __init__(self, name, start_time, dst_sensitivity, active, execution_mode, frequency, tasks):
+    def __init__(self, name: str, start_time: ChoreStartTime, dst_sensitivity: bool, active: bool,
+                 execution_mode: str, frequency: ChoreFrequency, tasks: Iterable[ChoreTask]):
         self._name = name
         self._start_time = start_time
         self._dst_sensitivity = dst_sensitivity
         self._active = active
         self._execution_mode = execution_mode
         self._frequency = frequency
-        self._tasks = tasks
+        self._tasks = list(tasks)
 
     @classmethod
-    def from_json(cls, chore_as_json):
+    def from_json(cls, chore_as_json: str) -> 'Chore':
         """ Alternative constructor
 
         :param chore_as_json: string, JSON. Response of /api/v1/Chores('x')/Tasks?$expand=*
@@ -36,7 +38,7 @@ class Chore(TM1Object):
         return cls.from_dict(chore_as_dict)
 
     @classmethod
-    def from_dict(cls, chore_as_dict):
+    def from_dict(cls, chore_as_dict: Dict) -> 'Chore':
         """ Alternative constructor
 
         :param chore_as_dict: Chore as dict
@@ -51,35 +53,35 @@ class Chore(TM1Object):
                    tasks=[ChoreTask.from_dict(task) for task in chore_as_dict['Tasks']])
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._name
 
     @name.setter
-    def name(self, name):
+    def name(self, name: str):
         self._name = name
 
     @property
-    def start_time(self):
+    def start_time(self) -> ChoreStartTime:
         return self._start_time
 
     @start_time.setter
-    def start_time(self, start_time):
+    def start_time(self, start_time: ChoreStartTime):
         self._start_time = start_time
 
     @property
-    def dst_sensitivity(self):
+    def dst_sensitivity(self) -> bool:
         return self._dst_sensitivity
 
     @dst_sensitivity.setter
-    def dst_sensitivity(self, dst_sensitivity):
+    def dst_sensitivity(self, dst_sensitivity: bool):
         self._dst_sensitivity = dst_sensitivity
 
     @property
-    def active(self):
+    def active(self) -> bool:
         return self._active
 
     @property
-    def execution_mode(self):
+    def execution_mode(self) -> str:
         return self._execution_mode
 
     @execution_mode.setter
@@ -87,30 +89,30 @@ class Chore(TM1Object):
         self._execution_mode = execution_mode
 
     @property
-    def frequency(self):
+    def frequency(self) -> ChoreFrequency:
         return self._frequency
 
     @frequency.setter
-    def frequency(self, frequency):
+    def frequency(self, frequency: ChoreFrequency):
         self._frequency = frequency
 
     @property
-    def tasks(self):
+    def tasks(self) -> List[ChoreTask]:
         return self._tasks
 
     @tasks.setter
-    def tasks(self, tasks):
+    def tasks(self, tasks: List[ChoreTask]):
         self._tasks = tasks
 
     @property
-    def body(self):
+    def body(self) -> str:
         return self.construct_body()
 
     @property
-    def body_as_dict(self):
+    def body_as_dict(self) -> Dict:
         return json.loads(self.body)
 
-    def add_task(self, task):
+    def add_task(self, task: ChoreTask):
         self._tasks.append(task)
 
     def activate(self):
@@ -119,10 +121,10 @@ class Chore(TM1Object):
     def deactivate(self):
         self._active = False
 
-    def reschedule(self, days=0, hours=0, minutes=0, seconds=0):
+    def reschedule(self, days: int = 0, hours: int = 0, minutes: int = 0, seconds: int = 0):
         self._start_time.add(days=days, hours=hours, minutes=minutes, seconds=seconds)
 
-    def construct_body(self):
+    def construct_body(self) -> str:
         """
         construct self.body (json) from the class attributes
         :return: String, TM1 JSON representation of a chore

--- a/TM1py/Objects/ChoreFrequency.py
+++ b/TM1py/Objects/ChoreFrequency.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from typing import Union
 
 from TM1py.Objects.TM1Object import TM1Object
 
@@ -7,58 +8,60 @@ class ChoreFrequency(TM1Object):
     """ Utility class to handle time representation fore Chore Frequency
     
     """
-    def __init__(self, days, hours, minutes, seconds):
+
+    def __init__(self, days: Union[str, int], hours: Union[str, int], minutes: Union[str, int],
+                 seconds: Union[str, int]):
         self._days = str(days).zfill(2)
         self._hours = str(hours).zfill(2)
         self._minutes = str(minutes).zfill(2)
         self._seconds = str(seconds).zfill(2)
 
     @property
-    def days(self):
+    def days(self) -> str:
         return self._days
 
     @property
-    def hours(self):
+    def hours(self) -> str:
         return self._hours
 
     @property
-    def minutes(self):
+    def minutes(self) -> str:
         return self._minutes
 
     @property
-    def seconds(self):
+    def seconds(self) -> str:
         return self._seconds
 
     @days.setter
-    def days(self, value):
+    def days(self, value: Union[str, int]):
         self._days = str(value).zfill(2)
 
     @hours.setter
-    def hours(self, value):
+    def hours(self, value: Union[str, int]):
         self._hours = str(value).zfill(2)
 
     @minutes.setter
-    def minutes(self, value):
+    def minutes(self, value: Union[str, int]):
         self._minutes = str(value).zfill(2)
 
     @seconds.setter
-    def seconds(self, value):
+    def seconds(self, value: Union[str, int]):
         self._seconds = str(value).zfill(2)
 
     @classmethod
-    def from_string(cls, frequency_string):
+    def from_string(cls, frequency_string: str) -> 'ChoreFrequency':
         pos_dt = frequency_string.find('DT', 1)
         pos_h = frequency_string.find('H', pos_dt)
         pos_m = frequency_string.find('M', pos_h)
-        pos_s = len(frequency_string)-1
+        pos_s = len(frequency_string) - 1
         return cls(days=frequency_string[1:pos_dt],
-                   hours=frequency_string[pos_dt+2:pos_h],
-                   minutes=frequency_string[pos_h+1:pos_m],
-                   seconds=frequency_string[pos_m+1:pos_s])
+                   hours=frequency_string[pos_dt + 2:pos_h],
+                   minutes=frequency_string[pos_h + 1:pos_m],
+                   seconds=frequency_string[pos_m + 1:pos_s])
 
     @property
-    def frequency_string(self):
+    def frequency_string(self) -> str:
         return "P{}DT{}H{}M{}S".format(self._days, self._hours, self._minutes, self._seconds)
 
-    def __str__(self):
-        return "P{}DT{}H{}M{}S".format(self._days, self._hours, self._minutes, self._seconds)
+    def __str__(self) -> str:
+        return self.frequency_string

--- a/TM1py/Objects/ChoreStartTime.py
+++ b/TM1py/Objects/ChoreStartTime.py
@@ -9,7 +9,8 @@ class ChoreStartTime(TM1Object):
     """ Utility class to handle time representation for Chore Start Time
         
     """
-    def __init__(self, year, month, day, hour, minute, second):
+
+    def __init__(self, year: int, month: int, day: int, hour: int, minute: int, second: int):
         """
         
         :param year: year 
@@ -22,7 +23,7 @@ class ChoreStartTime(TM1Object):
         self._datetime = datetime.datetime.combine(datetime.date(year, month, day), datetime.time(hour, minute, second))
 
     @classmethod
-    def from_string(cls, start_time_string):
+    def from_string(cls, start_time_string: str) -> 'ChoreStartTime':
         # f to handle strange timestamp 2016-09-25T20:25Z instead of common 2016-09-25T20:25:01Z
         f = lambda x: int(x) if x else 0
         return cls(year=f(start_time_string[0:4]),
@@ -33,13 +34,14 @@ class ChoreStartTime(TM1Object):
                    second=f(start_time_string[17:19]))
 
     @property
-    def start_time_string(self):
+    def start_time_string(self) -> str:
         return self._datetime.strftime("%Y-%m-%dT%H:%M:%SZ")
 
     def __str__(self):
-        return self._datetime.strftime("%Y-%m-%dT%H:%M:%SZ")
+        return self.start_time_string
 
-    def set_time(self, year=None, month=None, day=None, hour=None, minute=None, second=None):
+    def set_time(self, year: int = None, month: int = None, day: int = None, hour: int = None, minute: int = None,
+                 second: int = None):
         if year:
             self._datetime = self._datetime.replace(year=year)
         if month:
@@ -53,8 +55,8 @@ class ChoreStartTime(TM1Object):
         if second:
             self._datetime = self._datetime.replace(second=second)
 
-    def add(self, days=0, hours=0, minutes=0, seconds=0):
+    def add(self, days: int = 0, hours: int = 0, minutes: int = 0, seconds: int = 0):
         self._datetime = self._datetime + datetime.timedelta(days=days, hours=hours, minutes=minutes, seconds=seconds)
 
-    def substract(self, days=0, hours=0, minutes=0, seconds=0):
+    def subtract(self, days: int = 0, hours: int = 0, minutes: int = 0, seconds: int = 0):
         self._datetime = self._datetime - datetime.timedelta(days=days, hours=hours, minutes=minutes, seconds=seconds)

--- a/TM1py/Objects/ChoreTask.py
+++ b/TM1py/Objects/ChoreTask.py
@@ -2,8 +2,10 @@
 
 import collections
 import json
+from typing import Dict, List
 
 from TM1py.Objects.TM1Object import TM1Object
+from TM1py.Utils import format_url
 
 
 class ChoreTask(TM1Object):
@@ -16,7 +18,8 @@ class ChoreTask(TM1Object):
         - The parameters for the process
     
     """
-    def __init__(self, step, process_name, parameters):
+
+    def __init__(self, step: int, process_name: str, parameters: List[Dict[str, str]]):
         """
         
         :param step: step in the execution order of the Chores' processes. 1 to n, where n the number of processes
@@ -34,36 +37,36 @@ class ChoreTask(TM1Object):
         self._parameters = parameters
 
     @classmethod
-    def from_dict(cls, chore_task_as_dict):
+    def from_dict(cls, chore_task_as_dict: Dict):
         return cls(step=int(chore_task_as_dict['Step']),
                    process_name=chore_task_as_dict['Process']['Name'],
-                   parameters=[{'Name': p['Name'], 'Value':p['Value']} for p in chore_task_as_dict['Parameters']])
+                   parameters=[{'Name': p['Name'], 'Value': p['Value']} for p in chore_task_as_dict['Parameters']])
 
     @property
-    def body_as_dict(self):
+    def body_as_dict(self) -> Dict:
         body_as_dict = collections.OrderedDict()
-        body_as_dict['Process@odata.bind'] = 'Processes(\'{}\')'.format(self._process_name)
+        body_as_dict['Process@odata.bind'] = format_url("Processes('{}')", self._process_name)
         body_as_dict['Parameters'] = self._parameters
         return body_as_dict
 
     @property
-    def step(self):
+    def step(self) -> int:
         return self._step
 
     @property
-    def process_name(self):
+    def process_name(self) -> str:
         return self._process_name
 
     @property
-    def parameters(self):
+    def parameters(self) -> List[Dict[str, str]]:
         return self._parameters
 
     @property
-    def body(self):
+    def body(self) -> str:
         return json.dumps(self.body_as_dict, ensure_ascii=False)
 
-    def __eq__(self, other):
+    def __eq__(self, other: 'ChoreTask') -> bool:
         return self.process_name == other.process_name and self.parameters == other.parameters
 
-    def __ne__(self, other):
+    def __ne__(self, other: 'ChoreTask') -> bool:
         return self.process_name != other.process_name or self._parameters != other.parameters

--- a/TM1py/Objects/Cube.py
+++ b/TM1py/Objects/Cube.py
@@ -2,16 +2,19 @@
 
 import collections
 import json
+from typing import Iterable, List, Dict, Optional
 
 from TM1py.Objects.Rules import Rules
 from TM1py.Objects.TM1Object import TM1Object
+from TM1py.Utils import format_url
 
 
 class Cube(TM1Object):
     """ Abstraction of a TM1 Cube
         
     """
-    def __init__(self, name, dimensions, rules=None):
+
+    def __init__(self, name: str, dimensions: Iterable[str], rules: Optional[Rules] = None):
         """
         
         :param name: name of the Cube
@@ -19,55 +22,55 @@ class Cube(TM1Object):
         :param rules: instance of TM1py.Objects.Rules
         """
         self._name = name
-        self.dimensions = dimensions
+        self.dimensions = list(dimensions)
         self.rules = rules
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._name
 
     @property
-    def dimensions(self):
+    def dimensions(self) -> List[str]:
         return self._dimensions
 
     @dimensions.setter
-    def dimensions(self, value):
+    def dimensions(self, value: List[str]):
         self._dimensions = value
 
     @property
-    def has_rules(self):
+    def has_rules(self) -> bool:
         if self._rules:
             return True
         return False
 
     @property
-    def rules(self):
+    def rules(self) -> Rules:
         return self._rules
 
     @rules.setter
-    def rules(self, value):
+    def rules(self, value: Rules):
         self._rules = value
 
     @property
-    def skipcheck(self):
+    def skipcheck(self) -> bool:
         if self.has_rules:
             return self.rules.skipcheck
         return False
 
     @property
-    def undefvals(self):
+    def undefvals(self) -> bool:
         if self.has_rules:
             return self.rules.undefvals
         return False
 
     @property
-    def feedstrings(self):
+    def feedstrings(self) -> bool:
         if self.has_rules:
             return self.rules.feedstrings
         return False
 
     @classmethod
-    def from_json(cls, cube_as_json):
+    def from_json(cls, cube_as_json: str) -> 'Cube':
         """ Alternative constructor
 
         :param cube_as_json: user as JSON string
@@ -77,30 +80,31 @@ class Cube(TM1Object):
         return cls.from_dict(cube_as_dict)
 
     @classmethod
-    def from_dict(cls, cube_as_dict):
+    def from_dict(cls, cube_as_dict: Dict) -> 'Cube':
         """ Alternative constructor
 
         :param cube_as_dict: user as dict
         :return: user, an instance of this class
         """
-        return cls(name=cube_as_dict['Name'],
-                   dimensions=[dimension['Name'] for dimension in cube_as_dict['Dimensions']],
-                   rules=Rules(cube_as_dict['Rules']) if cube_as_dict['Rules'] else None)
+        return cls(
+            name=cube_as_dict['Name'],
+            dimensions=[dimension['Name'] for dimension in cube_as_dict['Dimensions']],
+            rules=Rules(cube_as_dict['Rules']) if cube_as_dict['Rules'] else None)
 
     @property
-    def body(self):
+    def body(self) -> str:
         return self._construct_body()
 
-    def _construct_body(self):
+    def _construct_body(self) -> str:
         """
         construct body (json) from the class attributes
         :return: String, TM1 JSON representation of a cube
         """
         body_as_dict = collections.OrderedDict()
         body_as_dict['Name'] = self.name
-        body_as_dict['Dimensions@odata.bind'] = ['Dimensions(\'{}\')'.format(dimension)
+        body_as_dict['Dimensions@odata.bind'] = [format_url("Dimensions('{}')", dimension)
                                                  for dimension
                                                  in self.dimensions]
-        if self.rules:
+        if self.has_rules:
             body_as_dict['Rules'] = str(self.rules)
         return json.dumps(body_as_dict, ensure_ascii=False)

--- a/TM1py/Objects/Dimension.py
+++ b/TM1py/Objects/Dimension.py
@@ -2,6 +2,7 @@
 
 import collections
 import json
+from typing import Optional, Iterable, Dict, List
 
 from TM1py.Objects.Hierarchy import Hierarchy
 from TM1py.Objects.TM1Object import TM1Object
@@ -14,7 +15,7 @@ class Dimension(TM1Object):
         A Dimension is a container for hierarchies.
     """
 
-    def __init__(self, name, hierarchies=None):
+    def __init__(self, name: str, hierarchies: Optional[Iterable[Hierarchy]] = None):
         """ Abstraction of TM1 Dimension
         
          
@@ -26,39 +27,39 @@ class Dimension(TM1Object):
         self._attributes = {'Caption': name}
 
     @classmethod
-    def from_json(cls, dimension_as_json):
+    def from_json(cls, dimension_as_json: str) -> 'Dimension':
         dimension_as_dict = json.loads(dimension_as_json)
         return cls.from_dict(dimension_as_dict)
 
     @classmethod
-    def from_dict(cls, dimension_as_dict):
+    def from_dict(cls, dimension_as_dict: Dict) -> 'Dimension':
         return cls(name=dimension_as_dict['Name'],
                    hierarchies=[Hierarchy.from_dict(hierarchy)
                                 for hierarchy
                                 in dimension_as_dict['Hierarchies']])
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._name
 
     @property
-    def unique_name(self):
+    def unique_name(self) -> str:
         return '[' + self._name + ']'
 
     @property
-    def hierarchies(self):
+    def hierarchies(self) -> List[Hierarchy]:
         return self._hierarchies
 
     @property
-    def hierarchy_names(self):
+    def hierarchy_names(self) -> List[str]:
         return [hierarchy.name for hierarchy in self._hierarchies]
 
     @property
-    def default_hierarchy(self):
+    def default_hierarchy(self) -> Hierarchy:
         return self._hierarchies[0]
 
     @name.setter
-    def name(self, value):
+    def name(self, value: str):
         for hierarchy in self.hierarchies:
             hierarchy._dimension_name = value
             if hierarchy.name == self._name:
@@ -66,11 +67,11 @@ class Dimension(TM1Object):
         self._name = value
 
     @property
-    def body(self):
+    def body(self) -> str:
         return json.dumps(self._construct_body())
 
     @property
-    def body_as_dict(self):
+    def body_as_dict(self) -> Dict:
         return self._construct_body()
 
     def __iter__(self):
@@ -85,32 +86,33 @@ class Dimension(TM1Object):
     def __getitem__(self, item):
         return self.get_hierarchy(item)
 
-    def contains_hierarchy(self, hierarchy_name):
+    def contains_hierarchy(self, hierarchy_name: str) -> bool:
         for hierarchy in self._hierarchies:
             if case_and_space_insensitive_equals(hierarchy.name, hierarchy_name):
                 return True
         return False
 
-    def get_hierarchy(self, hierarchy_name):
+    def get_hierarchy(self, hierarchy_name: str) -> Hierarchy:
         for hierarchy in self._hierarchies:
             if case_and_space_insensitive_equals(hierarchy.name, hierarchy_name):
                 return hierarchy
         raise ValueError("Hierarchy: {} not found in dimension: {}".format(hierarchy_name, self.name))
 
-    def add_hierarchy(self, hierarchy):
+    def add_hierarchy(self, hierarchy: Hierarchy):
         if self.contains_hierarchy(hierarchy.name):
             raise ValueError("Hierarchy: {} already exists in dimension: {}".format(hierarchy.name, self.name))
         self._hierarchies.append(hierarchy)
 
-    def remove_hierarchy(self, hierarchy_name):
+    def remove_hierarchy(self, hierarchy_name: str):
         if case_and_space_insensitive_equals(hierarchy_name, "leaves"):
-            raise ValueError("Leaves hierarchy can't be removed from dimension")
+            raise ValueError("'Leaves' hierarchy must not be removed from dimension")
+
         for num, hierarchy in enumerate(self._hierarchies):
             if case_and_space_insensitive_equals(hierarchy.name, hierarchy_name):
                 del self._hierarchies[num]
                 return
 
-    def _construct_body(self, include_leaves_hierarchy=False):
+    def _construct_body(self, include_leaves_hierarchy=False) -> Dict:
         body_as_dict = collections.OrderedDict()
         body_as_dict["Name"] = self._name
         body_as_dict["UniqueName"] = self.unique_name

--- a/TM1py/Objects/Element.py
+++ b/TM1py/Objects/Element.py
@@ -3,6 +3,7 @@
 import collections
 import json
 from enum import Enum
+from typing import Union, Iterable, Dict, List
 
 from TM1py.Objects.TM1Object import TM1Object
 
@@ -22,14 +23,15 @@ class Element(TM1Object):
             return self.name.capitalize()
 
         @classmethod
-        def _missing_(cls, value):
+        def _missing_(cls, value: str):
             for member in cls:
                 if member.name.lower() == value.replace(" ", "").lower():
                     return member
             # default
             raise ValueError("Invalid element type=" + value)
 
-    def __init__(self, name, element_type, attributes=None, unique_name=None, index=None):
+    def __init__(self, name, element_type: Union[Types, str], attributes: List[str] = None, unique_name: str = None,
+                 index: int = None):
         self._name = name
         self._unique_name = unique_name
         self._index = index
@@ -38,7 +40,7 @@ class Element(TM1Object):
         self._attributes = attributes
 
     @staticmethod
-    def from_dict(element_as_dict):
+    def from_dict(element_as_dict: Dict) -> 'Element':
         return Element(name=element_as_dict['Name'],
                        unique_name=element_as_dict['UniqueName'],
                        index=element_as_dict['Index'],
@@ -46,42 +48,42 @@ class Element(TM1Object):
                        attributes=element_as_dict['Attributes'])
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._name
 
     @name.setter
-    def name(self, value):
+    def name(self, value: str):
         self._name = value
 
     @property
-    def unique_name(self):
+    def unique_name(self) -> str:
         return self._unique_name
 
     @property
-    def index(self):
+    def index(self) -> int:
         return self._index
 
     @property
-    def element_attributes(self):
+    def element_attributes(self) -> List[str]:
         return self._attributes
 
     @property
-    def element_type(self):
+    def element_type(self) -> Types:
         return self._element_type
 
     @element_type.setter
-    def element_type(self, value):
+    def element_type(self, value: Union[Types, str]):
         self._element_type = Element.Types(value)
 
     @property
-    def body(self):
+    def body(self) -> str:
         return json.dumps(self._construct_body())
 
     @property
-    def body_as_dict(self):
+    def body_as_dict(self) -> Dict:
         return self._construct_body()
 
-    def _construct_body(self):
+    def _construct_body(self) -> Dict:
         body_as_dict = collections.OrderedDict()
         body_as_dict['Name'] = self._name
         body_as_dict['Type'] = str(self._element_type)

--- a/TM1py/Objects/ElementAttribute.py
+++ b/TM1py/Objects/ElementAttribute.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 
 import json
+from typing import Dict, Union
 
 from TM1py.Objects.TM1Object import TM1Object
+from TM1py.Utils import case_and_space_insensitive_equals
 
 
 class ElementAttribute(TM1Object):
@@ -11,45 +13,50 @@ class ElementAttribute(TM1Object):
     """
     valid_types = ['NUMERIC', 'STRING', 'ALIAS']
 
-    def __init__(self, name, attribute_type):
+    def __init__(self, name: str, attribute_type: str):
         self.name = name
         self.attribute_type = attribute_type
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._name
 
     @name.setter
-    def name(self, value):
+    def name(self, value: str):
         self._name = value
 
     @property
-    def attribute_type(self):
+    def attribute_type(self) -> str:
         return self._attribute_type
 
     @attribute_type.setter
-    def attribute_type(self, value):
-        if value.upper() in ElementAttribute.valid_types:
-            self._attribute_type = value
-        else:
-            raise Exception('{} not a valid Attribute Type.'.format(value))
+    def attribute_type(self, value: str):
+        if not value.upper() in ElementAttribute.valid_types:
+            raise ValueError("'{}' is not a valid Attribute Type".format(value))
+
+        self._attribute_type = value.capitalize()
 
     @property
-    def body_as_dict(self):
+    def body_as_dict(self) -> Dict:
         return {"Name": self._name, "Type": self._attribute_type}
 
     @property
-    def body(self):
+    def body(self) -> str:
         return json.dumps(self.body_as_dict, ensure_ascii=False)
 
     @classmethod
-    def from_json(cls, element_attribute_as_json):
+    def from_json(cls, element_attribute_as_json: str) -> 'ElementAttribute':
         return cls.from_dict(json.loads(element_attribute_as_json))
 
     @classmethod
-    def from_dict(cls, element_attribute_as_dict):
+    def from_dict(cls, element_attribute_as_dict: Dict) -> 'ElementAttribute':
         return cls(name=element_attribute_as_dict['Name'],
                    attribute_type=element_attribute_as_dict['Type'])
 
-    def __eq__(self, other):
-        return self.name == other
+    def __eq__(self, other: Union[str, 'ElementAttribute']):
+        if isinstance(other, str):
+            return case_and_space_insensitive_equals(self.name, other)
+        elif isinstance(other, ElementAttribute):
+            return case_and_space_insensitive_equals(self.name, other.name)
+        else:
+            raise ValueError("Argument: 'other' must be of type str or ElementAttribute")

--- a/TM1py/Objects/Hierarchy.py
+++ b/TM1py/Objects/Hierarchy.py
@@ -2,11 +2,13 @@
 
 import collections
 import json
+from typing import List, Dict, Iterable, Optional, Tuple, Union
 
 from TM1py.Objects.Element import Element
 from TM1py.Objects.ElementAttribute import ElementAttribute
 from TM1py.Objects.TM1Object import TM1Object
-from TM1py.Utils.Utils import CaseAndSpaceInsensitiveDict, CaseAndSpaceInsensitiveTuplesDict, lower_and_drop_spaces
+from TM1py.Utils.Utils import CaseAndSpaceInsensitiveDict, CaseAndSpaceInsensitiveTuplesDict, lower_and_drop_spaces, \
+    case_and_space_insensitive_equals
 
 
 class Hierarchy(TM1Object):
@@ -32,125 +34,138 @@ class Hierarchy(TM1Object):
 
     """
 
-    def __init__(self, name, dimension_name, elements=None, element_attributes=None,
-                 edges=None, subsets=None, structure=None, default_member=None):
+    def __init__(
+            self,
+            name: str,
+            dimension_name: str,
+            elements: Optional[Iterable['Element']] = None,
+            element_attributes: Optional[Iterable['ElementAttribute']] = None,
+            edges: Optional['CaseAndSpaceInsensitiveTuplesDict'] = None,
+            subsets: Optional[Iterable[str]] = None,
+            structure: Optional[int] = None,
+            default_member: Optional[str] = None):
+
         self._name = name
-        self._dimension_name = dimension_name
+        self._dimension_name = None
+        self.dimension_name = dimension_name
         self._elements = CaseAndSpaceInsensitiveDict()
         if elements:
             for elem in elements:
                 self._elements[elem.name] = elem
-        self._element_attributes = element_attributes if element_attributes else []
+        self._element_attributes = list(element_attributes) if element_attributes else []
         self._edges = CaseAndSpaceInsensitiveTuplesDict(edges) if edges else CaseAndSpaceInsensitiveTuplesDict()
-        self._subsets = subsets if subsets else []
+        self._subsets = list(subsets) if subsets else []
         # balanced is true, false or None (in versions < TM1 11)
-        self._balanced = structure if not structure else structure == 0
+        self._balanced = False if not structure else structure == 0
         self._default_member = default_member
 
     @classmethod
-    def from_dict(cls, hierarchy_as_dict):
+    def from_dict(cls, hierarchy_as_dict: Dict) -> 'Hierarchy':
         # Build the Dictionary for the edges
-        edges = CaseAndSpaceInsensitiveTuplesDict({(edge['ParentName'], edge['ComponentName']): edge['Weight']
-                                                   for edge
-                                                   in hierarchy_as_dict['Edges']})
-        return cls(name=hierarchy_as_dict['Name'],
-                   dimension_name=hierarchy_as_dict['UniqueName'][1:hierarchy_as_dict['UniqueName'].find("].[")],
-                   elements=[Element.from_dict(elem) for elem in hierarchy_as_dict['Elements']],
-                   element_attributes=[ElementAttribute(ea['Name'], ea['Type'])
-                                       for ea in hierarchy_as_dict['ElementAttributes']],
-                   edges=edges,
-                   subsets=[subset['Name'] for subset in hierarchy_as_dict['Subsets']],
-                   structure=hierarchy_as_dict['Structure'] if 'Structure' in hierarchy_as_dict else None,
-                   default_member=hierarchy_as_dict['DefaultMember']['Name']
-                   if hierarchy_as_dict['DefaultMember'] else None)
+        edges = CaseAndSpaceInsensitiveTuplesDict(
+            {(edge['ParentName'], edge['ComponentName']): edge['Weight']
+             for edge
+             in hierarchy_as_dict['Edges']})
+
+        return cls(
+            name=hierarchy_as_dict['Name'],
+            dimension_name=hierarchy_as_dict['UniqueName'][1:hierarchy_as_dict['UniqueName'].find("].[")],
+            elements=[Element.from_dict(elem) for elem in hierarchy_as_dict['Elements']],
+            element_attributes=[ElementAttribute(ea['Name'], ea['Type'])
+                                for ea in hierarchy_as_dict['ElementAttributes']],
+            edges=edges,
+            subsets=[subset['Name'] for subset in hierarchy_as_dict['Subsets']],
+            structure=hierarchy_as_dict['Structure'] if 'Structure' in hierarchy_as_dict else None,
+            default_member=hierarchy_as_dict['DefaultMember']['Name']
+            if hierarchy_as_dict['DefaultMember'] else None)
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._name
 
     @name.setter
-    def name(self, value):
+    def name(self, value: str):
         self._name = value
 
     @property
-    def dimension_name(self):
+    def dimension_name(self) -> str:
         return self._dimension_name
 
     @dimension_name.setter
-    def dimension_name(self, dimension_name):
+    def dimension_name(self, dimension_name: str):
         self._dimension_name = dimension_name
 
     @property
-    def elements(self):
+    def elements(self) -> CaseAndSpaceInsensitiveDict:
         return self._elements
 
     @property
-    def element_attributes(self):
+    def element_attributes(self) -> List[ElementAttribute]:
         return self._element_attributes
 
     @property
-    def edges(self):
+    def edges(self) -> 'CaseAndSpaceInsensitiveTuplesDict':
         return self._edges
 
     @property
-    def subsets(self):
+    def subsets(self) -> List[str]:
         return self._subsets
 
     @property
-    def balanced(self):
+    def balanced(self) -> bool:
         return self._balanced
 
     @property
-    def default_member(self):
+    def default_member(self) -> str:
         return self._default_member
 
     @property
-    def body(self):
+    def body(self) -> str:
         return json.dumps(self._construct_body())
 
     @property
-    def body_as_dict(self):
+    def body_as_dict(self) -> Dict:
         return self._construct_body()
 
-    def contains_element(self, element_name):
+    def contains_element(self, element_name: str) -> bool:
         return element_name in self._elements
 
-    def get_element(self, element_name):
+    def get_element(self, element_name: str) -> Element:
         if element_name in self._elements:
             return self._elements[element_name]
         else:
             raise ValueError("Element: {} not found in Hierarchy: {}".format(element_name, self.name))
 
-    def add_element(self, element_name, element_type):
+    def add_element(self, element_name: str, element_type: Union[str, Element.Types]):
         if element_name in self._elements:
-            raise Exception("Elementname must be unique")
-        e = Element(name=element_name, element_type=element_type)
-        self._elements[element_name] = e
+            raise ValueError("Element name must be unique")
 
-    def update_element(self, element_name, element_type=None):
+        self._elements[element_name] = Element(name=element_name, element_type=element_type)
+
+    def update_element(self, element_name: str, element_type: Union[str, Element.Types]):
         self._elements[element_name].element_type = element_type
 
-    def remove_element(self, element_name):
+    def remove_element(self, element_name: str):
         if element_name not in self._elements:
             return
         del self._elements[element_name]
         self.remove_edges_related_to_element(element_name=element_name)
 
-    def add_edge(self, parent, component, weight):
+    def add_edge(self, parent: str, component: str, weight: int):
         self._edges[(parent, component)] = weight
 
-    def update_edge(self, parent, component, weight):
+    def update_edge(self, parent: str, component: str, weight: int):
         self._edges[(parent, component)] = weight
 
-    def remove_edge(self, parent, component):
+    def remove_edge(self, parent: str, component: str):
         if (parent, component) in self.edges:
             del self.edges[(parent, component)]
 
-    def remove_edges(self, edges):
+    def remove_edges(self, edges: Iterable[Tuple[str, str]]):
         for edge in edges:
             self.remove_edge(*edge)
 
-    def remove_edges_related_to_element(self, element_name):
+    def remove_edges_related_to_element(self, element_name: str):
         element_name_adjusted = lower_and_drop_spaces(element_name)
         edges_to_remove = set()
         for edge in self._edges.adjusted_keys():
@@ -158,16 +173,19 @@ class Hierarchy(TM1Object):
                 edges_to_remove.add(edge)
         self.remove_edges(edges=edges_to_remove)
 
-    def add_element_attribute(self, name, attribute_type):
-        if name not in self.element_attributes:
-            self.element_attributes.append(ElementAttribute(name, attribute_type))
+    def add_element_attribute(self, name: str, attribute_type: str):
+        attribute = ElementAttribute(name, attribute_type)
+        if attribute not in self.element_attributes:
+            self.element_attributes.append(attribute)
 
-    def remove_element_attribute(self, name):
-        if name in self.element_attributes:
-            self.element_attributes.remove(name)
+    def remove_element_attribute(self, name: str):
+        self._element_attributes = [
+            element_attribute
+            for element_attribute
+            in self.element_attributes if not case_and_space_insensitive_equals(element_attribute.name, name)]
 
-    def _construct_body(self, element_attributes=False):
-        """ 
+    def _construct_body(self, element_attributes: Optional[bool] = False) -> Dict:
+        """
         With TM1 10.2.2 Hierarchy and Element Attributes can't be created in one batch
         -> https://www.ibm.com/developerworks/community/forums/html/threadTopic?id=d91f3e0e-d305-44db-ac02-2fdcbee00393
         Thus, no need to have the ElementAttribute included in the JSON

--- a/TM1py/Objects/MDXView.py
+++ b/TM1py/Objects/MDXView.py
@@ -2,6 +2,7 @@
 
 import collections
 import json
+from typing import Optional, Dict
 
 from TM1py.Objects.View import View
 
@@ -11,34 +12,35 @@ class MDXView(View):
 
         IMPORTANT. MDXViews can't be seen through the old TM1 clients (Archict, Perspectives). They do exist though!
     """
-    def __init__(self, cube_name, view_name, MDX):
+
+    def __init__(self, cube_name: str, view_name: str, MDX: str):
         View.__init__(self, cube_name, view_name)
         self._MDX = MDX
 
     @property
-    def MDX(self):
+    def MDX(self) -> str:
         return self._MDX
 
     @MDX.setter
-    def MDX(self, value):
+    def MDX(self, value: str):
         self._MDX = value
 
     @property
-    def body(self):
+    def body(self) -> str:
         return self.construct_body()
 
     @classmethod
-    def from_json(cls, view_as_json, cube_name=None):
+    def from_json(cls, view_as_json: str, cube_name: Optional[str] = None) -> 'MDXView':
         view_as_dict = json.loads(view_as_json)
         return cls.from_dict(view_as_dict, cube_name)
 
     @classmethod
-    def from_dict(cls, view_as_dict, cube_name=None):
+    def from_dict(cls, view_as_dict: Dict, cube_name: str = None) -> 'MDXView':
         return cls(cube_name=view_as_dict['Cube']['Name'] if not cube_name else cube_name,
                    view_name=view_as_dict['Name'],
                    MDX=view_as_dict['MDX'])
 
-    def construct_body(self):
+    def construct_body(self) -> str:
         mdx_view_as_dict = collections.OrderedDict()
         mdx_view_as_dict['@odata.type'] = 'ibm.tm1.api.v1.MDXView'
         mdx_view_as_dict['Name'] = self._name

--- a/TM1py/Objects/NativeView.py
+++ b/TM1py/Objects/NativeView.py
@@ -194,7 +194,7 @@ class NativeView(View):
         self._titles.append(view_title_selection)
 
     def remove_title(self, dimension_name: str):
-        """ Reemove dimension from the titles-axis
+        """ Remove dimension from the titles-axis
 
         :param dimension_name: name of the dimension.
         :return:

--- a/TM1py/Objects/NativeView.py
+++ b/TM1py/Objects/NativeView.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 
 import json
+from typing import Optional, Iterable, List, Union, Dict
 
 from TM1py.Objects.Axis import ViewAxisSelection, ViewTitleSelection
 from TM1py.Objects.Subset import Subset, AnonymousSubset
 from TM1py.Objects.View import View
+from TM1py.Utils import case_and_space_insensitive_equals
 
 
 class NativeView(View):
@@ -15,40 +17,40 @@ class NativeView(View):
     """
 
     def __init__(self,
-                 cube_name,
-                 view_name,
-                 suppress_empty_columns=False,
-                 suppress_empty_rows=False,
-                 format_string="0.#########",
-                 titles=None,
-                 columns=None,
-                 rows=None):
+                 cube_name: str,
+                 view_name: str,
+                 suppress_empty_columns: Optional[bool] = False,
+                 suppress_empty_rows: Optional[bool] = False,
+                 format_string: Optional[str] = "0.#########",
+                 titles: Optional[Iterable[ViewTitleSelection]] = None,
+                 columns: Optional[Iterable[ViewAxisSelection]] = None,
+                 rows: Optional[Iterable[ViewAxisSelection]] = None):
         super().__init__(cube_name, view_name)
         self._suppress_empty_columns = suppress_empty_columns
         self._suppress_empty_rows = suppress_empty_rows
         self._format_string = format_string
-        self._titles = titles if titles else []
-        self._columns = columns if columns else []
-        self._rows = rows if rows else []
+        self._titles = list(titles) if titles else []
+        self._columns = list(columns) if columns else []
+        self._rows = list(rows) if rows else []
 
     @property
-    def body(self):
+    def body(self) -> str:
         return self._construct_body()
 
     @property
-    def rows(self):
+    def rows(self) -> List[ViewAxisSelection]:
         return self._rows
 
     @property
-    def columns(self):
+    def columns(self) -> List[ViewAxisSelection]:
         return self._columns
 
     @property
-    def MDX(self):
+    def MDX(self) -> str:
         return self.as_MDX
 
     @property
-    def as_MDX(self):
+    def as_MDX(self) -> str:
         """ Build a valid MDX Query from an Existing cubeview. 
         Takes Zero suppression into account. 
         Throws an Exception when no elements are place on the columns.
@@ -108,59 +110,59 @@ class NativeView(View):
         return mdx
 
     @property
-    def suppress_empty_cells(self):
+    def suppress_empty_cells(self) -> bool:
         return self._suppress_empty_columns and self._suppress_empty_rows
 
     @property
-    def suppress_empty_columns(self):
+    def suppress_empty_columns(self) -> bool:
         return self._suppress_empty_columns
 
     @property
-    def suppress_empty_rows(self):
+    def suppress_empty_rows(self) -> bool:
         return self._suppress_empty_rows
 
     @property
-    def format_string(self):
+    def format_string(self) -> str:
         return self._format_string
 
     @suppress_empty_cells.setter
-    def suppress_empty_cells(self, value):
+    def suppress_empty_cells(self, value: bool):
         self.suppress_empty_columns = value
         self.suppress_empty_rows = value
 
     @suppress_empty_rows.setter
-    def suppress_empty_rows(self, value):
+    def suppress_empty_rows(self, value: bool):
         self._suppress_empty_rows = value
 
     @suppress_empty_columns.setter
-    def suppress_empty_columns(self, value):
+    def suppress_empty_columns(self, value: bool):
         self._suppress_empty_columns = value
 
     @format_string.setter
-    def format_string(self, value):
+    def format_string(self, value: str):
         self._format_string = value
 
-    def add_column(self, dimension_name, subset=None):
+    def add_column(self, dimension_name: str, subset: Union[Subset, AnonymousSubset] = None):
         """ Add Dimension or Subset to the column-axis
 
         :param dimension_name: name of the dimension
-        :param subset: instance of TM1py.Subset. Can be None instead.
+        :param subset: instance of TM1py.Subset. Can be None
         :return:
         """
         view_axis_selection = ViewAxisSelection(dimension_name=dimension_name, subset=subset)
         self._columns.append(view_axis_selection)
 
-    def remove_column(self, dimension_name):
+    def remove_column(self, dimension_name: str):
         """ remove dimension from the column axis
 
         :param dimension_name:
         :return:
         """
-        for column in self._columns:
-            if column.dimension_name == dimension_name:
+        for column in self._columns[:]:
+            if case_and_space_insensitive_equals(column.dimension_name, dimension_name):
                 self._columns.remove(column)
 
-    def add_row(self, dimension_name, subset=None):
+    def add_row(self, dimension_name: str, subset: Subset = None):
         """ Add Dimension or Subset to the row-axis
 
         :param dimension_name:
@@ -170,17 +172,17 @@ class NativeView(View):
         view_axis_selection = ViewAxisSelection(dimension_name=dimension_name, subset=subset)
         self._rows.append(view_axis_selection)
 
-    def remove_row(self, dimension_name):
+    def remove_row(self, dimension_name: str):
         """ remove dimension from the row axis
 
         :param dimension_name:
         :return:
         """
-        for row in self._rows:
-            if row.dimension_name == dimension_name:
+        for row in self._rows[:]:
+            if case_and_space_insensitive_equals(row.dimension_name, dimension_name):
                 self._rows.remove(row)
 
-    def add_title(self, dimension_name, selection, subset=None):
+    def add_title(self, dimension_name: str, selection: str, subset: Union[Subset, AnonymousSubset] = None):
         """ Add subset and element to the titles-axis
 
         :param dimension_name: name of the dimension.
@@ -191,18 +193,18 @@ class NativeView(View):
         view_title_selection = ViewTitleSelection(dimension_name, subset, selection)
         self._titles.append(view_title_selection)
 
-    def remove_title(self, dimension_name):
-        """ remove dimension from the titles-axis
+    def remove_title(self, dimension_name: str):
+        """ Reemove dimension from the titles-axis
 
         :param dimension_name: name of the dimension.
         :return:
         """
-        for title in self._titles:
-            if title.dimension_name == dimension_name:
+        for title in self._titles[:]:
+            if case_and_space_insensitive_equals(title.dimension_name, dimension_name):
                 self._titles.remove(title)
 
     @classmethod
-    def from_json(cls, view_as_json, cube_name=None):
+    def from_json(cls, view_as_json: str, cube_name: Optional[str] = None) -> 'NativeView':
         """ Alternative constructor
                 :Parameters:
                     `view_as_json` : string, JSON
@@ -214,7 +216,7 @@ class NativeView(View):
         return NativeView.from_dict(view_as_dict, cube_name)
 
     @classmethod
-    def from_dict(cls, view_as_dict, cube_name=None):
+    def from_dict(cls, view_as_dict: Dict, cube_name: str = None) -> 'NativeView':
         titles, columns, rows = [], [], []
 
         for selection in view_as_dict['Titles']:
@@ -246,8 +248,8 @@ class NativeView(View):
             columns=columns,
             rows=rows)
 
-    def _construct_body(self):
-        """ construct the ODATA conform JSON represenation for the NativeView entity.
+    def _construct_body(self) -> str:
+        """ construct the ODATA conform JSON representation for the NativeView entity.
 
         :return: string, the valid JSON
         """

--- a/TM1py/Objects/Process.py
+++ b/TM1py/Objects/Process.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 
-import re
 import json
+import re
+from typing import Optional, Iterable, Dict, List, Union
+
 from TM1py.Objects.TM1Object import TM1Object
 
 
@@ -12,44 +14,44 @@ class Process(TM1Object):
     """
 
     """ the auto_generated_string code is required to be in all code-tabs. """
-    begin_generated_statements = "#****Begin: Generated Statements***"
-    end_generated_statements = "#****End: Generated Statements****"
-    auto_generated_string = "{}\r\n{}\r\n".format(begin_generated_statements, end_generated_statements)
+    BEGIN_GENERATED_STATEMENTS = "#****Begin: Generated Statements***"
+    END_GENERATED_STATEMENTS = "#****End: Generated Statements****"
+    AUTO_GENERATED_STATEMENTS = "{}\r\n{}\r\n".format(BEGIN_GENERATED_STATEMENTS, END_GENERATED_STATEMENTS)
 
     @staticmethod
-    def add_generated_string_to_code(code):
+    def add_generated_string_to_code(code: str) -> str:
         pattern = r"#\*\*\*\*Begin: Generated Statements(?s)(.*)#\*\*\*\*End: Generated Statements\*\*\*\*"
         if re.search(pattern=pattern, string=code):
             return code
         else:
-            return Process.auto_generated_string + code
+            return Process.AUTO_GENERATED_STATEMENTS + code
 
     def __init__(self,
-                 name,
-                 has_security_access=False,
-                 ui_data="CubeAction=1511€DataAction=1503€CubeLogChanges=0€",
-                 parameters=None,
-                 variables=None,
-                 variables_ui_data=None,
-                 prolog_procedure='',
-                 metadata_procedure='',
-                 data_procedure='',
-                 epilog_procedure='',
-                 datasource_type='None',
-                 datasource_ascii_decimal_separator='.',
-                 datasource_ascii_delimiter_char=';',
-                 datasource_ascii_delimiter_type='Character',
-                 datasource_ascii_header_records=1,
-                 datasource_ascii_quote_character='',
-                 datasource_ascii_thousand_separator=',',
-                 datasource_data_source_name_for_client='',
-                 datasource_data_source_name_for_server='',
-                 datasource_password='',
-                 datasource_user_name='',
-                 datasource_query='',
-                 datasource_uses_unicode=True,
-                 datasource_view='',
-                 datasource_subset=''):
+                 name: str,
+                 has_security_access: Optional[bool] = False,
+                 ui_data: str = "CubeAction=1511€DataAction=1503€CubeLogChanges=0€",
+                 parameters: Iterable = None,
+                 variables: Iterable = None,
+                 variables_ui_data: Iterable = None,
+                 prolog_procedure: str = '',
+                 metadata_procedure: str = '',
+                 data_procedure: str = '',
+                 epilog_procedure: str = '',
+                 datasource_type: str = 'None',
+                 datasource_ascii_decimal_separator: str = '.',
+                 datasource_ascii_delimiter_char: str = ';',
+                 datasource_ascii_delimiter_type: str = 'Character',
+                 datasource_ascii_header_records: int = 1,
+                 datasource_ascii_quote_character: str = '',
+                 datasource_ascii_thousand_separator: str = ',',
+                 datasource_data_source_name_for_client: str = '',
+                 datasource_data_source_name_for_server: str = '',
+                 datasource_password: str = '',
+                 datasource_user_name: str = '',
+                 datasource_query: str = '',
+                 datasource_uses_unicode: bool = True,
+                 datasource_view: str = '',
+                 datasource_subset: str = ''):
         """ Default construcor
 
         :param name: name of the process - mandatory
@@ -81,7 +83,7 @@ class Process(TM1Object):
         self._name = name
         self._has_security_access = has_security_access
         self._ui_data = ui_data
-        self._parameters = list(parameters)if parameters else []
+        self._parameters = list(parameters) if parameters else []
         self._variables = list(variables) if variables else []
         self._variables_ui_data = list(variables_ui_data) if variables_ui_data else []
         self._prolog_procedure = Process.add_generated_string_to_code(prolog_procedure)
@@ -105,7 +107,7 @@ class Process(TM1Object):
         self._datasource_subset = datasource_subset
 
     @classmethod
-    def from_json(cls, process_as_json):
+    def from_json(cls, process_as_json: str) -> 'Process':
         """
         :param process_as_json: response of /api/v1/Processes('x')?$expand=*
         :return: an instance of this class
@@ -114,12 +116,11 @@ class Process(TM1Object):
         return cls.from_dict(process_as_dict)
 
     @classmethod
-    def from_dict(cls, process_as_dict):
+    def from_dict(cls, process_as_dict: Dict) -> 'Process':
         """
         :param process_as_dict: Dictionary, process as dictionary
         :return: an instance of this class
         """
-        f = lambda dic, k: dic[k] if k in dic else ''
         return cls(name=process_as_dict['Name'],
                    has_security_access=process_as_dict['HasSecurityAccess'],
                    ui_data=process_as_dict['UIData'],
@@ -130,219 +131,219 @@ class Process(TM1Object):
                    metadata_procedure=process_as_dict['MetadataProcedure'],
                    data_procedure=process_as_dict['DataProcedure'],
                    epilog_procedure=process_as_dict['EpilogProcedure'],
-                   datasource_type=f(process_as_dict['DataSource'], 'Type'),
-                   datasource_ascii_decimal_separator=f(process_as_dict['DataSource'], 'asciiDecimalSeparator'),
-                   datasource_ascii_delimiter_char=f(process_as_dict['DataSource'], 'asciiDelimiterChar'),
-                   datasource_ascii_delimiter_type=f(process_as_dict['DataSource'], 'asciiDelimiterType'),
-                   datasource_ascii_header_records=f(process_as_dict['DataSource'], 'asciiHeaderRecords'),
-                   datasource_ascii_quote_character=f(process_as_dict['DataSource'], 'asciiQuoteCharacter'),
-                   datasource_ascii_thousand_separator=f(process_as_dict['DataSource'], 'asciiThousandSeparator'),
-                   datasource_data_source_name_for_client=f(process_as_dict['DataSource'], 'dataSourceNameForClient'),
-                   datasource_data_source_name_for_server=f(process_as_dict['DataSource'], 'dataSourceNameForServer'),
-                   datasource_password=f(process_as_dict['DataSource'], 'password'),
-                   datasource_user_name=f(process_as_dict['DataSource'], 'userName'),
-                   datasource_query=f(process_as_dict['DataSource'], 'query'),
-                   datasource_uses_unicode=f(process_as_dict['DataSource'], 'usesUnicode'),
-                   datasource_view=f(process_as_dict['DataSource'], 'view'),
-                   datasource_subset=f(process_as_dict['DataSource'], 'subset'))
+                   datasource_type=process_as_dict['DataSource'].get('Type', ''),
+                   datasource_ascii_decimal_separator=process_as_dict['DataSource'].get('asciiDecimalSeparator', ''),
+                   datasource_ascii_delimiter_char=process_as_dict['DataSource'].get('asciiDelimiterChar', ''),
+                   datasource_ascii_delimiter_type=process_as_dict['DataSource'].get('asciiDelimiterType', ''),
+                   datasource_ascii_header_records=process_as_dict['DataSource'].get('asciiHeaderRecords', ''),
+                   datasource_ascii_quote_character=process_as_dict['DataSource'].get('asciiQuoteCharacter', ''),
+                   datasource_ascii_thousand_separator=process_as_dict['DataSource'].get('asciiThousandSeparator', ''),
+                   datasource_data_source_name_for_client=process_as_dict['DataSource'].get('dataSourceNameForClient',''),
+                   datasource_data_source_name_for_server=process_as_dict['DataSource'].get('dataSourceNameForServer',''),
+                   datasource_password=process_as_dict['DataSource'].get('password', ''),
+                   datasource_user_name=process_as_dict['DataSource'].get('userName', ''),
+                   datasource_query=process_as_dict['DataSource'].get('query', ''),
+                   datasource_uses_unicode=process_as_dict['DataSource'].get('usesUnicode', ''),
+                   datasource_view=process_as_dict['DataSource'].get('view', ''),
+                   datasource_subset=process_as_dict['DataSource'].get('subset', ''))
 
     @property
-    def body(self):
+    def body(self) -> str:
         return self._construct_body()
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._name
 
     @name.setter
-    def name(self, value):
+    def name(self, value: str):
         self._name = value
 
     @property
-    def has_security_access(self):
+    def has_security_access(self) -> bool:
         return self._has_security_access
 
     @has_security_access.setter
-    def has_security_access(self, value):
+    def has_security_access(self, value: bool):
         self._has_security_access = value
 
     @property
-    def variables(self):
+    def variables(self) -> List:
         return self._variables
 
     @property
-    def parameters(self):
+    def parameters(self) -> List:
         return self._parameters
 
     @property
-    def prolog_procedure(self):
+    def prolog_procedure(self) -> str:
         return self._prolog_procedure
 
     @prolog_procedure.setter
-    def prolog_procedure(self, value):
+    def prolog_procedure(self, value: str):
         self._prolog_procedure = Process.add_generated_string_to_code(value)
 
     @property
-    def metadata_procedure(self):
+    def metadata_procedure(self) -> str:
         return self._metadata_procedure
 
     @metadata_procedure.setter
-    def metadata_procedure(self, value):
+    def metadata_procedure(self, value: str):
         self._metadata_procedure = Process.add_generated_string_to_code(value)
 
     @property
-    def data_procedure(self):
+    def data_procedure(self) -> str:
         return self._data_procedure
 
     @data_procedure.setter
-    def data_procedure(self, value):
+    def data_procedure(self, value: str):
         self._data_procedure = Process.add_generated_string_to_code(value)
 
     @property
-    def epilog_procedure(self):
+    def epilog_procedure(self) -> str:
         return self._epilog_procedure
 
     @epilog_procedure.setter
-    def epilog_procedure(self, value):
+    def epilog_procedure(self, value: str):
         self._epilog_procedure = Process.add_generated_string_to_code(value)
 
     @property
-    def datasource_type(self):
+    def datasource_type(self) -> str:
         return self._datasource_type
 
     @datasource_type.setter
-    def datasource_type(self, value):
+    def datasource_type(self, value: str):
         self._datasource_type = value
 
     @property
-    def datasource_ascii_decimal_separator(self):
+    def datasource_ascii_decimal_separator(self) -> str:
         return self._datasource_ascii_decimal_separator
 
     @datasource_ascii_decimal_separator.setter
-    def datasource_ascii_decimal_separator(self, value):
+    def datasource_ascii_decimal_separator(self, value: str):
         self._datasource_ascii_decimal_separator = value
 
     @property
-    def datasource_ascii_delimiter_char(self):
+    def datasource_ascii_delimiter_char(self) -> str:
         return self._datasource_ascii_delimiter_char
 
     @datasource_ascii_delimiter_char.setter
-    def datasource_ascii_delimiter_char(self, value):
+    def datasource_ascii_delimiter_char(self, value: str):
         self._datasource_ascii_delimiter_char = value
 
     @property
-    def datasource_ascii_delimiter_type(self):
+    def datasource_ascii_delimiter_type(self) -> str:
         return self._datasource_ascii_delimiter_type
 
     @datasource_ascii_delimiter_type.setter
-    def datasource_ascii_delimiter_type(self, value):
+    def datasource_ascii_delimiter_type(self, value: str):
         self._datasource_ascii_delimiter_type = value
 
     @property
-    def datasource_ascii_header_records(self):
+    def datasource_ascii_header_records(self) -> int:
         return self._datasource_ascii_header_records
 
     @datasource_ascii_header_records.setter
-    def datasource_ascii_header_records(self, value):
+    def datasource_ascii_header_records(self, value: int):
         self._datasource_ascii_header_records = value
 
     @property
-    def datasource_ascii_quote_character(self):
+    def datasource_ascii_quote_character(self) -> str:
         return self._datasource_ascii_quote_character
 
     @datasource_ascii_quote_character.setter
-    def datasource_ascii_quote_character(self, value):
+    def datasource_ascii_quote_character(self, value: str):
         self._datasource_ascii_quote_character = value
 
     @property
-    def datasource_ascii_thousand_separator(self):
+    def datasource_ascii_thousand_separator(self) -> str:
         return self._datasource_ascii_thousand_separator
 
     @datasource_ascii_thousand_separator.setter
-    def datasource_ascii_thousand_separator(self, value):
+    def datasource_ascii_thousand_separator(self, value: str):
         self._datasource_ascii_thousand_separator = value
 
     @property
-    def datasource_data_source_name_for_client(self):
+    def datasource_data_source_name_for_client(self) -> str:
         return self._datasource_data_source_name_for_client
 
     @datasource_data_source_name_for_client.setter
-    def datasource_data_source_name_for_client(self, value):
+    def datasource_data_source_name_for_client(self, value: str):
         self._datasource_data_source_name_for_client = value
 
     @property
-    def datasource_data_source_name_for_server(self):
+    def datasource_data_source_name_for_server(self) -> str:
         return self._datasource_data_source_name_for_server
 
     @datasource_data_source_name_for_server.setter
-    def datasource_data_source_name_for_server(self, value):
+    def datasource_data_source_name_for_server(self, value: str):
         self._datasource_data_source_name_for_server = value
 
     @property
-    def datasource_password(self):
+    def datasource_password(self) -> str:
         return self._datasource_password
 
     @datasource_password.setter
-    def datasource_password(self, value):
+    def datasource_password(self, value: str):
         self._datasource_password = value
 
     @property
-    def datasource_user_name(self):
+    def datasource_user_name(self) -> str:
         return self._datasource_user_name
 
     @datasource_user_name.setter
-    def datasource_user_name(self, value):
+    def datasource_user_name(self, value: str):
         self._datasource_user_name = value
 
     @property
-    def datasource_query(self):
+    def datasource_query(self) -> str:
         return self._datasource_query
 
     @datasource_query.setter
-    def datasource_query(self, value):
+    def datasource_query(self, value: str):
         self._datasource_query = value
 
     @property
-    def datasource_uses_unicode(self):
+    def datasource_uses_unicode(self) -> bool:
         return self._datasource_uses_unicode
 
     @datasource_uses_unicode.setter
-    def datasource_uses_unicode(self, value):
+    def datasource_uses_unicode(self, value: bool):
         self._datasource_uses_unicode = value
 
     @property
-    def datasource_view(self):
+    def datasource_view(self) -> str:
         return self._datasource_view
 
     @datasource_view.setter
-    def datasource_view(self, value):
+    def datasource_view(self, value: str):
         self._datasource_view = value
 
     @property
-    def datasource_subset(self):
+    def datasource_subset(self) -> str:
         return self._datasource_subset
 
     @datasource_subset.setter
-    def datasource_subset(self, value):
+    def datasource_subset(self, value: str):
         self._datasource_subset = value
 
-    def add_variable(self, name, type):
+    def add_variable(self, name: str, variable_type: str):
         """ add variable to the process
 
         :param name: -
-        :param type: 'String' or 'Numeric'
+        :param variable_type: 'String' or 'Numeric'
         :return:
         """
         # variable consists of actual variable and UI-Information ('ignore','other', etc.)
         # 1. handle Variable info
         variable = {'Name': name,
-                    'Type': type,
+                    'Type': variable_type,
                     'Position': len(self._variables) + 1,
                     'StartByte': 0,
                     'EndByte': 0}
         self._variables.append(variable)
         # 2. handle UI info
-        var_type = 33 if type == 'Numeric' else 32
+        var_type = 33 if variable_type == 'Numeric' else 32
         # '\f' !
         variable_ui_data = 'VarType=' + str(var_type) + '\f' + 'ColType=' + str(827) + '\f'
         """
@@ -353,14 +354,15 @@ class Process(TM1Object):
         """
         self._variables_ui_data.append(variable_ui_data)
 
-    def remove_variable(self, name):
-        for variable in self.variables:
+    def remove_variable(self, name: str):
+        for variable in self.variables[:]:
             if variable['Name'] == name:
                 vuid = self._variables_ui_data[self._variables.index(variable)]
                 self._variables_ui_data.remove(vuid)
                 self._variables.remove(variable)
 
-    def add_parameter(self, name, prompt, value, parameter_type=None):
+    def add_parameter(self, name: str, prompt: str, value: Union[str, int, float],
+                      parameter_type: Optional[str] = None):
         """
         
         :param name: 
@@ -377,8 +379,8 @@ class Process(TM1Object):
                      'Type': parameter_type}
         self._parameters.append(parameter)
 
-    def remove_parameter(self, name):
-        for parameter in self.parameters:
+    def remove_parameter(self, name: str):
+        for parameter in self.parameters[:]:
             if parameter['Name'] == name:
                 self._parameters.remove(parameter)
 
@@ -388,7 +390,7 @@ class Process(TM1Object):
                 del self.parameters[p]['Type']
 
     # construct self.body (json) from the class-attributes
-    def _construct_body(self):
+    def _construct_body(self) -> str:
         # general parameters
         body_as_dict = {
             'Name': self._name,

--- a/TM1py/Objects/Rules.py
+++ b/TM1py/Objects/Rules.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from typing import List
 
 from TM1py.Objects.TM1Object import TM1Object
 
@@ -12,9 +13,9 @@ class Rules(TM1Object):
             comments are not included.
 
     """
-    keywords = ['SKIPCHECK', 'FEEDSTRINGS', 'UNDEFVALS', 'FEEDERS']
+    KEYWORDS = ['SKIPCHECK', 'FEEDSTRINGS', 'UNDEFVALS', 'FEEDERS']
 
-    def __init__(self, rules):
+    def __init__(self, rules: str):
         self._text = rules
         self._rules_analytics = []
         self.init_analytics()
@@ -30,48 +31,48 @@ class Rules(TM1Object):
                 self._rules_analytics.append(statement.replace('\n', '').upper())
 
     @property
-    def text(self):
+    def text(self) -> str:
         return self._text
 
     @property
-    def rules_analytics(self):
+    def rules_analytics(self) -> List[str]:
         return self._rules_analytics
 
     @property
-    def rule_statements(self):
+    def rule_statements(self) -> List[str]:
         if self.has_feeders:
             return self.rules_analytics[:self._rules_analytics.index('FEEDERS')]
         return self.rules_analytics
 
     @property
-    def feeder_statements(self):
+    def feeder_statements(self) -> List[str]:
         if self.has_feeders:
-            return self.rules_analytics[self._rules_analytics.index('FEEDERS')+1:]
+            return self.rules_analytics[self._rules_analytics.index('FEEDERS') + 1:]
         return []
 
     @property
-    def skipcheck(self):
+    def skipcheck(self) -> bool:
         for rule in self._rules_analytics[0:5]:
             if rule == 'SKIPCHECK':
                 return True
         return False
 
     @property
-    def undefvals(self):
+    def undefvals(self) -> bool:
         for rule in self._rules_analytics[0:5]:
             if rule == 'UNDEFVALS':
                 return True
         return False
 
     @property
-    def feedstrings(self):
+    def feedstrings(self) -> bool:
         for rule in self._rules_analytics[0:5]:
             if rule == 'FEEDSTRINGS':
                 return True
         return False
 
     @property
-    def has_feeders(self):
+    def has_feeders(self) -> bool:
         if 'FEEDERS' in self._rules_analytics:
             # has feeders declaration
             feeders = self.rules_analytics[self._rules_analytics.index('FEEDERS'):]

--- a/TM1py/Objects/Server.py
+++ b/TM1py/Objects/Server.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from typing import Dict
 
 
 class Server:
@@ -8,7 +9,7 @@ class Server:
             contains the information you get from http://localhost:5895/api/v1/Servers
             no methods so far
     """
-    def __init__(self, server_as_dict):
+    def __init__(self, server_as_dict: Dict):
         self.name = server_as_dict['Name']
         self.ip_address = server_as_dict['IPAddress']
         self.ip_v6_address = server_as_dict['IPv6Address']

--- a/TM1py/Objects/Subset.py
+++ b/TM1py/Objects/Subset.py
@@ -2,6 +2,7 @@
 
 import collections
 import json
+from typing import List, Dict, Optional, Iterable
 
 from TM1py.Objects.TM1Object import TM1Object
 from TM1py.Utils import format_url
@@ -10,16 +11,16 @@ from TM1py.Utils import format_url
 class Subset(TM1Object):
     """ Abstraction of the TM1 Subset (dynamic and static)
 
-        Done and tested. unittests available.
     """
 
-    def __init__(self, subset_name, dimension_name, hierarchy_name=None, alias=None, expression=None, elements=None):
+    def __init__(self, subset_name: str, dimension_name: str, hierarchy_name: str = None, alias: str = None,
+                 expression: str = None, elements: Iterable[str] = None):
         """
 
         :param subset_name: String
         :param dimension_name: String
         :param hierarchy_name: String
-        :param alias: String, alias that is on in this subset.
+        :param alias: String, alias that is active in this subset.
         :param expression: String
         :param elements: List, element names
         """
@@ -31,65 +32,65 @@ class Subset(TM1Object):
         self._elements = list(elements) if elements else []
 
     @property
-    def dimension_name(self):
+    def dimension_name(self) -> str:
         return self._dimension_name
 
     @dimension_name.setter
-    def dimension_name(self, value):
+    def dimension_name(self, value: str):
         self._dimension_name = value
 
     @property
-    def hierarchy_name(self):
+    def hierarchy_name(self) -> str:
         return self._hierarchy_name
 
     @hierarchy_name.setter
-    def hierarchy_name(self, value):
+    def hierarchy_name(self, value: str):
         self._hierarchy_name = value
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._subset_name
 
     @property
-    def alias(self):
+    def alias(self) -> str:
         return self._alias
 
     @alias.setter
-    def alias(self, value):
+    def alias(self, value: str):
         self._alias = value
 
     @property
-    def expression(self):
+    def expression(self) -> str:
         return self._expression
 
     @expression.setter
-    def expression(self, value):
+    def expression(self, value: str):
         self._expression = value
 
     @property
-    def elements(self):
+    def elements(self) -> List[str]:
         return self._elements
 
     @elements.setter
-    def elements(self, value):
+    def elements(self, value: List[str]):
         self._elements = value
 
     @property
-    def type(self):
+    def type(self) -> str:
         if self.expression:
             return 'dynamic'
         return 'static'
 
     @property
-    def is_dynamic(self):
-        return self.expression
+    def is_dynamic(self) -> bool:
+        return bool(self.expression)
 
     @property
-    def is_static(self):
+    def is_static(self) -> bool:
         return not self.is_dynamic
 
     @classmethod
-    def from_json(cls, subset_as_json):
+    def from_json(cls, subset_as_json: str) -> 'Subset':
         """ Alternative constructor
                 :Parameters:
                     `subset_as_json` : string, JSON
@@ -103,7 +104,7 @@ class Subset(TM1Object):
         return cls.from_dict(subset_as_dict=subset_as_dict)
 
     @classmethod
-    def from_dict(cls, subset_as_dict):
+    def from_dict(cls, subset_as_dict: Dict) -> 'Subset':
         return cls(dimension_name=subset_as_dict["UniqueName"][1:subset_as_dict["UniqueName"].find('].[')],
                    hierarchy_name=subset_as_dict["Hierarchy"]["Name"],
                    subset_name=subset_as_dict['Name'],
@@ -113,13 +114,13 @@ class Subset(TM1Object):
                    if not subset_as_dict['Expression'] else None)
 
     @property
-    def body(self):
+    def body(self) -> str:
         """ same logic here as in TM1 : when subset has expression its dynamic, otherwise static
         """
         return json.dumps(self.body_as_dict, ensure_ascii=False)
 
     @property
-    def body_as_dict(self):
+    def body_as_dict(self) -> Dict:
         """ same logic here as in TM1 : when subset has expression its dynamic, otherwise static
         """
         if self._expression:
@@ -127,14 +128,14 @@ class Subset(TM1Object):
         else:
             return self._construct_body_static()
 
-    def add_elements(self, elements):
+    def add_elements(self, elements: Iterable[str]):
         """ add Elements to static subsets
             :Parameters:
                 `elements` : list of element names
         """
-        self._elements = self._elements + elements
+        self._elements = self._elements + list(elements)
 
-    def _construct_body_dynamic(self):
+    def _construct_body_dynamic(self) -> Dict:
         body_as_dict = collections.OrderedDict()
         body_as_dict['Name'] = self._subset_name
         if self.alias:
@@ -145,7 +146,7 @@ class Subset(TM1Object):
         body_as_dict['Expression'] = self._expression
         return body_as_dict
 
-    def _construct_body_static(self):
+    def _construct_body_static(self) -> Dict:
         body_as_dict = collections.OrderedDict()
         body_as_dict['Name'] = self._subset_name
         if self.alias:
@@ -167,7 +168,8 @@ class AnonymousSubset(Subset):
 
     """
 
-    def __init__(self, dimension_name, hierarchy_name=None, expression=None, elements=None):
+    def __init__(self, dimension_name: str, hierarchy_name: Optional[str] = None, expression: Optional[str] = None,
+                 elements: Optional[Iterable[str]] = None):
         Subset.__init__(self,
                         dimension_name=dimension_name,
                         hierarchy_name=hierarchy_name if hierarchy_name else dimension_name,
@@ -177,7 +179,7 @@ class AnonymousSubset(Subset):
                         elements=elements)
 
     @classmethod
-    def from_json(cls, subset_as_json):
+    def from_json(cls, subset_as_json: str) -> 'Subset':
         """ Alternative constructor
                 :Parameters:
                     `subset_as_json` : string, JSON
@@ -190,7 +192,7 @@ class AnonymousSubset(Subset):
         return cls.from_dict(subset_as_dict=subset_as_dict)
 
     @classmethod
-    def from_dict(cls, subset_as_dict):
+    def from_dict(cls, subset_as_dict: Dict) -> 'Subset':
         """Alternative constructor
         
         :param subset_as_dict: dictionary, representation of Subset as specified in CSDL
@@ -202,14 +204,14 @@ class AnonymousSubset(Subset):
                    elements=[element['Name'] for element in subset_as_dict['Elements']]
                    if not subset_as_dict['Expression'] else None)
 
-    def _construct_body_dynamic(self):
+    def _construct_body_dynamic(self) -> Dict:
         body_as_dict = collections.OrderedDict()
         body_as_dict['Hierarchy@odata.bind'] = "Dimensions('{}')/Hierarchies('{}')" \
             .format(self._dimension_name, self.hierarchy_name)
         body_as_dict['Expression'] = self._expression
         return body_as_dict
 
-    def _construct_body_static(self):
+    def _construct_body_static(self) -> Dict:
         body_as_dict = collections.OrderedDict()
         body_as_dict['Hierarchy@odata.bind'] = "Dimensions('{}')/Hierarchies('{}')".format(
             self._dimension_name,

--- a/TM1py/Objects/Subset.py
+++ b/TM1py/Objects/Subset.py
@@ -4,7 +4,7 @@ import collections
 import json
 
 from TM1py.Objects.TM1Object import TM1Object
-from TM1py.Utils.Utils import odata_escape_single_quotes_in_object_names
+from TM1py.Utils import format_url
 
 
 class Subset(TM1Object):
@@ -155,9 +155,8 @@ class Subset(TM1Object):
             self.hierarchy_name)
         if self.elements and len(self.elements) > 0:
             body_as_dict['Elements@odata.bind'] = [
-                odata_escape_single_quotes_in_object_names(
-                    "Dimensions('{}')/Hierarchies('{}')/Elements('{}')".format(
-                        self.dimension_name, self.hierarchy_name, element))
+                format_url("Dimensions('{}')/Hierarchies('{}')/Elements('{}')",
+                           self.dimension_name, self.hierarchy_name, element)
                 for element
                 in self.elements]
         return body_as_dict
@@ -216,8 +215,7 @@ class AnonymousSubset(Subset):
             self._dimension_name,
             self.hierarchy_name)
         body_as_dict['Elements@odata.bind'] = [
-            odata_escape_single_quotes_in_object_names("Dimensions('{}')/Hierarchies('{}')/Elements('{}')".format(
-                self.dimension_name,
-                self.hierarchy_name,
-                element)) for element in self.elements]
+            format_url("Dimensions('{}')/Hierarchies('{}')/Elements('{}')",
+                       self.dimension_name, self.hierarchy_name, element)
+            for element in self.elements]
         return body_as_dict

--- a/TM1py/Objects/Subset.py
+++ b/TM1py/Objects/Subset.py
@@ -140,7 +140,8 @@ class Subset(TM1Object):
         body_as_dict['Name'] = self._subset_name
         if self.alias:
             body_as_dict['Alias'] = self._alias
-        body_as_dict['Hierarchy@odata.bind'] = "Dimensions('{}')/Hierarchies('{}')".format(
+        body_as_dict['Hierarchy@odata.bind'] = format_url(
+            "Dimensions('{}')/Hierarchies('{}')",
             self._dimension_name,
             self._hierarchy_name)
         body_as_dict['Expression'] = self._expression
@@ -151,7 +152,8 @@ class Subset(TM1Object):
         body_as_dict['Name'] = self._subset_name
         if self.alias:
             body_as_dict['Alias'] = self._alias
-        body_as_dict['Hierarchy@odata.bind'] = "Dimensions('{}')/Hierarchies('{}')".format(
+        body_as_dict['Hierarchy@odata.bind'] = format_url(
+            "Dimensions('{}')/Hierarchies('{}')",
             self._dimension_name,
             self.hierarchy_name)
         if self.elements and len(self.elements) > 0:
@@ -206,18 +208,24 @@ class AnonymousSubset(Subset):
 
     def _construct_body_dynamic(self) -> Dict:
         body_as_dict = collections.OrderedDict()
-        body_as_dict['Hierarchy@odata.bind'] = "Dimensions('{}')/Hierarchies('{}')" \
-            .format(self._dimension_name, self.hierarchy_name)
+        body_as_dict['Hierarchy@odata.bind'] = format_url(
+            "Dimensions('{}')/Hierarchies('{}')",
+            self._dimension_name,
+            self.hierarchy_name)
         body_as_dict['Expression'] = self._expression
         return body_as_dict
 
     def _construct_body_static(self) -> Dict:
         body_as_dict = collections.OrderedDict()
-        body_as_dict['Hierarchy@odata.bind'] = "Dimensions('{}')/Hierarchies('{}')".format(
+        body_as_dict['Hierarchy@odata.bind'] = format_url(
+            "Dimensions('{}')/Hierarchies('{}')",
             self._dimension_name,
             self.hierarchy_name)
         body_as_dict['Elements@odata.bind'] = [
-            format_url("Dimensions('{}')/Hierarchies('{}')/Elements('{}')",
-                       self.dimension_name, self.hierarchy_name, element)
+            format_url(
+                "Dimensions('{}')/Hierarchies('{}')/Elements('{}')",
+                self.dimension_name,
+                self.hierarchy_name,
+                element)
             for element in self.elements]
         return body_as_dict

--- a/TM1py/Objects/TM1Object.py
+++ b/TM1py/Objects/TM1Object.py
@@ -1,3 +1,4 @@
+from abc import abstractmethod
 
 
 class TM1Object:
@@ -7,6 +8,7 @@ class TM1Object:
     SANDBOX_DIMENSION = "Sandboxes"
 
     @property
+    @abstractmethod
     def body(self):
         pass
 

--- a/TM1py/Objects/User.py
+++ b/TM1py/Objects/User.py
@@ -2,6 +2,7 @@
 
 import collections
 import json
+from typing import Iterable, Optional, List, Dict
 
 from TM1py.Objects.TM1Object import TM1Object
 from TM1py.Utils.Utils import CaseAndSpaceInsensitiveSet, format_url
@@ -12,53 +13,54 @@ class User(TM1Object):
     
     """
 
-    def __init__(self, name, groups, friendly_name=None, password=None):
+    def __init__(self, name: str, groups: Iterable[str], friendly_name: Optional[str] = None,
+                 password: Optional[str] = None):
         self._name = name
         self._groups = CaseAndSpaceInsensitiveSet(*groups)
         self._friendly_name = friendly_name
         self._password = password
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._name
 
     @property
-    def friendly_name(self):
+    def friendly_name(self) -> str:
         return self._friendly_name
 
     @property
-    def password(self):
+    def password(self) -> str:
         if self._password:
             return self._password
 
     @property
-    def is_admin(self):
+    def is_admin(self) -> bool:
         return 'ADMIN' in self.groups
 
     @property
-    def groups(self):
+    def groups(self) -> List[str]:
         return [group for group in self._groups]
 
     @name.setter
-    def name(self, value):
+    def name(self, value: str):
         self._name = value
 
     @friendly_name.setter
-    def friendly_name(self, value):
+    def friendly_name(self, value: str):
         self._friendly_name = value
 
     @password.setter
-    def password(self, value):
+    def password(self, value: str):
         self._password = value
 
-    def add_group(self, group_name):
+    def add_group(self, group_name: str):
         self._groups.add(group_name)
 
-    def remove_group(self, group_name):
+    def remove_group(self, group_name: str):
         self._groups.discard(group_name)
 
     @classmethod
-    def from_json(cls, user_as_json):
+    def from_json(cls, user_as_json: str):
         """ Alternative constructor
 
         :param user_as_json: user as JSON string
@@ -68,7 +70,7 @@ class User(TM1Object):
         return cls.from_dict(user_as_dict)
 
     @classmethod
-    def from_dict(cls, user_as_dict):
+    def from_dict(cls, user_as_dict: Dict) -> 'User':
         """ Alternative constructor
 
         :param user_as_dict: user as dict
@@ -79,10 +81,10 @@ class User(TM1Object):
                    groups=[group["Name"] for group in user_as_dict['Groups']])
 
     @property
-    def body(self):
+    def body(self) -> str:
         return self.construct_body()
 
-    def construct_body(self):
+    def construct_body(self) -> str:
         """
         construct body (json) from the class attributes
         :return: String, TM1 JSON representation of a user

--- a/TM1py/Objects/User.py
+++ b/TM1py/Objects/User.py
@@ -4,7 +4,7 @@ import collections
 import json
 
 from TM1py.Objects.TM1Object import TM1Object
-from TM1py.Utils.Utils import CaseAndSpaceInsensitiveSet, odata_escape_single_quotes_in_object_names
+from TM1py.Utils.Utils import CaseAndSpaceInsensitiveSet, format_url
 
 
 class User(TM1Object):
@@ -92,8 +92,7 @@ class User(TM1Object):
         body_as_dict['FriendlyName'] = self.friendly_name or self.name
         if self.password:
             body_as_dict['Password'] = self._password
-        body_as_dict['Groups@odata.bind'] = [
-            odata_escape_single_quotes_in_object_names("Groups('{}')".format(group))
-            for group
-            in self.groups]
+        body_as_dict['Groups@odata.bind'] = [format_url("Groups('{}')", group)
+                                             for group
+                                             in self.groups]
         return json.dumps(body_as_dict, ensure_ascii=False)

--- a/TM1py/Objects/View.py
+++ b/TM1py/Objects/View.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from abc import abstractmethod
 
 from TM1py.Objects.TM1Object import TM1Object
 
@@ -8,22 +9,27 @@ class View(TM1Object):
         serves as a parentclass for TM1py.Objects.MDXView and TM1py.Objects.NativeView
 
     """
-    def __init__(self, cube, name):
+
+    def __init__(self, cube: str, name: str):
         self._cube = cube
         self._name = name
 
+    @abstractmethod
+    def body(self):
+        pass
+
     @property
-    def cube(self):
+    def cube(self) -> str:
         return self._cube
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._name
 
     @cube.setter
-    def cube(self, value):
+    def cube(self, value: str):
         self._cube = value
 
     @name.setter
-    def name(self, value):
+    def name(self, value: str):
         self._name = value

--- a/TM1py/Objects/View.py
+++ b/TM1py/Objects/View.py
@@ -15,7 +15,7 @@ class View(TM1Object):
         self._name = name
 
     @abstractmethod
-    def body(self):
+    def body(self) -> str:
         pass
 
     @property

--- a/TM1py/Services/AnnotationService.py
+++ b/TM1py/Services/AnnotationService.py
@@ -2,88 +2,86 @@
 
 import collections
 import json
+from typing import List
+
+from requests import Response
 
 from TM1py.Objects.Annotation import Annotation
 from TM1py.Services.ObjectService import ObjectService
+from TM1py.Services.RestService import RestService
+from TM1py.Utils import format_url
 
 
 class AnnotationService(ObjectService):
     """ Service to handle Object Updates for TM1 CellAnnotations
     
     """
-    def __init__(self, rest):
+
+    def __init__(self, rest: RestService):
         super().__init__(rest)
 
-    def get_all(self, cube_name):
+    def get_all(self, cube_name: str, **kwargs) -> List[Annotation]:
         """ get all annotations from given cube as a List.
-    
+
         :param cube_name:
-        :return: list of instances of TM1py.Annotation
         """
-        request = "/api/v1/Cubes('{}')/Annotations?$expand=DimensionalContext($select=Name)".format(cube_name)
-        response = self._rest.GET(request, '')
+        url = format_url("/api/v1/Cubes('{}')/Annotations?$expand=DimensionalContext($select=Name)", cube_name)
+        response = self._rest.GET(url, **kwargs)
+
         annotations_as_dict = response.json()['value']
         annotations = [Annotation.from_json(json.dumps(element)) for element in annotations_as_dict]
         return annotations
 
-    def create(self, annotation):
+    def create(self, annotation: Annotation, **kwargs) -> Response:
         """ create an Annotation
-    
-            :param annotation: instance of TM1py.Annotation
-            :return response
+
+        :param annotation: instance of TM1py.Annotation
         """
-        request = "/api/v1/Annotations"
+        url = "/api/v1/Annotations"
 
         payload = collections.OrderedDict()
         payload["Text"] = annotation.text
-        payload["ApplicationContext"] = [{"Facet@odata.bind": "ApplicationContextFacets('}Cubes')",
-                                          "Value": annotation.object_name}]
+        payload["ApplicationContext"] = [{
+            "Facet@odata.bind": "ApplicationContextFacets('}Cubes')",
+            "Value": annotation.object_name}]
         payload["DimensionalContext@odata.bind"] = []
         from TM1py import CubeService
         cube_dimensions = CubeService(self._rest).get_dimension_names(
             cube_name=annotation.object_name,
             skip_sandbox_dimension=True)
         for dimension, element in zip(cube_dimensions, annotation.dimensional_context):
-            coordinates = "Dimensions('{}')/Hierarchies('{}')/Members('{}')".format(dimension, dimension, element)
+            coordinates = format_url("Dimensions('{}')/Hierarchies('{}')/Members('{}')", dimension, dimension, element)
             payload["DimensionalContext@odata.bind"].append(coordinates)
         payload['objectName'] = annotation.object_name
         payload['commentValue'] = annotation.comment_value
         payload['commentType'] = 'ANNOTATION'
         payload['commentLocation'] = ','.join(annotation.dimensional_context)
-        response = self._rest.POST(request, json.dumps(payload, ensure_ascii=False))
+
+        response = self._rest.POST(url, json.dumps(payload, ensure_ascii=False), **kwargs)
         return response
 
-    def get(self, annotation_id):
-        """ get an annotation from any cube in TM1 Server through its id
-    
-            :param annotation_id: String, the id of the annotation
-    
-            :return:
-                Annotation: an instance of TM1py.Annoation
+    def get(self, annotation_id: str, **kwargs) -> Annotation:
+        """ get an annotation from any cube through its unique id
+
+        :param annotation_id: String, the id of the annotation
         """
-        request = "/api/v1/Annotations('{}')?$expand=DimensionalContext($select=Name)".format(annotation_id)
-        response = self._rest.GET(request=request)
+        request = format_url("/api/v1/Annotations('{}')?$expand=DimensionalContext($select=Name)", annotation_id)
+        response = self._rest.GET(url=request, **kwargs)
         return Annotation.from_json(response.text)
 
-    def update(self, annotation):
-        """ update Annotation on TM1 Server
-    
-            :param annotation: instance of TM1py.Annotation
-    
-            :Notes:
-                updateable attributes:
-                    commentValue
-        """
-        request = "/api/v1/Annotations('{}')".format(annotation.id)
-        return self._rest.PATCH(request=request, data=annotation.body)
+    def update(self, annotation: Annotation, **kwargs) -> Response:
+        """ update Annotation.
+        updateable attributes: commentValue
 
-    def delete(self, annotation_id):
-        """ delete Annotation on TM1 Server
-    
-            :param annotation_id: string, the id of the annotation
-    
-            :return:
-                string: the response
+        :param annotation: instance of TM1py.Annotation
         """
-        request = "/api/v1/Annotations('{}')".format(annotation_id)
-        return self._rest.DELETE(request=request)
+        url = format_url("/api/v1/Annotations('{}')", annotation.id)
+        return self._rest.PATCH(url=url, data=annotation.body, **kwargs)
+
+    def delete(self, annotation_id: str, **kwargs) -> Response:
+        """ delete Annotation
+    
+        :param annotation_id: string, the id of the annotation
+        """
+        url = format_url("/api/v1/Annotations('{}')", annotation_id)
+        return self._rest.DELETE(url=url, **kwargs)

--- a/TM1py/Services/ApplicationService.py
+++ b/TM1py/Services/ApplicationService.py
@@ -1,15 +1,21 @@
 # -*- coding: utf-8 -*-
-from TM1py.Objects.Application import DocumentApplication, ApplicationTypes, CubeApplication, ChoreApplication, \
-    FolderApplication, LinkApplication, ProcessApplication, DimensionApplication, SubsetApplication, ViewApplication
+from typing import Union
 
+from requests import Response
+
+from TM1py.Objects.Application import DocumentApplication, ApplicationTypes, CubeApplication, ChoreApplication, \
+    FolderApplication, LinkApplication, ProcessApplication, DimensionApplication, SubsetApplication, ViewApplication, \
+    Application
+from TM1py.Services import RestService
 from TM1py.Services.ObjectService import ObjectService
+from TM1py.Utils import format_url
 
 
 class ApplicationService(ObjectService):
     """ Service to Read and Write TM1 Applications
     """
 
-    def __init__(self, tm1_rest):
+    def __init__(self, tm1_rest: RestService):
         """
 
         :param tm1_rest:
@@ -17,11 +23,12 @@ class ApplicationService(ObjectService):
         super().__init__(tm1_rest)
         self._rest = tm1_rest
 
-    def get(self, path, application_type, name, private=False):
+    def get(self, path: str, application_type: Union[str, ApplicationTypes], name: str, private: bool = False,
+            **kwargs) -> Application:
         """ Retrieve Planning Analytics Application
 
-        :param path:
-        :param application_type:
+        :param path: path with forward slashes
+        :param application_type: str or ApplicationType from Enum
         :param name:
         :param private:
         :return:
@@ -31,7 +38,7 @@ class ApplicationService(ObjectService):
 
         # documents require special treatment
         if application_type == ApplicationTypes.DOCUMENT:
-            return self.get_document(path=path, name=name, private=private)
+            return self.get_document(path=path, name=name, private=private, **kwargs)
 
         if not application_type == ApplicationTypes.FOLDER:
             name += application_type.suffix
@@ -39,43 +46,46 @@ class ApplicationService(ObjectService):
         contents = 'PrivateContents' if private else 'Contents'
         mid = ""
         if path.strip() != '':
-            mid = "".join(["/Contents('{}')".format(element) for element in path.split('/')])
-        base_url = "/api/v1/Contents('Applications'){dynamic_mid}/{contents}('{application_name}')".format(
-            dynamic_mid=mid,
-            contents=contents,
+            mid = "".join([format_url("/Contents('{}')", element) for element in path.split('/')])
+
+        base_url = format_url(
+            "/api/v1/Contents('Applications')" + mid + "/" + contents + "('{application_name}')",
             application_name=name)
 
         if application_type == ApplicationTypes.CUBE:
-            response = self._rest.GET(base_url + "?$expand=Cube($select=Name)")
+            response = self._rest.GET(url=base_url + "?$expand=Cube($select=Name)", **kwargs)
             return CubeApplication(path=path, name=name, cube_name=response.json()["Cube"]["Name"])
 
         elif application_type == ApplicationTypes.CHORE:
-            response = self._rest.GET(base_url + "?$expand=Chore($select=Name)")
+            response = self._rest.GET(url=base_url + "?$expand=Chore($select=Name)", **kwargs)
             return ChoreApplication(path=path, name=name, chore_name=response.json()["Chore"]["Name"])
 
         elif application_type == ApplicationTypes.DIMENSION:
-            response = self._rest.GET(base_url + "?$expand=Dimension($select=Name)")
+            response = self._rest.GET(url=base_url + "?$expand=Dimension($select=Name)", **kwargs)
             return DimensionApplication(path=path, name=name, dimension_name=response.json()["Dimension"]["Name"])
 
         elif application_type == ApplicationTypes.FOLDER:
-            # implicit TM1pyException if doesn't exist
-            self._rest.GET(base_url)
+            # implicit TM1pyException if application doesn't exist
+            self._rest.GET(url=base_url, **kwargs)
             return FolderApplication(path=path, name=name)
 
         elif application_type == ApplicationTypes.LINK:
-            # implicit TM1pyException if doesn't exist
-            self._rest.GET(base_url)
-            response = self._rest.GET(base_url + "?$expand=*")
+            # implicit TM1pyException if application doesn't exist
+            self._rest.GET(url=base_url, **kwargs)
+            response = self._rest.GET(base_url + "?$expand=*", **kwargs)
             return LinkApplication(path=path, name=name, url=response.json()["URL"])
 
         elif application_type == ApplicationTypes.PROCESS:
-            response = self._rest.GET(base_url + "?$expand=Process($select=Name)")
+            response = self._rest.GET(url=base_url + "?$expand=Process($select=Name)", **kwargs)
             return ProcessApplication(path=path, name=name, process_name=response.json()["Process"]["Name"])
 
         elif application_type == ApplicationTypes.SUBSET:
+            url = "".join([
+                base_url,
+                "?$expand=Subset($select=Name;$expand=Hierarchy($select=Name;$expand=Dimension($select=Name)))"])
             response = self._rest.GET(
-                base_url +
-                "?$expand=Subset($select=Name;$expand=Hierarchy($select=Name;$expand=Dimension($select=Name)))")
+                url=url,
+                **kwargs)
             return SubsetApplication(
                 path=path,
                 name=name,
@@ -84,14 +94,16 @@ class ApplicationService(ObjectService):
                 subset_name=response.json()["Subset"]["Name"])
 
         elif application_type == ApplicationTypes.VIEW:
-            response = self._rest.GET(base_url + "?$expand=View($select=Name;$expand=Cube($select=Name))")
+            response = self._rest.GET(
+                url=base_url + "?$expand=View($select=Name;$expand=Cube($select=Name))",
+                **kwargs)
             return ViewApplication(
                 path=path,
                 name=name,
                 cube_name=response.json()["View"]["Cube"]["Name"],
                 view_name=response.json()["View"]["Name"])
 
-    def get_document(self, path, name, private=False):
+    def get_document(self, path: str, name: str, private: bool = False, **kwargs) -> DocumentApplication:
         """ Get Excel Application from TM1 Server in binary format. Can be dumped to file.
 
         :param path: path through folder structure to application. For instance: "Finance/P&L.xlsx"
@@ -103,16 +115,17 @@ class ApplicationService(ObjectService):
             name += ApplicationTypes.DOCUMENT.suffix
 
         contents = 'PrivateContents' if private else 'Contents'
-        mid = "".join(["/Contents('{}')".format(element) for element in path.split('/')])
-        request = "/api/v1/Contents('Applications'){dynamic_mid}/{contents}('{name}')/Document/Content".format(
-            dynamic_mid=mid,
-            contents=contents,
+        mid = "".join([format_url("/Contents('{}')", element) for element in path.split('/')])
+        url = format_url(
+            "/api/v1/Contents('Applications')" + mid + "/" + contents + "('{name}')/Document/Content",
             name=name)
-        response = self._rest.GET(request)
+
+        response = self._rest.GET(url, **kwargs)
         return DocumentApplication(path, name, response.content)
 
-    def delete(self, path, application_type, application_name, private=False):
-        """ Create Planning Analytics application process reference
+    def delete(self, path: str, application_type: Union[str, ApplicationTypes], application_name: str,
+               private: bool = False, **kwargs) -> Response:
+        """ Delete Planning Analytics application reference
 
         :param path: path through folder structure to delete the applications entry. For instance: "Finance/Reports"
         :param application_type: type of the to be deleted application entry
@@ -130,15 +143,14 @@ class ApplicationService(ObjectService):
         contents = 'PrivateContents' if private else 'Contents'
         mid = ""
         if path.strip() != '':
-            mid = "".join(["/Contents('{}')".format(element) for element in path.split('/')])
-        request = "/api/v1/Contents('Applications'){dynamic_mid}/{contents}('{application_name}')".format(
-            dynamic_mid=mid,
-            contents=contents,
+            mid = "".join([format_url("/Contents('{}')", element) for element in path.split('/')])
+
+        url = format_url(
+            "/api/v1/Contents('Applications')" + mid + "/" + contents + "('{application_name}')",
             application_name=application_name)
+        return self._rest.DELETE(url, **kwargs)
 
-        return self._rest.DELETE(request)
-
-    def create(self, application, private=False):
+    def create(self, application: Union[Application, DocumentApplication], private: bool = False, **kwargs) -> Response:
         """ Create Planning Analytics application
 
         :param application: instance of Application
@@ -147,20 +159,31 @@ class ApplicationService(ObjectService):
         """
 
         contents = 'PrivateContents' if private else 'Contents'
+
         mid = ""
         if application.path.strip() != '':
-            mid = "".join(["/Contents('{}')".format(element) for element in application.path.split('/')])
-        request = "/api/v1/Contents('Applications')" + mid + "/" + contents
-        response = self._rest.POST(request, application.body)
+            mid = "".join([format_url("/Contents('{}')", element) for element in application.path.split('/')])
+        url = "/api/v1/Contents('Applications')" + mid + "/" + contents
+        response = self._rest.POST(url, application.body, **kwargs)
 
         if application.application_type == ApplicationTypes.DOCUMENT:
-            request = "/api/v1/Contents('Applications'){dynamic_mid}/{contents}('{application_name}.blob')/Document/" \
-                      "Content".format(dynamic_mid=mid, contents=contents, application_name=application.name)
-            response = self._rest.PUT(request, application.content, self.BINARY_HTTP_HEADER)
+            url = format_url(
+                "/api/v1/Contents('Applications'){" + mid + "}/" + contents + "('{name}.blob')/Document/Content",
+                name=application.name)
+            response = self._rest.PUT(url, application.content, headers=self.BINARY_HTTP_HEADER, **kwargs)
 
         return response
 
-    def exists(self, path, application_type, name, private=False):
+    def exists(self, path: str, application_type: Union[str, ApplicationTypes], name: str,
+               private: bool = False, **kwargs) -> bool:
+        """ Check if application exists
+
+        :param path:
+        :param application_type:
+        :param name:
+        :param private:
+        :return:
+        """
         # raise ValueError if not a valid ApplicationType
         application_type = ApplicationTypes(application_type)
 
@@ -171,13 +194,22 @@ class ApplicationService(ObjectService):
         mid = ""
         if path.strip() != '':
             mid = "".join(["/Contents('{}')".format(element) for element in path.split('/')])
-        base_url = "/api/v1/Contents('Applications'){dynamic_mid}/{contents}('{application_name}')".format(
-            dynamic_mid=mid,
-            contents=contents,
-            application_name=name)
-        return self._exists(base_url)
 
-    def create_document_from_file(self, path_to_file, path, name, private=False):
+        url = format_url(
+            "/api/v1/Contents('Applications')" + mid + "/" + contents + "('{application_name}')",
+            application_name=name)
+        return self._exists(url, **kwargs)
+
+    def create_document_from_file(self, path_to_file: str, application_path: str, application_name: str,
+                                  private: bool = False, **kwargs) -> Response:
+        """ Create DocumentApplication in TM1 from local file
+
+        :param path_to_file:
+        :param application_path:
+        :param application_name:
+        :param private:
+        :return:
+        """
         with open(path_to_file, 'rb') as file:
-            app = DocumentApplication(path=path, name=name, content=file.read())
-            return self.create(application=app, private=private)
+            application = DocumentApplication(path=application_path, name=application_name, content=file.read())
+            return self.create(application=application, private=private, **kwargs)

--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -1051,10 +1051,10 @@ class CellService(ObjectService):
         :param kwargs:
         :return:
         """
-        url = "/api/v1/Cubes('{cube_name}')/{views}('{view_name}')/tm1.Execute".format(
-            cube_name=cube_name,
-            views='PrivateViews' if private else 'Views',
-            view_name=view_name)
+        url = format_url("/api/v1/Cubes('{cube_name}')/{views}('{view_name}')/tm1.Execute",
+                         cube_name=cube_name,
+                         views='PrivateViews' if private else 'Views',
+                         view_name=view_name)
         return self._rest.POST(url=url, **kwargs).json()['ID']
 
     def delete_cellset(self, cellset_id: str, **kwargs) -> Response:

--- a/TM1py/Services/DimensionService.py
+++ b/TM1py/Services/DimensionService.py
@@ -51,14 +51,14 @@ class DimensionService(ObjectService):
             raise e
         return response
 
-    def get(self, dimension_name: str) -> Dimension:
+    def get(self, dimension_name: str, **kwargs) -> Dimension:
         """ Get a Dimension
 
         :param dimension_name:
         :return:
         """
         url = format_url("/api/v1/Dimensions('{}')?$expand=Hierarchies($expand=*)", dimension_name)
-        response = self._rest.GET(url)
+        response = self._rest.GET(url, **kwargs)
         return Dimension.from_json(response.text)
 
     def update(self, dimension: Dimension, **kwargs):

--- a/TM1py/Services/DimensionService.py
+++ b/TM1py/Services/DimensionService.py
@@ -2,14 +2,18 @@
 
 import json
 import warnings
+from typing import List
+
+from requests import Response
 
 from TM1py.Exceptions import TM1pyException
 from TM1py.Objects.Dimension import Dimension
 from TM1py.Services.HierarchyService import HierarchyService
 from TM1py.Services.ObjectService import ObjectService
 from TM1py.Services.ProcessService import ProcessService
+from TM1py.Services.RestService import RestService
 from TM1py.Services.SubsetService import SubsetService
-from TM1py.Utils.Utils import case_and_space_insensitive_equals
+from TM1py.Utils.Utils import case_and_space_insensitive_equals, format_url, CaseAndSpaceInsensitiveSet
 
 
 class DimensionService(ObjectService):
@@ -17,12 +21,12 @@ class DimensionService(ObjectService):
     
     """
 
-    def __init__(self, rest):
+    def __init__(self, rest: RestService):
         super().__init__(rest)
         self.hierarchies = HierarchyService(rest)
         self.subsets = SubsetService(rest)
 
-    def create(self, dimension):
+    def create(self, dimension: Dimension, **kwargs) -> Response:
         """ Create a dimension
 
         :param dimension: instance of TM1py.Dimension
@@ -30,91 +34,94 @@ class DimensionService(ObjectService):
         """
         # If Dimension exists. throw Exception
         if self.exists(dimension.name):
-            raise Exception("Dimension already exists")
-        # If not all subsequent calls successfull -> undo everything that has been done in this function
+            raise RuntimeError("Dimension '{}' already exists".format(dimension.name))
+        # If not all subsequent calls successful -> undo everything that has been done in this function
         try:
             # Create Dimension, Hierarchies, Elements, Edges.
-            request = "/api/v1/Dimensions"
-            response = self._rest.POST(request, dimension.body)
+            url = "/api/v1/Dimensions"
+            response = self._rest.POST(url, dimension.body, **kwargs)
             # Create ElementAttributes
             for hierarchy in dimension:
                 if not case_and_space_insensitive_equals(hierarchy.name, "Leaves"):
-                    self.hierarchies.update(hierarchy)
+                    self.hierarchies.update(hierarchy, **kwargs)
         except TM1pyException as e:
             # undo everything if problem in step 1 or 2
-            if self.exists(dimension.name):
+            if self.exists(dimension.name, **kwargs):
                 self.delete(dimension.name)
             raise e
         return response
 
-    def get(self, dimension_name):
+    def get(self, dimension_name: str) -> Dimension:
         """ Get a Dimension
 
         :param dimension_name:
         :return:
         """
-        request = "/api/v1/Dimensions('{}')?$expand=Hierarchies($expand=*)".format(dimension_name)
-        response = self._rest.GET(request)
+        url = format_url("/api/v1/Dimensions('{}')?$expand=Hierarchies($expand=*)", dimension_name)
+        response = self._rest.GET(url)
         return Dimension.from_json(response.text)
 
-    def update(self, dimension):
+    def update(self, dimension: Dimension, **kwargs):
         """ Update an existing dimension
 
         :param dimension: instance of TM1py.Dimension
         :return: None
         """
         # delete hierarchies that have been removed from the dimension object
-        hierarchies_to_be_removed = set(self.hierarchies.get_all_names(dimension.name)) - set(dimension.hierarchy_names)
+        hierarchies_to_be_removed = CaseAndSpaceInsensitiveSet(*self.hierarchies.get_all_names(dimension.name, **kwargs))
+        for hierarchy in dimension.hierarchy_names:
+            hierarchies_to_be_removed.discard(hierarchy)
+
         for hierarchy_name in hierarchies_to_be_removed:
-            self.hierarchies.delete(dimension_name=dimension.name, hierarchy_name=hierarchy_name)
+            self.hierarchies.delete(dimension_name=dimension.name, hierarchy_name=hierarchy_name, **kwargs)
 
         # update all Hierarchies except for the implicitly maintained 'Leaves' Hierarchy
         for hierarchy in dimension:
             if not case_and_space_insensitive_equals(hierarchy.name, "Leaves"):
-                if self.hierarchies.exists(dimension_name=hierarchy.dimension_name, hierarchy_name=hierarchy.name):
-                    self.hierarchies.update(hierarchy)
+                if self.hierarchies.exists(hierarchy.dimension_name, hierarchy.name, **kwargs):
+                    self.hierarchies.update(hierarchy, **kwargs)
                 else:
-                    self.hierarchies.create(hierarchy)
+                    self.hierarchies.create(hierarchy, **kwargs)
 
-    def update_or_create(self, dimension):
+    def update_or_create(self, dimension: Dimension, **kwargs):
         """ update if exists else create
 
         :param dimension:
         :return:
         """
-        if self.exists(dimension_name=dimension.name):
+        if self.exists(dimension_name=dimension.name, **kwargs):
             return self.update(dimension=dimension)
         else:
             return self.create(dimension=dimension)
 
-    def delete(self, dimension_name):
+    def delete(self, dimension_name: str, **kwargs) -> Response:
         """ Delete a dimension
 
         :param dimension_name: Name of the dimension
         :return:
         """
-        request = '/api/v1/Dimensions(\'{}\')'.format(dimension_name)
-        return self._rest.DELETE(request)
+        url = format_url("/api/v1/Dimensions('{}')", dimension_name)
+        return self._rest.DELETE(url, **kwargs)
 
-    def exists(self, dimension_name):
+    def exists(self, dimension_name: str, **kwargs) -> bool:
         """ Check if dimension exists
         
         :return: 
         """
-        request = "/api/v1/Dimensions('{}')".format(dimension_name)
-        return self._exists(request)
+        url = format_url("/api/v1/Dimensions('{}')", dimension_name)
+        return self._exists(url, **kwargs)
 
-    def get_all_names(self):
+    def get_all_names(self, **kwargs) -> List[str]:
         """Ask TM1 Server for list with all dimension names
 
         :Returns:
             List of Strings
         """
-        response = self._rest.GET('/api/v1/Dimensions?$select=Name', '')
+        response = self._rest.GET(url='/api/v1/Dimensions?$select=Name', **kwargs)
         dimension_names = list(entry['Name'] for entry in response.json()['value'])
         return dimension_names
 
-    def execute_mdx(self, dimension_name, mdx):
+    def execute_mdx(self, dimension_name: str, mdx: str, **kwargs) -> List:
         """ Execute MDX against Dimension. 
         Requires }ElementAttributes_ Cube of the dimension to exist !
  
@@ -123,7 +130,8 @@ class DimensionService(ObjectService):
         :return: List of Element names
         """
 
-        warnings.warn("execute_mdx() will be deprecated; use ElementService execute_set_mdx.", DeprecationWarning, stacklevel=2)
+        warnings.warn("execute_mdx() will be deprecated; use ElementService execute_set_mdx.", DeprecationWarning,
+                      stacklevel=2)
 
         mdx_skeleton = "SELECT " \
                        "{} ON ROWS, " \
@@ -134,11 +142,11 @@ class DimensionService(ObjectService):
                   '$filter=Ordinal eq 1;' \
                   '$expand=Tuples($expand=Members($select=Ordinal;$expand=Element($select=Name))))'
         payload = {"MDX": mdx_full}
-        response = self._rest.POST(request, json.dumps(payload, ensure_ascii=False))
+        response = self._rest.POST(request, json.dumps(payload, ensure_ascii=False), **kwargs)
         raw_dict = response.json()
         return [row_tuple['Members'][0]['Element']['Name'] for row_tuple in raw_dict['Axes'][0]['Tuples']]
 
-    def create_element_attributes_through_ti(self, dimension):
+    def create_element_attributes_through_ti(self, dimension: Dimension, **kwargs):
         """ 
         
         :param dimension. Instance of TM1py.Objects.Dimension class
@@ -149,4 +157,4 @@ class DimensionService(ObjectService):
             statements = ["AttrInsert('{}', '', '{}', '{}');".format(dimension.name, ea.name, ea.attribute_type[0])
                           for ea
                           in h.element_attributes]
-            process_service.execute_ti_code(lines_prolog=statements)
+            process_service.execute_ti_code(lines_prolog=statements, **kwargs)

--- a/TM1py/Services/ElementService.py
+++ b/TM1py/Services/ElementService.py
@@ -74,9 +74,9 @@ class ElementService(ObjectService):
         return [Element.from_dict(element) for element in response.json()["value"]]
 
     def get_leaf_element_names(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[str]:
-        url = "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type ne 3".format(
-            dimension_name,
-            hierarchy_name)
+        url = format_url("/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type ne 3",
+                         dimension_name,
+                         hierarchy_name)
         response = self._rest.GET(url, **kwargs)
         return [e["Name"] for e in response.json()['value']]
 
@@ -387,8 +387,8 @@ class ElementService(ObjectService):
             expand_properties = ""
 
         url = f'/api/v1/ExecuteMDXSetExpression?$expand=Tuples({top}' \
-            f'$expand=Members({select_member_properties}' \
-            f'{expand_properties}))'
+              f'$expand=Members({select_member_properties}' \
+              f'{expand_properties}))'
 
         payload = {"MDX": mdx}
         response = self._rest.POST(url, json.dumps(payload, ensure_ascii=False), **kwargs)

--- a/TM1py/Services/HierarchyService.py
+++ b/TM1py/Services/HierarchyService.py
@@ -211,7 +211,7 @@ class HierarchyService(ObjectService):
         }
         return self._rest.PATCH(url=url, data=json.dumps(body), **kwargs)
 
-    def add_edges(self, dimension_name: str, hierarchy_name: str = None, edges: Dict[Tuple, int] = None,
+    def add_edges(self, dimension_name: str, hierarchy_name: str = None, edges: Dict[Tuple[str, str], int] = None,
                   **kwargs) -> Response:
         """ Add Edges to hierarchy. Fails if any edge already exists.
 

--- a/TM1py/Services/MonitoringService.py
+++ b/TM1py/Services/MonitoringService.py
@@ -1,62 +1,68 @@
 # -*- coding: utf-8 -*-
+from typing import List
+
+from requests import Response
 
 from TM1py.Objects.User import User
 from TM1py.Services.ObjectService import ObjectService
+from TM1py.Services.RestService import RestService
+from TM1py.Utils import format_url
 
 
 class MonitoringService(ObjectService):
     """ Service to Query and Cancel Threads in TM1
     
     """
-    def __init__(self, rest):
+
+    def __init__(self, rest: RestService):
         super().__init__(rest)
 
-    def get_threads(self):
+    def get_threads(self, **kwargs) -> List:
         """ Return a dict of the currently running threads from the TM1 Server
 
             :return:
                 dict: the response
         """
-        request = '/api/v1/Threads'
-        response = self._rest.GET(request)
+        url = '/api/v1/Threads'
+        response = self._rest.GET(url, **kwargs)
         return response.json()['value']
 
-    def cancel_thread(self, thread_id):
+    def cancel_thread(self, thread_id: int, **kwargs) -> Response:
         """ Kill a running thread
         
         :param thread_id: 
         :return: 
         """
-        request = "/api/v1/Threads('{}')/tm1.CancelOperation".format(thread_id)
-        response = self._rest.POST(request, '')
+        url = format_url("/api/v1/Threads('{}')/tm1.CancelOperation", str(thread_id))
+        response = self._rest.POST(url, **kwargs)
         return response
 
-    def get_active_users(self):
+    def get_active_users(self, **kwargs) -> List[User]:
         """ Get the activate users in TM1
 
         :return: List of TM1py.User instances
         """
-        request = '/api/v1/Users?$filter=IsActive eq true&$expand=Groups'
-        response = self._rest.GET(request)
+        url = '/api/v1/Users?$filter=IsActive eq true&$expand=Groups'
+        response = self._rest.GET(url, **kwargs)
         users = [User.from_dict(user) for user in response.json()['value']]
         return users
 
-    def user_is_active(self, user_name):
+    def user_is_active(self, user_name: str, **kwargs) -> bool:
         """ Check if user is currently active in TM1
 
         :param user_name:
         :return: Boolean
         """
-        request = "/api/v1/Users('{}')/IsActive".format(user_name)
-        response = self._rest.GET(request)
-        return response.json()['value']
+        url = format_url("/api/v1/Users('{}')/IsActive", user_name)
+        response = self._rest.GET(url, **kwargs)
+        return bool(response.json()['value'])
 
-    def disconnect_user(self, user_name):
+    def disconnect_user(self, user_name: str, **kwargs) -> Response:
         """ Disconnect User
         
         :param user_name: 
         :return: 
         """
-        request = "/api/v1/Users('{}')/tm1.Disconnect".format(user_name)
-        response = self._rest.POST(request)
+        url = format_url("/api/v1/Users('{}')/tm1.Disconnect", user_name)
+        response = self._rest.POST(url, **kwargs)
         return response

--- a/TM1py/Services/ObjectService.py
+++ b/TM1py/Services/ObjectService.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 
 from TM1py.Exceptions import TM1pyException
+from TM1py.Services import RestService
+from TM1py.Utils import format_url
 
 
 class ObjectService:
-    """ Parentclass for all Object Services
+    """ Parent class for all Object Services
     
     """
 
@@ -13,36 +15,39 @@ class ObjectService:
 
     BINARY_HTTP_HEADER = {'Content-Type': 'application/octet-stream; odata.streaming=true'}
 
-    def __init__(self, rest_service):
+    def __init__(self, rest_service: RestService):
         """ Constructor, Create an instance of ObjectService
         
         :param rest_service: 
         """
         self._rest = rest_service
 
-    def determine_actual_object_name(self, object_class, object_name):
-        request = "/api/v1/{}?$filter=tolower(replace(Name, ' ', '')) eq '{}'".format(
+    def determine_actual_object_name(self, object_class: str, object_name: str, **kwargs) -> str:
+        url = format_url(
+            "/api/v1/{}?$filter=tolower(replace(Name, ' ', '')) eq '{}'",
             object_class,
-            object_name.replace(" ", "").lower().replace("'", "''"))
-        response = self._rest.GET(request, odata_escape_single_quotes_in_object_names=False)
+            object_name.replace(" ", "").lower())
+        response = self._rest.GET(url, **kwargs)
+
         if len(response.json()["value"]) == 0:
             raise ValueError("Object '{}' of type '{}' doesn't exist".format(object_name, object_class))
+
         return response.json()["value"][0]["Name"]
 
-    def _exists(self, request):
-        """ Check if ressource exists in the TM1 Server
+    def _exists(self, url: str, **kwargs) -> bool:
+        """ Check if resource exists in the TM1 Server
         
-        :param request: 
+        :param url: 
         :return: 
         """
         try:
-            self._rest.GET(request)
+            self._rest.GET(url, **kwargs)
             return True
         except TM1pyException as e:
-            if e._status_code == 404:
+            if e.status_code == 404:
                 return False
             raise e
 
     @property
-    def version(self):
-        return self._rest._version
+    def version(self) -> str:
+        return self._rest.version

--- a/TM1py/Services/ProcessService.py
+++ b/TM1py/Services/ProcessService.py
@@ -236,8 +236,8 @@ class ProcessService(ObjectService):
         """
         process_name = "".join(['}TM1py', str(uuid.uuid4())])
         p = Process(name=process_name,
-                    prolog_procedure=Process.auto_generated_string + '\r\n'.join(lines_prolog),
-                    epilog_procedure=Process.auto_generated_string + '\r\n'.join(lines_epilog) if lines_epilog else '')
+                    prolog_procedure=Process.AUTO_GENERATED_STATEMENTS + '\r\n'.join(lines_prolog),
+                    epilog_procedure=Process.AUTO_GENERATED_STATEMENTS + '\r\n'.join(lines_epilog) if lines_epilog else '')
         self.create(p, **kwargs)
         try:
             return self.execute(process_name, **kwargs)

--- a/TM1py/Services/SecurityService.py
+++ b/TM1py/Services/SecurityService.py
@@ -1,10 +1,14 @@
 # -*- coding: utf-8 -*-
 
 import json
+from typing import List, Iterable
+
+from requests import Response
 
 from TM1py.Objects.User import User
 from TM1py.Services.ObjectService import ObjectService
-from TM1py.Utils.Utils import odata_escape_single_quotes_in_object_names
+from TM1py.Services.RestService import RestService
+from TM1py.Utils.Utils import format_url
 
 
 class SecurityService(ObjectService):
@@ -12,182 +16,181 @@ class SecurityService(ObjectService):
     
     """
 
-    def __init__(self, rest):
+    def __init__(self, rest: RestService):
         super().__init__(rest)
 
-    def determine_actual_user_name(self, user_name):
-        return self.determine_actual_object_name(object_class="Users", object_name=user_name)
+    def determine_actual_user_name(self, user_name: str, **kwargs) -> str:
+        return self.determine_actual_object_name(object_class="Users", object_name=user_name, **kwargs)
 
-    def determine_actual_group_name(self, group_name):
-        return self.determine_actual_object_name(object_class="Groups", object_name=group_name)
+    def determine_actual_group_name(self, group_name: str, **kwargs) -> str:
+        return self.determine_actual_object_name(object_class="Groups", object_name=group_name, **kwargs)
 
-    def create_user(self, user):
+    def create_user(self, user: User, **kwargs) -> Response:
         """ Create a user on TM1 Server
 
         :param user: instance of TM1py.User
         :return: response
         """
-        request = '/api/v1/Users'
-        return self._rest.POST(request, user.body)
+        url = '/api/v1/Users'
+        return self._rest.POST(url, user.body, **kwargs)
 
-    def create_group(self, group_name):
+    def create_group(self, group_name: str, **kwargs) -> Response:
         """ Create a Security group in the TM1 Server
 
         :param group_name:
         :return:
         """
-        request = '/api/v1/Groups'
-        return self._rest.POST(request, json.dumps({"Name": group_name}))
+        url = '/api/v1/Groups'
+        return self._rest.POST(url, json.dumps({"Name": group_name}), **kwargs)
 
-    def get_user(self, user_name):
+    def get_user(self, user_name: str, **kwargs) -> User:
         """ Get user from TM1 Server
 
         :param user_name:
         :return: instance of TM1py.User
         """
-        user_name = self.determine_actual_user_name(user_name)
-        request = "/api/v1/Users('{}')?$expand=Groups".format(user_name)
-        response = self._rest.GET(request)
+        user_name = self.determine_actual_user_name(user_name, **kwargs)
+        url = format_url("/api/v1/Users('{}')?$expand=Groups", user_name)
+        response = self._rest.GET(url, **kwargs)
         return User.from_dict(response.json())
 
-    def get_current_user(self):
+    def get_current_user(self, **kwargs) -> User:
         """ Get user and group assignments of this session
 
         :return: instance of TM1py.User
         """
-        request = "/api/v1/ActiveUser?$expand=Groups"
-        response = self._rest.GET(request)
+        url = "/api/v1/ActiveUser?$expand=Groups"
+        response = self._rest.GET(url, **kwargs)
         return User.from_dict(response.json())
 
-    def update_user(self, user):
+    def update_user(self, user: User, **kwargs) -> Response:
         """ Update user on TM1 Server
 
         :param user: instance of TM1py.User
         :return: response
         """
-        user.name = self.determine_actual_user_name(user.name)
-        for current_group in self.get_groups(user.name):
+        user.name = self.determine_actual_user_name(user.name, **kwargs)
+        for current_group in self.get_groups(user.name, **kwargs):
             if current_group not in user.groups:
-                self.remove_user_from_group(current_group, user.name)
-        request = "/api/v1/Users('{}')".format(user.name)
-        return self._rest.PATCH(request, user.body)
+                self.remove_user_from_group(current_group, user.name, **kwargs)
+        url = format_url("/api/v1/Users('{}')", user.name)
+        return self._rest.PATCH(url, user.body, **kwargs)
 
-    def delete_user(self, user_name):
+    def delete_user(self, user_name: str, **kwargs) -> Response:
         """ Delete user on TM1 Server
 
         :param user_name:
         :return: response
         """
-        user_name = self.determine_actual_user_name(user_name)
-        request = "/api/v1/Users('{}')".format(user_name)
-        return self._rest.DELETE(request)
+        user_name = self.determine_actual_user_name(user_name, **kwargs)
+        url = format_url("/api/v1/Users('{}')", user_name)
+        return self._rest.DELETE(url, **kwargs)
 
-    def delete_group(self, group_name):
+    def delete_group(self, group_name: str, **kwargs) -> Response:
         """ Delete a group in the TM1 Server
 
         :param group_name:
         :return:
         """
-        group_name = self.determine_actual_group_name(group_name)
-        request = "/api/v1/Groups('{}')".format(group_name)
-        return self._rest.DELETE(request)
+        group_name = self.determine_actual_group_name(group_name, **kwargs)
+        url = format_url("/api/v1/Groups('{}')", group_name)
+        return self._rest.DELETE(url, **kwargs)
 
-    def get_all_users(self):
+    def get_all_users(self, **kwargs):
         """ Get all users from TM1 Server
 
         :return: List of TM1py.User instances
         """
-        request = '/api/v1/Users?$expand=Groups'
-        response = self._rest.GET(request)
+        url = '/api/v1/Users?$expand=Groups'
+        response = self._rest.GET(url, **kwargs)
         users = [User.from_dict(user) for user in response.json()['value']]
         return users
 
-    def get_all_user_names(self):
+    def get_all_user_names(self, **kwargs):
         """ Get all user names from TM1 Server
 
         :return: List of TM1py.User instances
         """
-        request = '/api/v1/Users?select=Name'
-        response = self._rest.GET(request)
+        url = '/api/v1/Users?select=Name'
+        response = self._rest.GET(url, **kwargs)
         users = [user["Name"] for user in response.json()['value']]
         return users
 
-    def get_users_from_group(self, group_name):
+    def get_users_from_group(self, group_name: str, **kwargs):
         """ Get all users from group
 
         :param group_name:
         :return: List of TM1py.User instances
         """
-        request = "/api/v1/Groups('{}')?$expand=Users($expand=Groups)".format(group_name)
-        response = self._rest.GET(request)
+        url = format_url("/api/v1/Groups('{}')?$expand=Users($expand=Groups)", group_name)
+        response = self._rest.GET(url, **kwargs)
         users = [User.from_dict(user) for user in response.json()['Users']]
         return users
 
-    def get_user_names_from_group(self, group_name):
+    def get_user_names_from_group(self, group_name: str, **kwargs) -> List[str]:
         """ Get all users from group
 
         :param group_name:
         :return: List of strings
         """
-        request = "/api/v1/Groups('{}')?$expand=Users($expand=Groups)".format(group_name)
-        response = self._rest.GET(request)
+        url = format_url("/api/v1/Groups('{}')?$expand=Users($expand=Groups)", group_name)
+        response = self._rest.GET(url, **kwargs)
         users = [user["Name"] for user in response.json()['Users']]
         return users
 
-    def get_groups(self, user_name):
+    def get_groups(self, user_name: str, **kwargs) -> List[str]:
         """ Get the groups of a user in TM1 Server
 
         :param user_name:
         :return: List of strings
         """
-        user_name = self.determine_actual_user_name(user_name)
-        request = '/api/v1/Users(\'{}\')/Groups'.format(user_name)
-        response = self._rest.GET(request)
+        user_name = self.determine_actual_user_name(user_name, **kwargs)
+        url = format_url("/api/v1/Users('{}')/Groups", user_name)
+        response = self._rest.GET(url, **kwargs)
         return [group['Name'] for group in response.json()['value']]
 
-    def add_user_to_groups(self, user_name, groups):
+    def add_user_to_groups(self, user_name: str, groups: Iterable[str], **kwargs) -> Response:
         """
         
         :param user_name: name of user
         :param groups: iterable of groups
         :return: response
         """
-        user_name = self.determine_actual_user_name(user_name)
-        request = "/api/v1/Users('{}')".format(user_name)
+        user_name = self.determine_actual_user_name(user_name, **kwargs)
+        url = format_url("/api/v1/Users('{}')", user_name)
         body = {
             "Name": user_name,
             "Groups@odata.bind": [
-                odata_escape_single_quotes_in_object_names("Groups('{}')".format(
-                    self.determine_actual_group_name(group)))
+                format_url("Groups('{}')", self.determine_actual_group_name(group))
                 for group
                 in groups]
         }
-        return self._rest.PATCH(request, json.dumps(body))
+        return self._rest.PATCH(url, json.dumps(body), **kwargs)
 
-    def remove_user_from_group(self, group_name, user_name):
+    def remove_user_from_group(self, group_name: str, user_name: str, **kwargs) -> Response:
         """ Remove user from group in TM1 Server
 
         :param group_name:
         :param user_name:
         :return: response
         """
-        user_name = self.determine_actual_user_name(user_name)
-        group_name = self.determine_actual_group_name(group_name)
-        request = "/api/v1/Users('{}')/Groups?$id=Groups('{}')".format(user_name, group_name)
-        return self._rest.DELETE(request)
+        user_name = self.determine_actual_user_name(user_name, **kwargs)
+        group_name = self.determine_actual_group_name(group_name, **kwargs)
+        url = format_url("/api/v1/Users('{}')/Groups?$id=Groups('{}')", user_name, group_name)
+        return self._rest.DELETE(url, **kwargs)
 
-    def get_all_groups(self):
+    def get_all_groups(self, **kwargs) -> List[str]:
         """ Get all groups from TM1 Server
 
         :return: List of strings
         """
-        request = '/api/v1/Groups?$select=Name'
-        response = self._rest.GET(request)
+        url = '/api/v1/Groups?$select=Name'
+        response = self._rest.GET(url, **kwargs)
         groups = [entry['Name'] for entry in response.json()['value']]
         return groups
 
-    def security_refresh(self):
+    def security_refresh(self, **kwargs) -> Response:
         from TM1py.Services import ProcessService
         ti = "SecurityRefresh;"
         process_service = ProcessService(self._rest)
-        return process_service.execute_ti_code(ti)
+        return process_service.execute_ti_code(ti, **kwargs)

--- a/TM1py/Services/ServerService.py
+++ b/TM1py/Services/ServerService.py
@@ -2,10 +2,15 @@
 
 import functools
 import json
+from datetime import datetime
+from typing import Dict, Optional
 
 import pytz
+from requests import Response
 
 from TM1py.Services.ObjectService import ObjectService
+from TM1py.Services.RestService import RestService
+from TM1py.Utils import format_url
 
 
 def odata_track_changes_header(func):
@@ -33,50 +38,51 @@ class ServerService(ObjectService):
     
     """
 
-    def __init__(self, rest):
+    def __init__(self, rest: RestService):
         super().__init__(rest)
         self.tlog_last_delta_request = None
         self.mlog_last_delta_request = None
 
     @odata_track_changes_header
-    def initialize_transaction_log_delta_requests(self, filter=None):
-        request = "/api/v1/TransactionLogEntries"
+    def initialize_transaction_log_delta_requests(self, filter=None, **kwargs):
+        url = "/api/v1/TransactionLogEntries"
         if filter:
-            request += "?$filter={}".format(filter)
-        response = self._rest.GET(request=request)
+            url += "?$filter={}".format(filter)
+        response = self._rest.GET(url=url, **kwargs)
         # Read the next delta-request-url from the response
         self.tlog_last_delta_request = response.text[response.text.rfind("TransactionLogEntries/!delta('"):-2]
 
     @odata_track_changes_header
-    def execute_transaction_log_delta_request(self):
-        response = self._rest.GET(request="/api/v1/" + self.tlog_last_delta_request)
+    def execute_transaction_log_delta_request(self, **kwargs) -> Dict:
+        response = self._rest.GET(url="/api/v1/" + self.tlog_last_delta_request, **kwargs)
         self.tlog_last_delta_request = response.text[response.text.rfind("TransactionLogEntries/!delta('"):-2]
         return response.json()['value']
 
     @odata_track_changes_header
-    def initialize_message_log_delta_requests(self, filter=None):
-        request = "/api/v1/MessageLogEntries"
+    def initialize_message_log_delta_requests(self, filter=None, **kwargs):
+        url = "/api/v1/MessageLogEntries"
         if filter:
-            request += "?$filter={}".format(filter)
-        response = self._rest.GET(request=request)
+            url += "?$filter={}".format(filter)
+        response = self._rest.GET(url=url, **kwargs)
         # Read the next delta-request-url from the response
         self.mlog_last_delta_request = response.text[response.text.rfind("MessageLogEntries/!delta('"):-2]
 
     @odata_track_changes_header
-    def execute_message_log_delta_request(self):
-        response = self._rest.GET(request="/api/v1/" + self.mlog_last_delta_request)
+    def execute_message_log_delta_request(self, **kwargs) -> Dict:
+        response = self._rest.GET(url="/api/v1/" + self.mlog_last_delta_request, **kwargs)
         self.mlog_last_delta_request = response.text[response.text.rfind("MessageLogEntries/!delta('"):-2]
         return response.json()['value']
 
-    def get_message_log_entries(self, reverse=True, top=None):
+    def get_message_log_entries(self, reverse: bool = True, top: int = None, **kwargs) -> Dict:
         reverse = 'true' if reverse else 'false'
-        request = '/api/v1/MessageLog(Reverse={})'.format(reverse)
+        url = '/api/v1/MessageLog(Reverse={})'.format(reverse)
         if top:
-            request += '?$top={}'.format(top)
-        response = self._rest.GET(request, '')
+            url += '?$top={}'.format(top)
+        response = self._rest.GET(url, **kwargs)
         return response.json()['value']
 
-    def get_transaction_log_entries(self, reverse=True, user=None, cube=None, since=None, top=None):
+    def get_transaction_log_entries(self, reverse: bool = True, user: str = None, cube: str = None,
+                                    since: datetime = None, top: int = None, **kwargs) -> Dict:
         """
         
         :param reverse: 
@@ -87,105 +93,106 @@ class ServerService(ObjectService):
         :return: 
         """
         reverse = 'desc' if reverse else 'asc'
-        request = '/api/v1/TransactionLogEntries?$orderby=TimeStamp {} '.format(reverse)
+        url = '/api/v1/TransactionLogEntries?$orderby=TimeStamp {} '.format(reverse)
         # filter on user, cube and time
         if user or cube or since:
             log_filters = []
             if user:
-                log_filters.append("User eq '{}'".format(user))
+                log_filters.append(format_url("User eq '{}'", user))
             if cube:
-                log_filters.append("Cube eq '{}'".format(cube))
+                log_filters.append(format_url("Cube eq '{}'", cube))
             if since:
                 # If since doesn't have tz information, UTC is assumed
                 if not since.tzinfo:
                     since = pytz.utc.localize(since)
                 # TM1 REST API expects %Y-%m-%dT%H:%M:%SZ Format with UTC time !
                 since_utc = since.astimezone(pytz.utc)
-                log_filters.append("TimeStamp ge {}".format(since_utc.strftime("%Y-%m-%dT%H:%M:%SZ")))
-            request += "&$filter={}".format(" and ".join(log_filters))
+                log_filters.append(format_url("TimeStamp ge {}", since_utc.strftime("%Y-%m-%dT%H:%M:%SZ")))
+            url += "&$filter={}".format(" and ".join(log_filters))
         # top limit
         if top:
-            request += '&$top={}'.format(top)
-        response = self._rest.GET(request, '')
+            url += '&$top={}'.format(top)
+        response = self._rest.GET(url, **kwargs)
         return response.json()['value']
 
-    def get_last_process_message_from_messagelog(self, process_name):
-        """ Get the latest messagelog entry for a process
+    def get_last_process_message_from_messagelog(self, process_name: str, **kwargs) -> Optional[str]:
+        """ Get the latest message log entry for a process
 
             :param process_name: name of the process
             :return: String - the message, for instance: "Ausführung normal beendet, verstrichene Zeit 0.03  Sekunden"
         """
-        request = "/api/v1/MessageLog()?$orderby='TimeStamp'&$filter=Logger eq 'TM1.Process' " \
-                  "and contains( Message, '" + process_name + "')"
-        response = self._rest.GET(request=request)
+        url = format_url(
+            "/api/v1/MessageLog()?$orderby='TimeStamp'&$filter=Logger eq 'TM1.Process' and contains(Message, '{}')",
+            process_name)
+        response = self._rest.GET(url=url, **kwargs)
         response_as_list = response.json()['value']
         if len(response_as_list) > 0:
             message_log_entry = response_as_list[0]
             return message_log_entry['Message']
 
-    def get_server_name(self):
+    def get_server_name(self, **kwargs) -> str:
         """ Ask TM1 Server for its name
 
         :Returns:
             String, the server name
         """
-        request = '/api/v1/Configuration/ServerName/$value'
-        return self._rest.GET(request, '').text
+        url = '/api/v1/Configuration/ServerName/$value'
+        return self._rest.GET(url, **kwargs).text
 
-    def get_product_version(self):
+    def get_product_version(self, **kwargs) -> str:
         """ Ask TM1 Server for its version
 
         :Returns:
             String, the version
         """
-        request = '/api/v1/Configuration/ProductVersion/$value'
-        return self._rest.GET(request, '').text
+        url = '/api/v1/Configuration/ProductVersion/$value'
+        return self._rest.GET(url, **kwargs).text
 
-    def get_admin_host(self):
-        request = '/api/v1/Configuration/AdminHost/$value'
-        return self._rest.GET(request, '').text
+    def get_admin_host(self, **kwargs) -> str:
+        url = '/api/v1/Configuration/AdminHost/$value'
+        return self._rest.GET(url, **kwargs).text
 
-    def get_data_directory(self):
-        request = '/api/v1/Configuration/DataBaseDirectory/$value'
-        return self._rest.GET(request, '').text
+    def get_data_directory(self, **kwargs) -> str:
+        url = '/api/v1/Configuration/DataBaseDirectory/$value'
+        return self._rest.GET(url, **kwargs).text
 
-    def get_configuration(self):
-        request = '/api/v1/Configuration'
-        config = self._rest.GET(request, '').json()
+    def get_configuration(self, **kwargs) -> Dict:
+        url = '/api/v1/Configuration'
+        config = self._rest.GET(url, **kwargs).json()
         del config["@odata.context"]
         return config
 
-    def get_static_configuration(self):
-        """ Read current applied (!) TM1 config settings as dictionary from TM1 Server
+    def get_static_configuration(self, **kwargs) -> Dict:
+        """ Read TM1 config settings as dictionary from TM1 Server
 
         :return: config as dictionary
         """
-        request = '/api/v1/StaticConfiguration'
-        config = self._rest.GET(request, '').json()
+        url = '/api/v1/StaticConfiguration'
+        config = self._rest.GET(url, **kwargs).json()
         del config["@odata.context"]
         return config
 
-    def get_active_configuration(self):
-        """ Read current effective(!) TM1 config settings as dictionary from TM1 Server
+    def get_active_configuration(self, **kwargs) -> Dict:
+        """ Read effective(!) TM1 config settings as dictionary from TM1 Server
 
         :return: config as dictionary
         """
-        request = '/api/v1/ActiveConfiguration'
-        config = self._rest.GET(request, '').json()
+        url = '/api/v1/ActiveConfiguration'
+        config = self._rest.GET(url, **kwargs).json()
         del config["@odata.context"]
         return config
 
-    def update_static_configuration(self, configuration):
+    def update_static_configuration(self, configuration: Dict) -> Response:
         """ Update the .cfg file and triggers TM1 to re-read the file.
 
         :param configuration:
         :return: Response
         """
-        request = '/api/v1/StaticConfiguration'
-        return self._rest.PATCH(request, json.dumps(configuration))
+        url = '/api/v1/StaticConfiguration'
+        return self._rest.PATCH(url, json.dumps(configuration))
 
-    def save_data(self):
+    def save_data(self, **kwargs) -> Response:
         from TM1py.Services import ProcessService
         ti = "SaveDataAll;"
         process_service = ProcessService(self._rest)
-        process_service.execute_ti_code(ti)
+        return process_service.execute_ti_code(ti, **kwargs)

--- a/TM1py/Services/TM1Service.py
+++ b/TM1py/Services/TM1Service.py
@@ -8,13 +8,18 @@ class TM1Service:
     
     Can be saved and restored from File, to avoid multiple authentication with TM1.
     """
+
     def __init__(self, **kwargs):
-        self._tm1_rest = RESTService(**kwargs)
+        self._tm1_rest = RestService(**kwargs)
 
         # instantiate all Services
+        self.annotations = AnnotationService(self._tm1_rest)
+        self.cells = CellService(self._tm1_rest)
         self.chores = ChoreService(self._tm1_rest)
         self.cubes = CubeService(self._tm1_rest)
         self.dimensions = DimensionService(self._tm1_rest)
+        self.elements = ElementService(self._tm1_rest)
+        self.hierarchies = HierarchyService(self._tm1_rest)
         self.monitoring = MonitoringService(self._tm1_rest)
         self.power_bi = PowerBiService(self._tm1_rest)
         self.processes = ProcessService(self._tm1_rest)
@@ -22,11 +27,8 @@ class TM1Service:
         self.server = ServerService(self._tm1_rest)
         self.applications = ApplicationService(self._tm1_rest)
 
-        # Deprecated, use cubes.cells instead!
-        self.data = CellService(self._tm1_rest)
-
-    def logout(self):
-        self._tm1_rest.logout()
+    def logout(self, **kwargs):
+        self._tm1_rest.logout(**kwargs)
 
     def __enter__(self):
         return self

--- a/TM1py/Services/ViewService.py
+++ b/TM1py/Services/ViewService.py
@@ -1,11 +1,17 @@
 # -*- coding: utf-8 -*-
 
 import collections
+from typing import List, Tuple
+
+from requests import Response
 
 from TM1py.Exceptions.Exceptions import TM1pyException
+from TM1py.Objects import View
 from TM1py.Objects.MDXView import MDXView
 from TM1py.Objects.NativeView import NativeView
 from TM1py.Services.ObjectService import ObjectService
+from TM1py.Services.RestService import RestService
+from TM1py.Utils import format_url
 
 
 class ViewService(ObjectService):
@@ -13,10 +19,10 @@ class ViewService(ObjectService):
     
     """
 
-    def __init__(self, rest):
+    def __init__(self, rest: RestService):
         super().__init__(rest)
 
-    def create(self, view, private=False):
+    def create(self, view: View, private: bool = False, **kwargs) -> Response:
         """ create a new view on TM1 Server
 
         :param view: instance of subclass of TM1py.View (TM1py.NativeView or TM1py.MDXView)
@@ -25,10 +31,10 @@ class ViewService(ObjectService):
         :return: Response
         """
         view_type = "PrivateViews" if private else "Views"
-        request = "/api/v1/Cubes('{}')/{}".format(view.cube, view_type)
-        return self._rest.POST(request, view.body)
+        url = format_url("/api/v1/Cubes('{}')/{}", view.cube, view_type)
+        return self._rest.POST(url, view.body, **kwargs)
 
-    def exists(self, cube_name, view_name, private=None):
+    def exists(self, cube_name: str, view_name: str, private: bool = None, **kwargs):
         """ Checks if view exists as private, public or both
 
         :param cube_name:  string, name of the cube
@@ -37,35 +43,35 @@ class ViewService(ObjectService):
 
         :return boolean tuple
         """
-        request_template = "/api/v1/Cubes('{}')/{}('{}')"
-        if private is None:
-            view_types = collections.OrderedDict()
-            view_types['PrivateViews'] = False
-            view_types['Views'] = False
-            for view_type in view_types:
-                try:
-                    request = request_template.format(cube_name, view_type, view_name)
-                    self._rest.GET(request)
-                    view_types[view_type] = True
-                except TM1pyException as e:
-                    if e.status_code != 404:
-                        raise e
-            return tuple(view_types.values())
-        else:
-            request = request_template.format(cube_name, "PrivateViews" if private else "Views", view_name)
-            return self._exists(request)
+        url_template = "/api/v1/Cubes('{}')/{}('{}')"
+        if private is not None:
+            url = format_url(url_template, cube_name, "PrivateViews" if private else "Views", view_name)
+            return self._exists(url, **kwargs)
 
-    def get(self, cube_name, view_name, private=False):
+        view_types = collections.OrderedDict()
+        view_types['PrivateViews'] = False
+        view_types['Views'] = False
+        for view_type in view_types:
+            try:
+                url = format_url(url_template, cube_name, view_type, view_name)
+                self._rest.GET(url, **kwargs)
+                view_types[view_type] = True
+            except TM1pyException as e:
+                if e.status_code != 404:
+                    raise e
+        return tuple(view_types.values())
+
+    def get(self, cube_name: str, view_name: str, private: bool = False, **kwargs) -> View:
         view_type = "PrivateViews" if private else "Views"
-        request = "/api/v1/Cubes('{}')/{}('{}')?$expand=*".format(cube_name, view_type, view_name)
-        response = self._rest.GET(request)
+        url = format_url("/api/v1/Cubes('{}')/{}('{}')?$expand=*", cube_name, view_type, view_name)
+        response = self._rest.GET(url, **kwargs)
         view_as_dict = response.json()
         if "MDX" in view_as_dict:
             return MDXView(cube_name=cube_name, view_name=view_name, MDX=view_as_dict["MDX"])
         else:
             return self.get_native_view(cube_name=cube_name, view_name=view_name, private=private)
 
-    def get_native_view(self, cube_name, view_name, private=False):
+    def get_native_view(self, cube_name: str, view_name: str, private=False, **kwargs) -> NativeView:
         """ Get a NativeView from TM1 Server
 
         :param cube_name:  string, name of the cube
@@ -75,22 +81,24 @@ class ViewService(ObjectService):
         :return: instance of TM1py.NativeView
         """
         view_type = "PrivateViews" if private else "Views"
-        request = "/api/v1/Cubes('{}')/{}('{}')?$expand=" \
-                  "tm1.NativeView/Rows/Subset($expand=Hierarchy($select=Name;" \
-                  "$expand=Dimension($select=Name)),Elements($select=Name);" \
-                  "$select=Expression,UniqueName,Name, Alias),  " \
-                  "tm1.NativeView/Columns/Subset($expand=Hierarchy($select=Name;" \
-                  "$expand=Dimension($select=Name)),Elements($select=Name);" \
-                  "$select=Expression,UniqueName,Name,Alias), " \
-                  "tm1.NativeView/Titles/Subset($expand=Hierarchy($select=Name;" \
-                  "$expand=Dimension($select=Name)),Elements($select=Name);" \
-                  "$select=Expression,UniqueName,Name,Alias), " \
-                  "tm1.NativeView/Titles/Selected($select=Name)".format(cube_name, view_type, view_name)
-        response = self._rest.GET(request)
+        url = format_url(
+            "/api/v1/Cubes('{}')/{}('{}')?$expand="
+            "tm1.NativeView/Rows/Subset($expand=Hierarchy($select=Name;"
+            "$expand=Dimension($select=Name)),Elements($select=Name);"
+            "$select=Expression,UniqueName,Name, Alias),  "
+            "tm1.NativeView/Columns/Subset($expand=Hierarchy($select=Name;"
+            "$expand=Dimension($select=Name)),Elements($select=Name);"
+            "$select=Expression,UniqueName,Name,Alias), "
+            "tm1.NativeView/Titles/Subset($expand=Hierarchy($select=Name;"
+            "$expand=Dimension($select=Name)),Elements($select=Name);"
+            "$select=Expression,UniqueName,Name,Alias), "
+            "tm1.NativeView/Titles/Selected($select=Name)",
+            cube_name, view_type, view_name)
+        response = self._rest.GET(url, **kwargs)
         native_view = NativeView.from_json(response.text, cube_name)
         return native_view
 
-    def get_mdx_view(self, cube_name, view_name, private=False):
+    def get_mdx_view(self, cube_name: str, view_name: str, private: bool = False, **kwargs) -> MDXView:
         """ Get an MDXView from TM1 Server
 
         :param cube_name: String, name of the cube
@@ -100,12 +108,12 @@ class ViewService(ObjectService):
         :return: instance of TM1py.MDXView
         """
         view_type = 'PrivateViews' if private else 'Views'
-        request = "/api/v1/Cubes('{}')/{}('{}')?$expand=*".format(cube_name, view_type, view_name)
-        response = self._rest.GET(request)
+        url = format_url("/api/v1/Cubes('{}')/{}('{}')?$expand=*", cube_name, view_type, view_name)
+        response = self._rest.GET(url, **kwargs)
         mdx_view = MDXView.from_json(view_as_json=response.text)
         return mdx_view
 
-    def get_all(self, cube_name):
+    def get_all(self, cube_name: str, **kwargs) -> Tuple[List[View], List[View]]:
         """ Get all public and private views from cube.
 
         :param cube_name: String, name of the cube.
@@ -113,18 +121,20 @@ class ViewService(ObjectService):
         """
         private_views, public_views = [], []
         for view_type in ('PrivateViews', 'Views'):
-            request = "/api/v1/Cubes('{}')/{}?$expand=" \
-                      "tm1.NativeView/Rows/Subset($expand=Hierarchy($select=Name;" \
-                      "$expand=Dimension($select=Name)),Elements($select=Name);" \
-                      "$select=Expression,UniqueName,Name, Alias),  " \
-                      "tm1.NativeView/Columns/Subset($expand=Hierarchy($select=Name;" \
-                      "$expand=Dimension($select=Name)),Elements($select=Name);" \
-                      "$select=Expression,UniqueName,Name,Alias), " \
-                      "tm1.NativeView/Titles/Subset($expand=Hierarchy($select=Name;" \
-                      "$expand=Dimension($select=Name)),Elements($select=Name);" \
-                      "$select=Expression,UniqueName,Name,Alias), " \
-                      "tm1.NativeView/Titles/Selected($select=Name)".format(cube_name, view_type)
-            response = self._rest.GET(request)
+            url = format_url(
+                "/api/v1/Cubes('{}')/{}?$expand="
+                "tm1.NativeView/Rows/Subset($expand=Hierarchy($select=Name;"
+                "$expand=Dimension($select=Name)),Elements($select=Name);"
+                "$select=Expression,UniqueName,Name, Alias),  "
+                "tm1.NativeView/Columns/Subset($expand=Hierarchy($select=Name;"
+                "$expand=Dimension($select=Name)),Elements($select=Name);"
+                "$select=Expression,UniqueName,Name,Alias), "
+                "tm1.NativeView/Titles/Subset($expand=Hierarchy($select=Name;"
+                "$expand=Dimension($select=Name)),Elements($select=Name);"
+                "$select=Expression,UniqueName,Name,Alias), "
+                "tm1.NativeView/Titles/Selected($select=Name)",
+                cube_name, view_type)
+            response = self._rest.GET(url, **kwargs)
             response_as_list = response.json()['value']
             for view_as_dict in response_as_list:
                 if view_as_dict['@odata.type'] == '#ibm.tm1.api.v1.MDXView':
@@ -137,7 +147,7 @@ class ViewService(ObjectService):
                     public_views.append(view)
         return private_views, public_views
 
-    def get_all_names(self, cube_name):
+    def get_all_names(self, cube_name: str, **kwargs) -> Tuple[List[str], List[str]]:
         """
         
         :param cube_name: 
@@ -145,17 +155,19 @@ class ViewService(ObjectService):
         """
         private_views, public_views = [], []
         for view_type in ('PrivateViews', 'Views'):
-            request = "/api/v1/Cubes('{}')/{}?$select=Name".format(cube_name, view_type)
-            response = self._rest.GET(request)
+            url = format_url("/api/v1/Cubes('{}')/{}?$select=Name", cube_name, view_type)
+            response = self._rest.GET(url, **kwargs)
             response_as_list = response.json()['value']
+
             for view in response_as_list:
                 if view_type == "PrivateViews":
                     private_views.append(view['Name'])
                 else:
                     public_views.append(view['Name'])
+
         return private_views, public_views
 
-    def update(self, view, private=False):
+    def update(self, view: View, private: bool = False, **kwargs) -> Response:
         """ Update an existing view
 
         :param view: instance of TM1py.NativeView or TM1py.MDXView
@@ -163,11 +175,11 @@ class ViewService(ObjectService):
         :return: response
         """
         view_type = 'PrivateViews' if private else 'Views'
-        request = "/api/v1/Cubes('{}')/{}('{}')".format(view.cube, view_type, view.name)
-        response = self._rest.PATCH(request, view.body)
+        url = format_url("/api/v1/Cubes('{}')/{}('{}')", view.cube, view_type, view.name)
+        response = self._rest.PATCH(url, view.body, **kwargs)
         return response
 
-    def delete(self, cube_name, view_name, private=False):
+    def delete(self, cube_name: str, view_name: str, private: bool = False, **kwargs) -> Response:
         """ Delete an existing view (MDXView or NativeView) on the TM1 Server
 
         :param cube_name: String, name of the cube
@@ -177,6 +189,6 @@ class ViewService(ObjectService):
         :return: String, the response
         """
         view_type = 'PrivateViews' if private else 'Views'
-        request = "/api/v1/Cubes('{}')/{}('{}')".format(cube_name, view_type, view_name)
-        response = self._rest.DELETE(request)
+        url = format_url("/api/v1/Cubes('{}')/{}('{}')", cube_name, view_type, view_name)
+        response = self._rest.DELETE(url, **kwargs)
         return response

--- a/TM1py/Services/ViewService.py
+++ b/TM1py/Services/ViewService.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import collections
-from typing import List, Tuple
+from typing import List, Tuple, Union
 
 from requests import Response
 
@@ -22,7 +22,7 @@ class ViewService(ObjectService):
     def __init__(self, rest: RestService):
         super().__init__(rest)
 
-    def create(self, view: View, private: bool = False, **kwargs) -> Response:
+    def create(self, view: Union[MDXView, NativeView], private: bool = False, **kwargs) -> Response:
         """ create a new view on TM1 Server
 
         :param view: instance of subclass of TM1py.View (TM1py.NativeView or TM1py.MDXView)
@@ -167,7 +167,7 @@ class ViewService(ObjectService):
 
         return private_views, public_views
 
-    def update(self, view: View, private: bool = False, **kwargs) -> Response:
+    def update(self, view: Union[MDXView, NativeView], private: bool = False, **kwargs) -> Response:
         """ Update an existing view
 
         :param view: instance of TM1py.NativeView or TM1py.MDXView

--- a/TM1py/Services/__init__.py
+++ b/TM1py/Services/__init__.py
@@ -1,4 +1,3 @@
-from TM1py.Services.ObjectService import ObjectService
 from TM1py.Services.AnnotationService import AnnotationService
 from TM1py.Services.ApplicationService import ApplicationService
 from TM1py.Services.CellService import CellService
@@ -10,7 +9,7 @@ from TM1py.Services.HierarchyService import HierarchyService
 from TM1py.Services.MonitoringService import MonitoringService
 from TM1py.Services.PowerBiService import PowerBiService
 from TM1py.Services.ProcessService import ProcessService
-from TM1py.Services.RESTService import RESTService
+from TM1py.Services.RestService import RestService
 from TM1py.Services.SecurityService import SecurityService
 from TM1py.Services.ServerService import ServerService
 from TM1py.Services.SubsetService import SubsetService

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -1,17 +1,16 @@
 import collections
 import json
-import re
 import sys
 import warnings
+from typing import Dict
 
 import pandas as pd
+
 
 if sys.version[0] == '2':
     import httplib as http_client
 else:
     import http.client as http_client
-
-REGEX_OBJECT_NAMES = re.compile(r"(?<!\()(?<!eq )'(?!\)|\Z)")
 
 
 def get_all_servers_from_adminhost(adminhost='localhost'):
@@ -34,23 +33,22 @@ def get_all_servers_from_adminhost(adminhost='localhost'):
     return servers
 
 
-def odata_escape_single_quotes_in_object_names(url):
-    """ escape characters that need to be escaped in odata references like:
-    `Dimensions('dimension')/Hierarchies('hierarchy')/Elements('elem'ent')`
-    to
-    `Dimensions('dimension')/Hierarchies('hierarchy')/Elements('elem''ent')`
+def format_url(url, *args, **kwargs):
+    """ build url and escape single quotes in args and kwargs
 
-    :param url:
+    :param url: url with {} placeholders
+    :param args: arguments to placeholders
     :return:
     """
-    # escape ' as '' inside single-quoted string
-    index = 0
-    escaped_url = ""
-    for m in REGEX_OBJECT_NAMES.finditer(string=url):
-        escaped_url += url[index:m.start()] + m.group(0).replace("'", "''")
-        index = m.end()
-    escaped_url += url[index:]
-    return escaped_url
+    args = [arg.replace("'", "''") if isinstance(arg, str) else arg
+            for arg
+            in args]
+
+    kwargs = {key: value.replace("'", "''") if isinstance(value, str) else value
+              for key, value
+              in kwargs.items()}
+
+    return url.format(*args, **kwargs)
 
 
 def case_and_space_insensitive_equals(item1, item2):
@@ -92,7 +90,7 @@ def sort_coordinates(cube_dimensions, unsorted_coordinates):
     return tuple(sorted_coordinates)
 
 
-def build_content_from_cellset(raw_cellset_as_dict, top=None):
+def build_content_from_cellset(raw_cellset_as_dict: Dict, top=None) -> 'CaseAndSpaceInsensitiveTuplesDict':
     """ transform raw cellset data into concise dictionary
 
     :param raw_cellset_as_dict:

--- a/TM1py/__init__.py
+++ b/TM1py/__init__.py
@@ -6,7 +6,7 @@ https://github.com/cubewise-code/TM1py
 TM1py wraps the TM1 REST API into concise Python classes and Services that simplify TM1 interactions from python.
 
 Usage:
->>> with RESTService(address='', port=8001, user='admin', password='apple', ssl=False) as tm1_rest:
+>>> with RestService(address='', port=8001, user='admin', password='apple', ssl=False) as tm1_rest:
 >>>     subset_service = SubsetService(tm1_rest)
 >>>     subset = Subset(dimension_name='Month', subset_name='Q1', elements=['Jan', 'Feb', 'Mar'])
 >>>     subset_service.create(subset, private=True)
@@ -17,7 +17,7 @@ Usage:
 # __init__ can hoist attributes from submodules into higher namespaces for convenience
 
 from TM1py.Services.ObjectService import ObjectService
-from TM1py.Services.RESTService import RESTService
+from TM1py.Services.RestService import RestService
 from TM1py.Services.TM1Service import TM1Service
 from TM1py.Services.AnnotationService import AnnotationService
 from TM1py.Services.ApplicationService import ApplicationService

--- a/Tests/Annotation.py
+++ b/Tests/Annotation.py
@@ -1,9 +1,9 @@
 import configparser
 import json
-from pathlib import Path
 import random
 import string
 import unittest
+from pathlib import Path
 
 from TM1py import Element, Hierarchy, Dimension, Cube
 from TM1py.Objects import Annotation
@@ -11,6 +11,7 @@ from TM1py.Services import TM1Service
 
 config = configparser.ConfigParser()
 config.read(Path(__file__).parent.joinpath('config.ini'))
+
 
 class TestAnnotationMethods(unittest.TestCase):
     tm1 = TM1Service(**config['tm1srv01'])

--- a/Tests/Application.py
+++ b/Tests/Application.py
@@ -1,7 +1,7 @@
 import configparser
-from pathlib import Path
 import random
 import unittest
+from pathlib import Path
 
 from _datetime import datetime
 
@@ -214,7 +214,7 @@ class TestDataMethods(unittest.TestCase):
         self.run_test_dimension_application(private=False)
 
     def run_test_document_application(self, private):
-        with open(Path(__file__).parent.joinpath('resources','document.xlsx'), "rb") as file:
+        with open(Path(__file__).parent.joinpath('resources', 'document.xlsx'), "rb") as file:
             app = DocumentApplication(path=TM1PY_APP_FOLDER, name=DOCUMENT_NAME, content=file.read())
             self.tm1.applications.create(application=app, private=private)
 

--- a/Tests/Dimension.py
+++ b/Tests/Dimension.py
@@ -143,6 +143,9 @@ class TestDimensionMethods(unittest.TestCase):
         dimension = self.tm1.dimensions.get(DIMENSION_NAME)
         self.assertEqual(len(dimension.hierarchies[0].elements), len(elements))
 
+    def test_update_dimension_remove_hierarchy(self):
+        pass
+
     def test_get_all_names(self):
         self.assertIn(DIMENSION_NAME, self.tm1.dimensions.get_all_names())
 

--- a/Tests/Dimension.py
+++ b/Tests/Dimension.py
@@ -1,6 +1,6 @@
 import configparser
-from pathlib import Path
 import unittest
+from pathlib import Path
 
 from TM1py.Objects import Dimension, Hierarchy, Element
 from TM1py.Objects import ElementAttribute
@@ -144,7 +144,14 @@ class TestDimensionMethods(unittest.TestCase):
         self.assertEqual(len(dimension.hierarchies[0].elements), len(elements))
 
     def test_update_dimension_remove_hierarchy(self):
-        pass
+        self.create_dimension_with_multiple_hierarchies()
+        dimension = self.tm1.dimensions.get(DIMENSION_NAME_WITH_MULTI_HIERARCHY)
+        self.assertEqual(dimension.hierarchy_names, ['Hierarchy1', 'Hierarchy2', 'Hierarchy3', 'Leaves'])
+        dimension.remove_hierarchy('Hierarchy2')
+        dimension.remove_hierarchy('Hierarchy3')
+        self.tm1.dimensions.update(dimension)
+        dimension = self.tm1.dimensions.get(DIMENSION_NAME_WITH_MULTI_HIERARCHY)
+        self.assertEqual(dimension.hierarchy_names, ['Hierarchy1', 'Leaves'])
 
     def test_get_all_names(self):
         self.assertIn(DIMENSION_NAME, self.tm1.dimensions.get_all_names())

--- a/Tests/PowerBiService.py
+++ b/Tests/PowerBiService.py
@@ -137,7 +137,7 @@ class TestPowerBiService(unittest.TestCase):
         for attribute in cls.alias_attributes:
             h.add_element_attribute(attribute, "Alias")
         d.add_hierarchy(h)
-        cls.tm1.dimensions.create(d)
+        cls.tm1.dimensions.update_or_create(d)
 
         # write attribute values
         cls.tm1.cubes.cells.write_value('1988', '}ElementAttributes_' + DIMENSION_NAME, ('1989', 'Previous Year'))

--- a/Tests/Process.py
+++ b/Tests/Process.py
@@ -1,10 +1,10 @@
 import configparser
 import copy
-from pathlib import Path
 import random
 import time
 import unittest
 import uuid
+from pathlib import Path
 
 from TM1py.Objects import Process
 from TM1py.Objects import Subset
@@ -17,6 +17,7 @@ PROCESS_PREFIX = 'TM1py_Tests_'
 
 
 class TestProcessMethods(unittest.TestCase):
+    tm1 = None
 
     @classmethod
     def setUpClass(cls):
@@ -233,7 +234,6 @@ class TestProcessMethods(unittest.TestCase):
         self.assertEqual(status, "Aborted")
         self.assertIsNotNone(error_log_file)
 
-
     def test_execute_process_with_return_with_item_reject(self):
         process = Process(name=str(uuid.uuid4()))
         process.epilog_procedure = "ItemReject('Not Relevant');"
@@ -242,7 +242,6 @@ class TestProcessMethods(unittest.TestCase):
         self.assertFalse(success)
         self.assertEqual(status, "CompletedWithMessages")
         self.assertIsNotNone(error_log_file)
-
 
     def test_execute_process_with_return_with_process_break(self):
         process = Process(name=str(uuid.uuid4()))
@@ -253,7 +252,6 @@ class TestProcessMethods(unittest.TestCase):
         self.assertEqual(status, "CompletedSuccessfully")
         self.assertIsNone(error_log_file)
 
-
     def test_execute_process_with_return_with_process_quit(self):
         process = Process(name=str(uuid.uuid4()))
         process.prolog_procedure = "sText = 'Something'; ProcessQuit;"
@@ -262,7 +260,6 @@ class TestProcessMethods(unittest.TestCase):
         self.assertFalse(success)
         self.assertEqual(status, "QuitCalled")
         self.assertIsNone(error_log_file)
-
 
     def test_compile_process_success(self):
         p_good = Process(
@@ -277,7 +274,7 @@ class TestProcessMethods(unittest.TestCase):
             name=str(uuid.uuid4()),
             prolog_procedure="nPro = DimSize('}Processes');")
 
-        errors = self.tm1.processes.compile_process(p_bad.name)
+        errors = self.tm1.processes.compile_process(p_bad)
         self.assertTrue(len(errors) == 1)
         self.assertIn("Variable \"dimsize\" is undefined", errors[0]["Message"])
 

--- a/Tests/View.py
+++ b/Tests/View.py
@@ -49,7 +49,7 @@ class TestViewMethods(unittest.TestCase):
             element2 = 'Element ' + str(random.randint(1, 1000))
             element3 = 'Element ' + str(random.randint(1, 1000))
             cellset[(element1, element2, element3)] = random.randint(1, 1000)
-        cls.tm1.data.write_values(CUBE_NAME, cellset)
+        cls.tm1.cells.write_values(CUBE_NAME, cellset)
 
     def setUp(self):
         for private in (True, False):
@@ -206,7 +206,7 @@ class TestViewMethods(unittest.TestCase):
                 view_name=self.native_view_name,
                 private=private)
             # Sum up all the values from the views
-            data_original = self.tm1.data.execute_view(
+            data_original = self.tm1.cells.execute_view(
                 cube_name=CUBE_NAME,
                 view_name=self.native_view_name,
                 private=private)

--- a/Tests/View.py
+++ b/Tests/View.py
@@ -227,7 +227,7 @@ class TestViewMethods(unittest.TestCase):
                 view=native_view_original,
                 private=private)
             # Get it and check if its different
-            data_updated = self.tm1.data.execute_view(
+            data_updated = self.tm1.cells.execute_view(
                 cube_name=CUBE_NAME,
                 view_name=self.native_view_name,
                 private=private)
@@ -244,7 +244,7 @@ class TestViewMethods(unittest.TestCase):
                 view_name=self.mdx_view_name,
                 private=private)
             # Get data from mdx view
-            data_mdx_original = self.tm1.data.execute_view(
+            data_mdx_original = self.tm1.cells.execute_view(
                 cube_name=CUBE_NAME,
                 view_name=mdx_view_original.name,
                 private=private)
@@ -262,7 +262,7 @@ class TestViewMethods(unittest.TestCase):
                 cube_name=CUBE_NAME,
                 view_name=self.mdx_view_name,
                 private=private)
-            data_mdx_updated = self.tm1.data.execute_view(
+            data_mdx_updated = self.tm1.cells.execute_view(
                 cube_name=CUBE_NAME,
                 view_name=mdx_view_updated.name,
                 private=private)


### PR DESCRIPTION
- new `build_url` method to create url from format string + args, kwargs. Escape single quotes inside args, kwargs
- rename `request` variable to `url` in all services
- introduce `timeout` argument to all service methods through `**kwargs`
- add type hints to all methods in TM1py
- apply new `format_url` methods to URL in Odata JSON representations of TM1 objects.

Fixes #210
Fixes #117	


