### PR TITLE
Cast the timeout dict value to int

### DIFF
--- a/TM1py/Services/RESTService.py
+++ b/TM1py/Services/RESTService.py
@@ -94,7 +94,7 @@ class RESTService:
         self._address = kwargs.get('address', None)
         self._port = kwargs.get('port', None)
         self._verify = False
-        self._timeout = kwargs.get('timeout', None)
+        self._timeout = int(kwargs.get('timeout', None))
 
         if 'verify' in kwargs:
             if isinstance(kwargs['verify'], str):

--- a/TM1py/Services/RESTService.py
+++ b/TM1py/Services/RESTService.py
@@ -94,7 +94,7 @@ class RESTService:
         self._address = kwargs.get('address', None)
         self._port = kwargs.get('port', None)
         self._verify = False
-        self._timeout = int(kwargs.get('timeout', None))
+        self._timeout = None if kwargs.get('timeout', None) is None else int( kwargs.get('timeout'))
 
         if 'verify' in kwargs:
             if isinstance(kwargs['verify'], str):


### PR DESCRIPTION
Configparser returns values as string by default, so using timeout in server configuration in the config file will throw an type error in urllib3, with timeout being neither int or float, like this:
  File "site-packages\urllib3\util\timeout.py", line 140, in _validate_timeout
TypeError: '<=' not supported between instances of 'str' and 'int'