### PR TITLE
Revert 290 issue/fix create subset with ampersand

### DIFF
--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -33,11 +33,11 @@ def format_url(url, *args: str, **kwargs: str) -> str:
     :param args: arguments to placeholders
     :return:
     """
-    args = [arg.replace("'", "''").replace('%', '%25') if isinstance(arg, str) else arg
+    args = [arg.replace("'", "''") if isinstance(arg, str) else arg
             for arg
             in args]
 
-    kwargs = {key: value.replace("'", "''").replace('%', '%25') if isinstance(value, str) else value
+    kwargs = {key: value.replace("'", "''") if isinstance(value, str) else value
               for key, value
               in kwargs.items()}
 

--- a/Tests/Cube.py
+++ b/Tests/Cube.py
@@ -23,7 +23,7 @@ class TestCubeMethods(unittest.TestCase):
         PREFIX + "dimension3"]
 
     @classmethod
-    def setUp(cls):
+    def setUpClass(cls):
         cls.tm1 = TM1Service(**config['tm1srv01'])
 
         # Build Dimensions
@@ -146,8 +146,10 @@ class TestCubeMethods(unittest.TestCase):
         errors = self.tm1.cubes.check_rules(cube_name=self.cube_name)
         self.assertEqual(1, len(errors))
 
+
+
     @classmethod
-    def tearDown(cls):
+    def tearDownClass(cls):
         cls.tm1.cubes.delete(cls.cube_name)
         for dimension in cls.dimension_names:
             cls.tm1.dimensions.delete(dimension)


### PR DESCRIPTION
Reverts cubewise-code/tm1py#290

As we have `replace('%', '%25')` in two places `format_url` and `_url_and_body`... `%` becomes `%2525`

```Python
subset = Subset(subset_name='t% eeest', dimension_name='test %', hierarchy_name='test %',
                expression="{TM1FILTERBYLEVEL({TM1SUBSETALL ([test %])}, 0)}")
tm1.subsets.create(subset)
```

URL: `https://adminhost:port/api/v1/Dimensions('test%20%2525')/Hierarchies('test%20%2525')/Subsets`

We should remove `replace` in any one place.