### PR TITLE
Improving build_cellset_from_pandas_dataframe method

### DIFF
--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -387,8 +387,8 @@ def build_cellset_from_pandas_dataframe(df: pd.DataFrame) -> 'CaseAndSpaceInsens
     if isinstance(df.index, pd.MultiIndex):
         df.reset_index(inplace=True)
     cellset = CaseAndSpaceInsensitiveTuplesDict()
-    split = df.to_dict(orient='split')
-    for row in split['data']:
+    split = df.to_numpy().tolist()
+    for row in split:
         cellset[tuple(row[0:-1])] = row[-1]
     return cellset
 


### PR DESCRIPTION
Instead of getting the list via dict(orient), getting it via numpy improves the efficiency by 50%.

df.shape = (106920, 12)
new method took - 0.9022 seconds
old method took - 1.7175 seconds