### PR TITLE
New methods

### DIFF
--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -549,7 +549,7 @@ class CellService(ObjectService):
     def execute_mdx_dict(self, mdx: str, top: int = None, skip: int = None, skip_zeros: bool = True,
                               skip_consolidated_cells: bool = False, skip_rule_derived_cells: bool = False,
                               **kwargs) -> Dict:
-        """ Get Dict from MDX Query.
+        """ Optimized for performance. Get Dict from MDX Query.
 
         :param mdx: Valid MDX Query
         :param top: Int, number of cells to return (counting from top)
@@ -632,7 +632,7 @@ class CellService(ObjectService):
                           skip: int = None, skip_zeros: bool = True, skip_consolidated_cells: bool = False,
                           skip_rule_derived_cells: bool = False, value_separator: str = "|", **kwargs) -> dict:
         """ Optimized for performance. Get a Dict(tuple, value) from an existing Cube View
-        Context dimensions are omitted in the resulting Dataframe !
+        Context dimensions are omitted in the resulting Dictionary !
         Cells with Zero/null are omitted by default, but still configurable!
 
         :param cube_name: String, name of the cube
@@ -1111,7 +1111,7 @@ class CellService(ObjectService):
             skip_rule_derived_cells: bool = False,
             value_separator: str = "|",
             **kwargs) -> dict:
-        """ Execute cellset and return only the 'Content', in csv format
+        """ Execute cellset and return only the 'Content' as a dictionary
 
         :param cellset_id: String; ID of existing cellset
         :param top: Int, number of cells to return (counting from top)

--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -18,7 +18,7 @@ from TM1py.Services.RestService import RestService
 from TM1py.Services.ViewService import ViewService
 from TM1py.Utils import Utils, CaseAndSpaceInsensitiveSet, format_url
 from TM1py.Utils.Utils import build_pandas_dataframe_from_cellset, dimension_name_from_element_unique_name, \
-    CaseAndSpaceInsensitiveTuplesDict, abbreviate_mdx, build_csv_from_cellset_dict
+    CaseAndSpaceInsensitiveTuplesDict, abbreviate_mdx, build_csv_from_cellset_dict, build_dict_from_cellset_dict
 
 
 def tidy_cellset(func):
@@ -546,6 +546,24 @@ class CellService(ObjectService):
                                         skip_rule_derived_cells=skip_rule_derived_cells, line_separator=line_separator,
                                         value_separator=value_separator, **kwargs)
 
+    def execute_mdx_dict(self, mdx: str, top: int = None, skip: int = None, skip_zeros: bool = True,
+                              skip_consolidated_cells: bool = False, skip_rule_derived_cells: bool = False,
+                              **kwargs) -> Dict:
+        """ Get Dict from MDX Query.
+
+        :param mdx: Valid MDX Query
+        :param top: Int, number of cells to return (counting from top)
+        :param skip: Int, number of cells to skip (counting from top)
+        :param skip_zeros: skip zeros in cellset (irrespective of zero suppression in MDX / view)
+        :param skip_consolidated_cells: skip consolidated cells in cellset
+        :param skip_rule_derived_cells: skip rule derived cells in cellset
+        :return: Dictionary
+        """
+        cellset_id = self.create_cellset(mdx, **kwargs)
+        return self.extract_cellset_dict(cellset_id, top=top, skip=skip, skip_zeros=skip_zeros,
+                                         skip_consolidated_cells=skip_consolidated_cells,
+                                         skip_rule_derived_cells=skip_rule_derived_cells, **kwargs)
+
     def execute_mdx_dataframe(self, mdx: str, top: int = None, skip: int = None, skip_zeros: bool = True,
                               skip_consolidated_cells: bool = False, skip_rule_derived_cells: bool = False,
                               **kwargs) -> pd.DataFrame:
@@ -608,6 +626,31 @@ class CellService(ObjectService):
         """
         cellset_id = self.create_cellset(mdx, **kwargs)
         return self.extract_cellset_cellcount(cellset_id, delete_cellset=True, **kwargs)
