### PR TITLE
Move escaping of characters entirely to utils

### DIFF
--- a/TM1py/Services/RestService.py
+++ b/TM1py/Services/RestService.py
@@ -305,7 +305,7 @@ class RestService:
         """ create proper url and payload
         """
         url = self._base_url + url
-        url = url.replace('%', '%25').replace(' ', '%20').replace('#', '%23')
+        url = url.replace(' ', '%20')
         if isinstance(data, str):
             data = data.encode(encoding)
         return url, data

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -26,6 +26,10 @@ def get_all_servers_from_adminhost(adminhost='localhost') -> List:
     return servers
 
 
+def build_url_friendly_object_name(object_name: str) -> str:
+    return object_name.replace("'", "''").replace('%', '%25').replace('#', '%23')
+
+
 def format_url(url, *args: str, **kwargs: str) -> str:
     """ build url and escape single quotes in args and kwargs
 
@@ -33,11 +37,11 @@ def format_url(url, *args: str, **kwargs: str) -> str:
     :param args: arguments to placeholders
     :return:
     """
-    args = [arg.replace("'", "''") if isinstance(arg, str) else arg
+    args = [build_url_friendly_object_name(arg) if isinstance(arg, str) else arg
             for arg
             in args]
 
-    kwargs = {key: value.replace("'", "''") if isinstance(value, str) else value
+    kwargs = {key: build_url_friendly_object_name(value) if isinstance(value, str) else value
               for key, value
               in kwargs.items()}
 

--- a/Tests/Cube.py
+++ b/Tests/Cube.py
@@ -1,7 +1,7 @@
 import configparser
-from pathlib import Path
 import unittest
 import uuid
+from pathlib import Path
 
 from TM1py import Element, Hierarchy, Dimension
 from TM1py.Objects import Cube
@@ -23,7 +23,7 @@ class TestCubeMethods(unittest.TestCase):
         PREFIX + "dimension3"]
 
     @classmethod
-    def setUpClass(cls):
+    def setUp(cls):
         cls.tm1 = TM1Service(**config['tm1srv01'])
 
         # Build Dimensions
@@ -146,10 +146,8 @@ class TestCubeMethods(unittest.TestCase):
         errors = self.tm1.cubes.check_rules(cube_name=self.cube_name)
         self.assertEqual(1, len(errors))
 
-
-
     @classmethod
-    def tearDownClass(cls):
+    def tearDown(cls):
         cls.tm1.cubes.delete(cls.cube_name)
         for dimension in cls.dimension_names:
             cls.tm1.dimensions.delete(dimension)


### PR DESCRIPTION
Now escaping of illegal characters in object names happens exclusively in `format_url` method.
This way it also applies for ODATA URL references inside the JSON.