### PR TITLE
Fix top argument usage in extract_cellset_raw

### DIFF
--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -957,7 +957,7 @@ class CellService(ObjectService):
         url = "/api/v1/Cellsets('{cellset_id}')?$expand=" \
               "Cube($select=Name;$expand=Dimensions($select=Name))," \
               "Axes({filter_axis}$expand=Tuples($expand=Members({select_member_properties}" \
-              "{expand_elem_properties}){top_rows}))," \
+              "{expand_elem_properties}{top_rows})))," \
               "Cells($select={cell_properties}{top_cells}{skip_cells}{filter_cells})" \
             .format(cellset_id=cellset_id,
                     top_rows=f";$top={top}" if top and not skip else "",
@@ -1088,7 +1088,8 @@ class CellService(ObjectService):
                                                 skip_consolidated_cells=skip_consolidated_cells,
                                                 skip_rule_derived_cells=skip_rule_derived_cells,
                                                 delete_cellset=True, **kwargs)
-        return build_csv_from_cellset_dict(rows, columns, cellset_dict, line_separator=line_separator,value_separator=value_separator)
+        return build_csv_from_cellset_dict(rows, columns, cellset_dict, line_separator=line_separator,
+                                           value_separator=value_separator, top=top)
 
     def extract_cellset_dataframe(
             self,
@@ -1107,7 +1108,6 @@ class CellService(ObjectService):
         :param skip_zeros: skip zeros in cellset (irrespective of zero suppression in MDX / view)
         :param skip_consolidated_cells: skip consolidated cells in cellset
         :param skip_rule_derived_cells: skip rule derived cells in cellset
-
         :param kwargs:
         :return:
         """

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -157,7 +157,6 @@ def build_csv_from_cellset_dict(
     :param row_dimensions:
     :param raw_cellset_as_dict:
     :param top: Maximum Number of cells
-    :param top: Number of cells of skip
     :param line_separator:
     :param value_separator:
     :return:

--- a/Tests/Cell.py
+++ b/Tests/Cell.py
@@ -1410,6 +1410,19 @@ class TestDataMethods(unittest.TestCase):
         values = df[["Value"]].values
         self.assertEqual(self.total_value, sum(values))
 
+    def test_execute_view_dataframe_with_top_argument(self):
+        df = self.tm1.cubes.cells.execute_view_dataframe(
+            cube_name=CUBE_NAME,
+            view_name=VIEW_NAME,
+            top=2,
+            private=False)
+
+        # check row count
+        self.assertTrue(len(df) == 2)
+
+        # check type
+        self.assertIsInstance(df, pd.DataFrame)
+
     def test_execute_view_dataframe_pivot_two_row_one_column_dimensions(self):
         view_name = PREFIX + "Pivot_two_row_one_column_dimensions"
         view = NativeView(


### PR DESCRIPTION
The `extract_cellset_raw` method did not use the `top` argument properly.

**Before PR:**
`Axes($filter=Ordinal ne 2;$expand=Tuples($expand=Members($select=Name);$top=5))`

**After PR:**
`Axes($filter=Ordinal ne 2;$expand=Tuples($expand=Members($select=Name;$top=5)))`



**Code to replicate:**
```Python
from TM1py.Services import TM1Service

tm1 = TM1Service(****)
tm1.cells.execute_view_dataframe(cube_name='test', view_name='test', top=5, private=False)
```

Also the `extract_cellset_csv` method was not passing the `top` argument to `build_csv_from_cellset_dict` method.