+
+
+    def execute_view_dict(self, cube_name: str, view_name: str, private: bool = False, top: int = None,
+                          skip: int = None, skip_zeros: bool = True, skip_consolidated_cells: bool = False,
+                          skip_rule_derived_cells: bool = False, value_separator: str = "|", **kwargs) -> dict:
+        """ Optimized for performance. Get a Dict(tuple, value) from an existing Cube View
+        Context dimensions are omitted in the resulting Dataframe !
+        Cells with Zero/null are omitted by default, but still configurable!
+
+        :param cube_name: String, name of the cube
+        :param view_name: String, name of the view
+        :param private: True (private) or False (public)
+        :param top: Int, number of cells to return (counting from top)
+        :param skip: Int, number of cells to skip (counting from top)
+        :param skip_zeros: skip zeros in cellset (irrespective of zero suppression in MDX / view)
+        :param skip_consolidated_cells: skip consolidated cells in cellset
+        :param skip_rule_derived_cells: skip rule derived cells in cellset
+        :param value_separator: value separator the tuple
+        :return: Dict
+        """
+        cellset_id = self.create_cellset_from_view(cube_name=cube_name, view_name=view_name, private=private, **kwargs)
+        return self.extract_cellset_dict(cellset_id, top=top, skip=skip, skip_zeros=skip_zeros,
+                                         skip_consolidated_cells=skip_consolidated_cells,
+                                         skip_rule_derived_cells=skip_rule_derived_cells,
+                                         value_separator=value_separator, **kwargs)
 
     def execute_view_dataframe(self, cube_name: str, view_name: str, private: bool = False, top: int = None,
                                skip: int = None, skip_zeros: bool = True, skip_consolidated_cells: bool = False,
@@ -1057,6 +1100,36 @@ class CellService(ObjectService):
         url = "/api/v1/Cellsets('{}')/Cells/$count".format(cellset_id)
         response = self._rest.GET(url, **kwargs)
         return int(response.content)
+
+    def extract_cellset_dict(
+            self,
+            cellset_id: str,
+            top: int = None,
+            skip: int = None,
+            skip_zeros: bool = True,
+            skip_consolidated_cells: bool = False,
+            skip_rule_derived_cells: bool = False,
+            value_separator: str = "|",
+            **kwargs) -> dict:
+        """ Execute cellset and return only the 'Content', in csv format
+
+        :param cellset_id: String; ID of existing cellset
+        :param top: Int, number of cells to return (counting from top)
+        :param skip: Int, number of cells to skip (counting from top)
+        :param skip_zeros: skip zeros in cellset (irrespective of zero suppression in MDX / view)
+        :param skip_consolidated_cells: skip consolidated cells in cellset
+        :param skip_rule_derived_cells: skip rule derived cells in cellset
+        :param value_separator: Value separator the tuple
+        :return: Dict
+        """
+        _, _, rows, columns = self.extract_cellset_composition(cellset_id, delete_cellset=False, **kwargs)
+
+        cellset_dict = self.extract_cellset_raw(cellset_id, cell_properties=["Value"], top=top, skip=skip,
+                                                skip_contexts=True, skip_zeros=skip_zeros,
+                                                skip_consolidated_cells=skip_consolidated_cells,
+                                                skip_rule_derived_cells=skip_rule_derived_cells,
+                                                delete_cellset=True, **kwargs)
+        return build_dict_from_cellset_dict(cellset_dict, value_separator=value_separator)
 
     def extract_cellset_csv(
             self,

--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -548,7 +548,7 @@ class CellService(ObjectService):
 
     def execute_mdx_elements_value_dict(self, mdx: str, top: int = None, skip: int = None, skip_zeros: bool = True,
                                         skip_consolidated_cells: bool = False, skip_rule_derived_cells: bool = False,
-                                        value_separator: str = "|", **kwargs) -> Dict[str, Union[str, float]]:
+                                        element_separator: str = "|", **kwargs) -> Dict[str, Union[str, float]]:
         """ Optimized for performance. Get Dict from MDX Query.
 
         :param mdx: Valid MDX Query
@@ -557,14 +557,14 @@ class CellService(ObjectService):
         :param skip_zeros: skip zeros in cellset (irrespective of zero suppression in MDX / view)
         :param skip_consolidated_cells: skip consolidated cells in cellset
         :param skip_rule_derived_cells: skip rule derived cells in cellset
-        :param value_separator: value separator the tuple
+        :param element_separator: separator for the dimension element combination
         :return: Dict  {'2020|Jan|Sales': 2000, '2020|Feb|Sales': 3000}
         """
         lines = self.execute_mdx_csv(mdx=mdx, top=top, skip=skip, skip_zeros=skip_zeros,
                                      skip_consolidated_cells=skip_consolidated_cells,
                                      skip_rule_derived_cells=skip_rule_derived_cells,
-                                     value_separator=value_separator, **kwargs)
-        return {value_separator.join(entries.split(value_separator)[:-1]): entries.split(value_separator)[-1]
+                                     value_separator=element_separator, **kwargs)
+        return {element_separator.join(entries.split(element_separator)[:-1]): entries.split(element_separator)[-1]
                 for entries in lines.split("\r\n")[1:]}
 
     def execute_mdx_dataframe(self, mdx: str, top: int = None, skip: int = None, skip_zeros: bool = True,
@@ -633,7 +633,7 @@ class CellService(ObjectService):
     def execute_view_elements_value_dict(self, cube_name: str, view_name: str, private: bool = False,
                                          top: int = None, skip: int = None, skip_zeros: bool = True,
                                          skip_consolidated_cells: bool = False, skip_rule_derived_cells: bool = False,
-                                         value_separator: str = "|", **kwargs) -> Dict[str, Union[str, float]]:
+                                         element_separator: str = "|", **kwargs) -> Dict[str, Union[str, float]]:
         """ Optimized for performance. Get a Dict(tuple, value) from an existing Cube View
         Context dimensions are omitted in the resulting Dataframe !
         Cells with Zero/null are omitted by default, but still configurable!
@@ -646,14 +646,14 @@ class CellService(ObjectService):
         :param skip_zeros: skip zeros in cellset (irrespective of zero suppression in MDX / view)
         :param skip_consolidated_cells: skip consolidated cells in cellset
         :param skip_rule_derived_cells: skip rule derived cells in cellset
-        :param value_separator: value separator the tuple
+        :param element_separator: separator for the dimension element combination
         :return: Dict  {'2020|Jan|Sales': 2000, '2020|Feb|Sales': 3000}
         """
         lines = self.execute_view_csv(cube_name=cube_name, view_name=view_name, private=private, top=top, skip=skip,
                                       skip_zeros=skip_zeros, skip_consolidated_cells=skip_consolidated_cells,
                                       skip_rule_derived_cells=skip_rule_derived_cells,
-                                      value_separator=value_separator, **kwargs)
-        return {value_separator.join(entries.split(value_separator)[:-1]): entries.split(value_separator)[-1]
+                                      value_separator=element_separator, **kwargs)
+        return {element_separator.join(entries.split(element_separator)[:-1]): entries.split(element_separator)[-1]
                 for entries in lines.split("\r\n")[1:]}
 
     def execute_view_dataframe(self, cube_name: str, view_name: str, private: bool = False, top: int = None,

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -144,6 +144,47 @@ def build_content_from_cellset_dict(
     return content_as_dict
 
 
+def build_dict_from_cellset_dict(raw_cellset_as_dict: Dict, top: Optional[int] = None,
+                                 value_separator: str = "|") -> dict:
+    """ transform raw cellset data into concise dictionary
+
+    :param raw_cellset_as_dict:
+    :param top: Maximum Number of cells
+    :param value_separator:
+    :return: dictionary
+    """
+    tuple_value_dict = dict()
+
+    cells = raw_cellset_as_dict['Cells']
+    if len(cells) == 0:
+        return tuple_value_dict
+
+    row_axis, column_axis, _ = extract_axes_from_cellset(raw_cellset_as_dict=raw_cellset_as_dict)
+
+    for ordinal, cell in enumerate(cells[:top or len(cells)]):
+        # if skip is used in execution we must use the original ordinal from the cell, if not we can simply enumerate
+        ordinal = cell.get("Ordinal", ordinal)
+
+        dict_entry = ''
+
+        if row_axis:
+            index_rows = ordinal // row_axis['Cardinality'] % column_axis['Cardinality']
+            dict_entry = ''.join([dict_entry,
+                                 value_separator.join(
+                                     extract_element_names_from_members(
+                                         column_axis['Tuples'][index_rows]['Members']))])
+        if column_axis:
+            index_columns = ordinal % row_axis['Cardinality']
+            dict_entry = value_separator.join([dict_entry,
+                                              value_separator.join(
+                                                  extract_element_names_from_members(
+                                                      row_axis['Tuples'][index_columns]['Members']))])
+
+        tuple_value_dict[dict_entry] = cell["Value"]
+
+    return tuple_value_dict
+
+
 def build_csv_from_cellset_dict(
         row_dimensions: List[str],
         column_dimensions: List[str],

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -143,47 +143,6 @@ def build_content_from_cellset_dict(
     return content_as_dict
 
 
-def build_dict_from_cellset_dict(raw_cellset_as_dict: Dict, top: Optional[int] = None,
-                                 value_separator: str = "|") -> dict:
-    """ transform raw cellset data into concise dictionary
-
-    :param raw_cellset_as_dict:
-    :param top: Int, number of cells to return (counting from top)
-    :param value_separator: value separator the dimension combination in the dict key
-    :return: dictionary
-    """
-    tuple_value_dict = dict()
-
-    cells = raw_cellset_as_dict['Cells']
-    if len(cells) == 0:
-        return tuple_value_dict
-
-    row_axis, column_axis, _ = extract_axes_from_cellset(raw_cellset_as_dict=raw_cellset_as_dict)
-
-    for ordinal, cell in enumerate(cells[:top or len(cells)]):
-        # if skip is used in execution we must use the original ordinal from the cell, if not we can simply enumerate
-        ordinal = cell.get("Ordinal", ordinal)
-
-        dict_entry = ''
-
-        if row_axis:
-            index_rows = ordinal // row_axis['Cardinality'] % column_axis['Cardinality']
-            dict_entry = ''.join([dict_entry,
-                                 value_separator.join(
-                                     extract_element_names_from_members(
-                                         column_axis['Tuples'][index_rows]['Members']))])
-        if column_axis:
-            index_columns = ordinal % row_axis['Cardinality']
-            dict_entry = value_separator.join([dict_entry,
-                                              value_separator.join(
-                                                  extract_element_names_from_members(
-                                                      row_axis['Tuples'][index_columns]['Members']))])
-
-        tuple_value_dict[dict_entry] = cell["Value"]
-
-    return tuple_value_dict
-
-
 def build_csv_from_cellset_dict(
         row_dimensions: List[str],
         column_dimensions: List[str],

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -116,8 +116,7 @@ def build_content_from_cellset_dict(
     """ transform raw cellset data into concise dictionary
 
     :param raw_cellset_as_dict:
-    :param top: Maximum Number of cells
-    :param top: Number of cells of skip
+    :param top: Int, number of cells to return (counting from top)
     :return:
     """
     cube_dimensions = [dim['Name'] for dim in raw_cellset_as_dict['Cube']['Dimensions']]
@@ -149,8 +148,8 @@ def build_dict_from_cellset_dict(raw_cellset_as_dict: Dict, top: Optional[int] =
     """ transform raw cellset data into concise dictionary
 
     :param raw_cellset_as_dict:
-    :param top: Maximum Number of cells
-    :param value_separator:
+    :param top: Int, number of cells to return (counting from top)
+    :param value_separator: value separator the dimension combination in the dict key
     :return: dictionary
     """
     tuple_value_dict = dict()

--- a/Tests/Cell.py
+++ b/Tests/Cell.py
@@ -891,7 +891,7 @@ class TestDataMethods(unittest.TestCase):
         for value in values:
             self.assertEqual(value, 3)
 
-    def test_execute_mdx_dict(self):
+    def test_execute_mdx_elements_value_dict(self):
         mdx = MdxBuilder.from_cube(CUBE_NAME) \
             .rows_non_empty() \
             .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[0], DIMENSION_NAMES[0])) \
@@ -899,7 +899,7 @@ class TestDataMethods(unittest.TestCase):
             .add_hierarchy_set_to_column_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[2], DIMENSION_NAMES[2])) \
             .to_mdx()
 
-        values = self.tm1.cubes.cells.execute_mdx_dict(mdx)
+        values = self.tm1.cubes.cells.execute_mdx_elements_value_dict(mdx)
 
         # check type
         self.assertIsInstance(values, dict)
@@ -909,7 +909,7 @@ class TestDataMethods(unittest.TestCase):
         self.assertEqual(len(coordinates), len(self.target_coordinates))
 
         # check values
-        values = [value for key, value in values.items()]
+        values = [float(value) for _, value in values.items()]
         self.assertEqual(self.total_value, sum(values))
 
     def test_execute_mdx_dataframe(self):
@@ -1411,8 +1411,8 @@ class TestDataMethods(unittest.TestCase):
         # check if sum of retrieved values is sum of written values
         self.assertEqual(self.total_value, sum(values))
 
-    def test_execute_view_dict(self):
-        values = self.tm1.cubes.cells.execute_view_dict(
+    def test_execute_view_elements_value_dict(self):
+        values = self.tm1.cubes.cells.execute_view_elements_value_dict(
             cube_name=CUBE_NAME,
             view_name=VIEW_NAME,
             private=False)
@@ -1425,11 +1425,11 @@ class TestDataMethods(unittest.TestCase):
         self.assertEqual(len(coordinates), len(self.target_coordinates))
 
         # check values
-        values = [value for key, value in values.items()]
+        values = [float(value) for _, value in values.items()]
         self.assertEqual(self.total_value, sum(values))
 
-    def test_execute_view_dict_with_top_argument(self):
-        values = self.tm1.cubes.cells.execute_view_dict(
+    def test_execute_view_elements_value_dict_with_top_argument(self):
+        values = self.tm1.cubes.cells.execute_view_elements_value_dict(
             cube_name=CUBE_NAME,
             view_name=VIEW_NAME,
             top=4,

--- a/Tests/Cell.py
+++ b/Tests/Cell.py
@@ -891,6 +891,27 @@ class TestDataMethods(unittest.TestCase):
         for value in values:
             self.assertEqual(value, 3)
 
+    def test_execute_mdx_dict(self):
+        mdx = MdxBuilder.from_cube(CUBE_NAME) \
+            .rows_non_empty() \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[0], DIMENSION_NAMES[0])) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[1], DIMENSION_NAMES[1])) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[2], DIMENSION_NAMES[2])) \
+            .to_mdx()
+
+        values = self.tm1.cubes.cells.execute_mdx_dict(mdx)
+
+        # check type
+        self.assertIsInstance(values, dict)
+
+        # check coordinates
+        coordinates = {key for key, value in values.items()}
+        self.assertEqual(len(coordinates), len(self.target_coordinates))
+
+        # check values
+        values = [value for key, value in values.items()]
+        self.assertEqual(self.total_value, sum(values))
+
     def test_execute_mdx_dataframe(self):
         mdx = MdxBuilder.from_cube(CUBE_NAME) \
             .rows_non_empty() \
@@ -1389,6 +1410,36 @@ class TestDataMethods(unittest.TestCase):
 
         # check if sum of retrieved values is sum of written values
         self.assertEqual(self.total_value, sum(values))
+
+    def test_execute_view_dict(self):
+        values = self.tm1.cubes.cells.execute_view_dict(
+            cube_name=CUBE_NAME,
+            view_name=VIEW_NAME,
+            private=False)
+
+        # check type
+        self.assertIsInstance(values, dict)
+
+        # check coordinates
+        coordinates = {key for key, value in values.items()}
+        self.assertEqual(len(coordinates), len(self.target_coordinates))
+
+        # check values
+        values = [value for key, value in values.items()]
+        self.assertEqual(self.total_value, sum(values))
+
+    def test_execute_view_dict_with_top_argument(self):
+        values = self.tm1.cubes.cells.execute_view_dict(
+            cube_name=CUBE_NAME,
+            view_name=VIEW_NAME,
+            top=4,
+            private=False)
+
+        # check row count
+        self.assertTrue(len(values) == 4)
+
+        # check type
+        self.assertIsInstance(values, dict)
 
     def test_execute_view_dataframe(self):
         df = self.tm1.cubes.cells.execute_view_dataframe(


### PR DESCRIPTION
New methods for getting `dict` from `MDX` or `view` created `cellset`.

```Python
from TM1py.Services import TM1Service

tm1 = TM1Service(****)


# MDX Dict
mdx = "SELECT " \
      "NON EMPTY {TM1SUBSETALL( [}Clients] )} on ROWS, " \
      "NON EMPTY {TM1SUBSETALL( [}Groups] )} ON COLUMNS " \
      "FROM [}ClientGroups]"
values = tm1.cells.execute_mdx_dict(mdx)
for key, value in values.items():
    print(f'{key}:{value}')

# View Dict
values = tm1.cells.execute_view_dict(cube_name='}ClientGroups', view_name='Default')
for key, value in values.items():
    print(f'{key}:{value}')
```