### PR TITLE
New method for getting element(')s respective attribute values

### DIFF
--- a/TM1py/Services/ElementService.py
+++ b/TM1py/Services/ElementService.py
@@ -172,8 +172,9 @@ class ElementService(ObjectService):
             dim=dimension_name)
         return self._retrieve_mdx_rows_and_cell_values_as_string_set(mdx, **kwargs)
 
-    def get_element_by_attribute(self, dimension_name: str, hierarchy_name: str, attribute: str,
-                                 elements: Union[str, List[str]] = None, **kwargs) -> dict:
+    def get_attribute_of_elements(self, dimension_name: str, hierarchy_name: str, attribute: str,
+                                  elements: Union[str, List[str]] = None, exclude_empty_cells: bool = True,
+                                  element_unique_names: bool = False) -> dict:
         """
          Get element name and attribute value for a set of elements in a hierarchy
 
@@ -181,11 +182,10 @@ class ElementService(ObjectService):
         :param hierarchy_name:
         :param attribute: Name of the Attribute
         :param elements:  MDX (Set) expression or iterable of elements
-        :keyword exclude_empty_cells: Boolean
-        :keyword element_unique_names: Boolean
-        :return:
+        :param exclude_empty_cells: Boolean
+        :param element_unique_names: Boolean
+        :return: Dict {'01':'Jan', '02':'Feb'}
         """
-        exclude_empty_cells = kwargs.get('exclude_empty_cells') if 'exclude_empty_cells' in kwargs else True
         if not elements:
             elements = self.get_element_names(dimension_name=dimension_name, hierarchy_name=hierarchy_name)
 
@@ -205,7 +205,7 @@ class ElementService(ObjectService):
             elem_mdx=mdx_element_selection,
             attr_mdx="[}ElementAttributes_" + dimension_name + "].[" + attribute + "]",
             dim=dimension_name)
-        rows_and_values = self._retrieve_mdx_rows_and_values(mdx, **kwargs)
+        rows_and_values = self._retrieve_mdx_rows_and_values(mdx, element_unique_names=element_unique_names)
         return self._extract_dict_from_rows_and_values(rows_and_values, exclude_empty_cells=exclude_empty_cells)
 
     @staticmethod

--- a/Tests/Element.py
+++ b/Tests/Element.py
@@ -143,6 +143,29 @@ class TestElementMethods(unittest.TestCase):
             '1988')
         self.assertIn('1989', elements)
 
+    def test_get_element_by_attribute_without_elements(self):
+        elements = self.tm1.dimensions.hierarchies.elements.get_element_by_attribute(
+            dimension_name=DIMENSION_NAME,
+            hierarchy_name=HIERARCHY_NAME,
+            attribute='Previous Year',
+            element_unique_names=False)
+        self.assertEqual('1989', elements['1990'])
+        self.assertEqual('1990', elements['1991'])
+        self.assertNotIn(self.extra_year, elements)
+        self.assertIsInstance(elements, dict)
+
+    def test_get_element_by_attribute_with_elements(self):
+        elements = self.tm1.dimensions.hierarchies.elements.get_element_by_attribute(
+            dimension_name=DIMENSION_NAME,
+            hierarchy_name=HIERARCHY_NAME,
+            elements=["1990", "1991"],
+            attribute="Previous Year",
+            element_unique_names=False)
+        self.assertNotIn("1989", elements)
+        self.assertEqual("1989", elements["1990"])
+        self.assertIn("1991", elements)
+        self.assertIsInstance(elements, dict)
+
     def test_create_filter_and_delete_element_attribute(self):
         attribute = ElementAttribute('Leap Year', 'Numeric')
         self.tm1.dimensions.hierarchies.elements.create_element_attribute(

--- a/Tests/Element.py
+++ b/Tests/Element.py
@@ -18,8 +18,8 @@ class TestElementMethods(unittest.TestCase):
     tm1 = None
 
     @classmethod
-    # def setup_class(cls):
-    def setUpClass(cls) -> None:
+    def setup_class(cls):
+
         # Connection to TM1
         cls.tm1 = TM1Service(**config['tm1srv01'])
 

--- a/Tests/Element.py
+++ b/Tests/Element.py
@@ -18,8 +18,8 @@ class TestElementMethods(unittest.TestCase):
     tm1 = None
 
     @classmethod
-    def setup_class(cls):
-
+    # def setup_class(cls):
+    def setUpClass(cls) -> None:
         # Connection to TM1
         cls.tm1 = TM1Service(**config['tm1srv01'])
 
@@ -144,26 +144,25 @@ class TestElementMethods(unittest.TestCase):
         self.assertIn('1989', elements)
 
     def test_get_element_by_attribute_without_elements(self):
-        elements = self.tm1.dimensions.hierarchies.elements.get_element_by_attribute(
+        elements = self.tm1.dimensions.hierarchies.elements.get_attribute_of_elements(
             dimension_name=DIMENSION_NAME,
             hierarchy_name=HIERARCHY_NAME,
-            attribute='Previous Year',
-            element_unique_names=False)
+            attribute='Previous Year')
         self.assertEqual('1989', elements['1990'])
         self.assertEqual('1990', elements['1991'])
         self.assertNotIn(self.extra_year, elements)
         self.assertIsInstance(elements, dict)
 
     def test_get_element_by_attribute_with_elements(self):
-        elements = self.tm1.dimensions.hierarchies.elements.get_element_by_attribute(
+        elements = self.tm1.dimensions.hierarchies.elements.get_attribute_of_elements(
             dimension_name=DIMENSION_NAME,
             hierarchy_name=HIERARCHY_NAME,
             elements=["1990", "1991"],
             attribute="Previous Year",
-            element_unique_names=False)
-        self.assertNotIn("1989", elements)
-        self.assertEqual("1989", elements["1990"])
-        self.assertIn("1991", elements)
+            element_unique_names=True)
+        self.assertNotIn("[" + DIMENSION_NAME + "]." + "[" + HIERARCHY_NAME + "]." + "[1989]", elements)
+        self.assertEqual("1989", elements["[" + DIMENSION_NAME + "]." + "[" + HIERARCHY_NAME + "]." + "[1990]"])
+        self.assertIn("[" + DIMENSION_NAME + "]." + "[" + HIERARCHY_NAME + "]." + "[1991]", elements)
         self.assertIsInstance(elements, dict)
 
     def test_create_filter_and_delete_element_attribute(self):


### PR DESCRIPTION
I would use it something like this:

```
from TM1py.Services import TM1Service

with TM1Service(address=ADDRESS, port=PORT, ssl=SSL, user=USER, password=PASSWORD) as tm1:
    period = tm1.elements.get_element_by_attribute(dimension_name='Period', hierarchy_name='Period', 
                                                   attribute='Month', elements=['01', '02'], 
                                                   exclude_empty_cells=True, element_unique_names=False)
```

the output would be:

`{'01': 'Jan', '02': 'Feb'}`