### PR TITLE
Introduce `ibm_cloud_mode` to Tm1Service

### DIFF
--- a/TM1py/Objects/Process.py
+++ b/TM1py/Objects/Process.py
@@ -85,7 +85,11 @@ class Process(TM1Object):
         self._ui_data = ui_data
         self._parameters = list(parameters) if parameters else []
         self._variables = list(variables) if variables else []
-        self._variables_ui_data = list(variables_ui_data) if variables_ui_data else []
+        if variables_ui_data:
+            # Handle encoding issue in variable_ui_data for async requests
+            self._variables_ui_data = [entry.replace("€", "\f") for entry in variables_ui_data]
+        else:
+            self._variables_ui_data = []
         self._prolog_procedure = Process.add_generated_string_to_code(prolog_procedure)
         self._metadata_procedure = Process.add_generated_string_to_code(metadata_procedure)
         self._data_procedure = Process.add_generated_string_to_code(data_procedure)

--- a/TM1py/Services/ChoreService.py
+++ b/TM1py/Services/ChoreService.py
@@ -91,7 +91,7 @@ class ChoreService(ObjectService):
             self.activate(chore.name)
         return response
 
-    def delete(self, chore_name: str) -> Response:
+    def delete(self, chore_name: str, **kwargs) -> Response:
         """ delete chore in TM1
         :param chore_name:
         :return: response
@@ -100,14 +100,14 @@ class ChoreService(ObjectService):
         response = self._rest.DELETE(url)
         return response
 
-    def exists(self, chore_name: str) -> bool:
+    def exists(self, chore_name: str, **kwargs) -> bool:
         """ Check if Chore exists
 
         :param chore_name:
         :return:
         """
         url = format_url("/api/v1/Chores('{}')", chore_name)
-        return self._exists(url)
+        return self._exists(url, **kwargs)
 
     @deactivate_activate
     def update(self, chore: Chore, **kwargs):

--- a/TM1py/Services/DimensionService.py
+++ b/TM1py/Services/DimensionService.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 import json
 import warnings
 from typing import List
@@ -91,9 +90,9 @@ class DimensionService(ObjectService):
         :return:
         """
         if self.exists(dimension_name=dimension.name, **kwargs):
-            return self.update(dimension=dimension)
+            return self.update(dimension=dimension, **kwargs)
         else:
