### PR TITLE
Fix redundant calls in dimension update and create

### DIFF
--- a/TM1py/Objects/Hierarchy.py
+++ b/TM1py/Objects/Hierarchy.py
@@ -40,7 +40,7 @@ class Hierarchy(TM1Object):
             dimension_name: str,
             elements: Optional[Iterable['Element']] = None,
             element_attributes: Optional[Iterable['ElementAttribute']] = None,
-            edges: Optional['CaseAndSpaceInsensitiveTuplesDict'] = None,
+            edges: Optional['Dict'] = None,
             subsets: Optional[Iterable[str]] = None,
             structure: Optional[int] = None,
             default_member: Optional[str] = None):

--- a/TM1py/Services/DimensionService.py
+++ b/TM1py/Services/DimensionService.py
@@ -43,7 +43,7 @@ class DimensionService(ObjectService):
             # Create ElementAttributes
             for hierarchy in dimension:
                 if not case_and_space_insensitive_equals(hierarchy.name, "Leaves"):
-                    self.hierarchies.update(hierarchy, **kwargs)
+                    self.hierarchies.update_element_attributes(hierarchy, **kwargs)
         except TM1pyException as e:
             # undo everything if problem in step 1 or 2
             if self.exists(dimension.name, **kwargs):
@@ -68,7 +68,8 @@ class DimensionService(ObjectService):
         :return: None
         """
         # delete hierarchies that have been removed from the dimension object
-        hierarchies_to_be_removed = CaseAndSpaceInsensitiveSet(*self.hierarchies.get_all_names(dimension.name, **kwargs))
+        hierarchies_to_be_removed = CaseAndSpaceInsensitiveSet(
+            *self.hierarchies.get_all_names(dimension.name, **kwargs))
         for hierarchy in dimension.hierarchy_names:
             hierarchies_to_be_removed.discard(hierarchy)
 

--- a/TM1py/Services/HierarchyService.py
+++ b/TM1py/Services/HierarchyService.py
@@ -82,7 +82,7 @@ class HierarchyService(ObjectService):
         responses.append(self._rest.PATCH(url, json.dumps(hierarchy_body), **kwargs))
 
         # 2. Update Attributes
-        responses.append(self._update_element_attributes(hierarchy=hierarchy, **kwargs))
+        responses.append(self.update_element_attributes(hierarchy=hierarchy, **kwargs))
 
         # Workaround EDGES
         if self.version[0:8] in self.EDGES_WORKAROUND_VERSIONS:
@@ -126,7 +126,7 @@ class HierarchyService(ObjectService):
                 for hierarchy_property
                 in hierarchy_properties}
 
-    def _update_element_attributes(self, hierarchy: Hierarchy, **kwargs):
+    def update_element_attributes(self, hierarchy: Hierarchy, **kwargs):
         """ Update the elementattributes of a hierarchy
 
         :param hierarchy: Instance of TM1py.Hierarchy


### PR DESCRIPTION
build dimension, hierarchies, elements, edges with one call.
Then create ElementeAttributes in a seperate call without updating Elements, Edges.