### PR TITLE
Method to convert the Duration to seconds

### DIFF
--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -401,6 +401,20 @@ def lower_and_drop_spaces(item: str) -> str:
     return item.replace(" ", "").lower()
 
 
+def get_seconds_from_duration(time_str: str) -> int:
+    """
+    This function will convert the TM1 time to seconds
+    :param time_str: P0DT00H01M43S
+    :return: int
+    """
+    import re
+    pattern = re.compile('\w(\d+)\w\w(\d+)\w(\d+)\w(\d+)\w')
+    matches = pattern.search(time_str)
+    d, h, m, s = matches.groups()
+    seconds = (int(d) * 86400) + (int(h) * 3600) + (int(m) * 60) + int(s)
+    return seconds
+
+
 class CaseAndSpaceInsensitiveDict(collections.abc.MutableMapping):
     """A case-and-space-insensitive dict-like object with String keys.
 

--- a/Tests/Utils.py
+++ b/Tests/Utils.py
@@ -699,7 +699,12 @@ class TestMDXUtils(unittest.TestCase):
         process_name = "pro'ces's"
         escaped_url = format_url(url, process_name=process_name)
         self.assertEqual("/api/v1/Processes('pro''ces''s')/tm1.ExecuteWithReturn?$expand=*", escaped_url)
-
+        
+    def test_get_seconds_from_duration(self):
+        elapsed_time = "P0DT00H04M02S"
+        seconds = Utils.get_seconds_from_duration(elapsed_time)
+        self.assertEqual(242, seconds)
+       
     @classmethod
     def tearDownClass(cls):
         cls.tm1.logout()


### PR DESCRIPTION
REST API returned duration like this {'ElapsedTime': 'P0DT00H02M16S', 'WaitTime': 'P0DT00H00M00S'} can be converted to seconds (136).

```
from TM1py.Services import TM1Service
import pandas as pd
import re

def get_seconds_from_duration(time_str: str) -> int:
    """
    This function will convert the TM1 time to seconds
    :param time_str: P0DT00H01M43S
    :return: int
    """
    pattern = re.compile('\w(\d+)\w\w(\d+)\w(\d+)\w(\d+)\w')
    matches = pattern.search(time_str)
    d, h, m, s = matches.groups()
    seconds = (int(d) * 86400) + (int(h) * 3600) + (int(m) * 60) + int(s)
    return seconds

with TM1Service(address=ADDRESS, port=PORT, ssl=SSL, user=USER, password=PASSWORD) as tm1:
    threads = pd.DataFrame(tm1.monitoring.get_threads())
    threads[['ElapsedTime', 'WaitTime']] = threads[['ElapsedTime', 'WaitTime']].applymap(get_seconds_from_duration)
    print(threads[['ElapsedTime', 'WaitTime']])
```