### PR TITLE
General makeup - thanks to PyCharm

### DIFF
--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -677,7 +677,7 @@ class CellService(ObjectService):
             mdx: str,
             elem_properties: Iterable[str] = None,
             member_properties: Iterable[str] = None,
-            value_precision: Iterable[str] = 2,
+            value_precision: int = 2,
             top: int = None,
             skip: int = None,
             **kwargs) -> Dict:

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -227,6 +227,7 @@ def build_ui_arrays_from_cellset(raw_cellset_as_dict: Dict, value_precision: int
     titles = header_map['titles']
     headers = header_map['headers']
     cardinality = header_map['cardinality']
+    value_format_string = ""
 
     if value_precision:
         value_format_string = "{{0:.{}f}}".format(value_precision)
@@ -278,6 +279,7 @@ def build_ui_dygraph_arrays_from_cellset(raw_cellset_as_dict: Dict, value_precis
     titles = header_map['titles']
     headers = header_map['headers']
     cardinality = header_map['cardinality']
+    value_format_string = ""
 
     if value_precision:
         value_format_string = "{{0:.{}f}}".format(value_precision)


### PR DESCRIPTION
1. Correcting typing mismatch

2. Avoid - Local variable 'value_format_string' might be referenced before assignment