-            return self.create(dimension=dimension)
+            return self.create(dimension=dimension, **kwargs)
 
     def delete(self, dimension_name: str, **kwargs) -> Response:
         """ Delete a dimension

--- a/Tests/RestService.py
+++ b/Tests/RestService.py
@@ -1,0 +1,74 @@
+import configparser
+import unittest
+from pathlib import Path
+
+from requests import Response
+
+from TM1py import TM1Service
+from TM1py.Services.RestService import RestService
+
+config = configparser.ConfigParser()
+config.read(Path(__file__).parent.joinpath('config.ini'))
+
+
+class TestRestServiceMethods(unittest.TestCase):
+    tm1 = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tm1 = TM1Service(**config['tm1srv01'])
+
+    def test_wait_time_generator_with_timeout(self):
+        self.assertEqual(
+            [0.1, 0.3, 0.6, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+            list(self.tm1._tm1_rest.wait_time_generator(10)))
+        self.assertEqual(sum(self.tm1._tm1_rest.wait_time_generator(10)), 10)
+
+    def test_wait_time_generator_without_timeout(self):
+        generator = self.tm1._tm1_rest.wait_time_generator(None)
+        self.assertEqual(0.1, next(generator))
+        self.assertEqual(0.3, next(generator))
+        self.assertEqual(0.6, next(generator))
+        self.assertEqual(1, next(generator))
+        self.assertEqual(1, next(generator))
+
+    def test_build_response_from_async_response_ok(self):
+        response = Response()
+        response._content = b'HTTP/1.1 200 OK\r\nContent-Length: 32\r\nConnection: keep-alive\r\nContent-Encoding: ' \
+                            b'gzip\r\nCache-Control: no-cache\r\nContent-Type: text/plain; charset=utf-8\r\n' \
+                            b'OData-Version: 4.0\r\n\r\n\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x0b34\xd43\xd730000' \
+                            b'\xd23\x04\x00\xf4\x1c\xa0j\x0c\x00\x00\x00'
+        response = RestService.build_response_from_async_response(response=response)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers.get("Content-Length"), "32")
+        self.assertEqual(response.headers.get("Connection"), "keep-alive")
+        self.assertEqual(response.headers.get("Content-Encoding"), "gzip")
+        self.assertEqual(response.headers.get("Cache-Control"), "no-cache")
+        self.assertEqual(response.headers.get("Content-Type"), "text/plain; charset=utf-8")
+        self.assertEqual(response.headers.get("OData-Version"), "4.0")
+        self.assertEqual(response.text, "11.7.00002.1")
+
+    def test_build_response_from_async_response_not_found(self):
+        response = Response()
+        response._content = b'HTTP/1.1 404 Not Found\r\nContent-Length: 105\r\nConnection: keep-alive\r\n' \
+                            b'Content-Encoding: gzip\r\nCache-Control: no-cache\r\n' \
+                            b'Content-Type: application/json; charset=utf-8\r\nOData-Version: 4.0\r\n' \
+                            b'\r\n\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x0b\x15\xc71\n\x800\x0c\x05\xd0\xab|\xb2t\x11' \
+                            b'\x07\x17\xc5Sx\x05M\xa3\x14\xdaD\xda:\x94\xe2\xdd\xc5\xb7\xbdN\x92\xb3eZ;\xb1y\xa1\x95' \
+                            b'\xa6y\xa1\x81\x92\x94\xb2_\xff\x9d\x7fRj\x0e\xbc+\xd4*\x0e\xc1i\x8fz\x04\x05[\x8c\xc25' \
+                            b'\x98\xc2N\xd4v\x0b\xdc\x96\x8d\xa5\x147\xd2\xfb~Od\xf8E^\x00\x00\x00'
+        response = RestService.build_response_from_async_response(response=response)
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.headers.get("Content-Length"), "105")
+        self.assertEqual(response.headers.get("Connection"), "keep-alive")
+        self.assertEqual(response.headers.get("Content-Encoding"), "gzip")
+        self.assertEqual(response.headers.get("Cache-Control"), "no-cache")
+        self.assertEqual(response.headers.get("Content-Type"), "application/json; charset=utf-8")
+        self.assertEqual(response.headers.get("OData-Version"), "4.0")
+        self.assertEqual(
+            response.text,
+            "{\"error\":{\"code\":\"278\",\"message\":\"\'dummy\' can not be found in collection of type \'Process\'.\"}}")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.tm1.logout()

--- a/Tests/RestService.py
+++ b/Tests/RestService.py
@@ -2,8 +2,6 @@ import configparser
 import unittest
 from pathlib import Path
 
-from requests import Response
-
 from TM1py import TM1Service
 from TM1py.Services.RestService import RestService
 
@@ -33,12 +31,11 @@ class TestRestServiceMethods(unittest.TestCase):
         self.assertEqual(1, next(generator))
 
     def test_build_response_from_async_response_ok(self):
-        response = Response()
-        response._content = b'HTTP/1.1 200 OK\r\nContent-Length: 32\r\nConnection: keep-alive\r\nContent-Encoding: ' \
-                            b'gzip\r\nCache-Control: no-cache\r\nContent-Type: text/plain; charset=utf-8\r\n' \
-                            b'OData-Version: 4.0\r\n\r\n\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x0b34\xd43\xd730000' \
-                            b'\xd23\x04\x00\xf4\x1c\xa0j\x0c\x00\x00\x00'
-        response = RestService.build_response_from_async_response(response=response)
+        response_content = b'HTTP/1.1 200 OK\r\nContent-Length: 32\r\nConnection: keep-alive\r\nContent-Encoding: ' \
+                           b'gzip\r\nCache-Control: no-cache\r\nContent-Type: text/plain; charset=utf-8\r\n' \
+                           b'OData-Version: 4.0\r\n\r\n\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x0b34\xd43\xd730000' \
+                           b'\xd23\x04\x00\xf4\x1c\xa0j\x0c\x00\x00\x00'
+        response = RestService.build_response_from_raw_bytes(response_content)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.headers.get("Content-Length"), "32")
         self.assertEqual(response.headers.get("Connection"), "keep-alive")
@@ -49,15 +46,14 @@ class TestRestServiceMethods(unittest.TestCase):
         self.assertEqual(response.text, "11.7.00002.1")
 
     def test_build_response_from_async_response_not_found(self):
-        response = Response()
-        response._content = b'HTTP/1.1 404 Not Found\r\nContent-Length: 105\r\nConnection: keep-alive\r\n' \
-                            b'Content-Encoding: gzip\r\nCache-Control: no-cache\r\n' \
-                            b'Content-Type: application/json; charset=utf-8\r\nOData-Version: 4.0\r\n' \
-                            b'\r\n\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x0b\x15\xc71\n\x800\x0c\x05\xd0\xab|\xb2t\x11' \
-                            b'\x07\x17\xc5Sx\x05M\xa3\x14\xdaD\xda:\x94\xe2\xdd\xc5\xb7\xbdN\x92\xb3eZ;\xb1y\xa1\x95' \
-                            b'\xa6y\xa1\x81\x92\x94\xb2_\xff\x9d\x7fRj\x0e\xbc+\xd4*\x0e\xc1i\x8fz\x04\x05[\x8c\xc25' \
-                            b'\x98\xc2N\xd4v\x0b\xdc\x96\x8d\xa5\x147\xd2\xfb~Od\xf8E^\x00\x00\x00'
-        response = RestService.build_response_from_async_response(response=response)
+        response_content = b'HTTP/1.1 404 Not Found\r\nContent-Length: 105\r\nConnection: keep-alive\r\n' \
+                           b'Content-Encoding: gzip\r\nCache-Control: no-cache\r\n' \
+                           b'Content-Type: application/json; charset=utf-8\r\nOData-Version: 4.0\r\n' \
+                           b'\r\n\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x0b\x15\xc71\n\x800\x0c\x05\xd0\xab|\xb2t\x11' \
+                           b'\x07\x17\xc5Sx\x05M\xa3\x14\xdaD\xda:\x94\xe2\xdd\xc5\xb7\xbdN\x92\xb3eZ;\xb1y\xa1\x95' \
+                           b'\xa6y\xa1\x81\x92\x94\xb2_\xff\x9d\x7fRj\x0e\xbc+\xd4*\x0e\xc1i\x8fz\x04\x05[\x8c\xc25' \
+                           b'\x98\xc2N\xd4v\x0b\xdc\x96\x8d\xa5\x147\xd2\xfb~Od\xf8E^\x00\x00\x00'
+        response = RestService.build_response_from_raw_bytes(response_content)
         self.assertEqual(response.status_code, 404)
         self.assertEqual(response.headers.get("Content-Length"), "105")
         self.assertEqual(response.headers.get("Connection"), "keep-alive")

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-SCHEDULE_VERSION = '1.4.1'
+SCHEDULE_VERSION = '1.5.0'
 SCHEDULE_DOWNLOAD_URL = (
         'https://github.com/Cubewise-code/TM1py/tarball/' + SCHEDULE_VERSION
 )


### PR DESCRIPTION
When TM1 is hosted in the IBM cloud, there is a hard constraint that incoming REST requests time out after 60 seconds. 
So far the only way to work around this constraint with TM1py was to avoid executing large queries and long-running processes.

This issue is now addressed.
When instantiating the `TM1Service` (or any other TM1py Service), you can pass `async_requests_mode=True`  as an optional argument.
The user would not notice the difference when dealing with a high-level TM1py Service.

Behind the scenes, TM1py will execute all requests in an async-mode. That means in the `RestService` we do a request and then check in fixed intervals (0.1s, 0.3s, 0.6s, 1s, 1s, 1s. ... ) if the response is available, until the TM1py timeout is reached (if a TM1py timeout is configured)

Fixes https://github.com/cubewise-code/tm1py-samples/issues/69