### PR TITLE
Add optional `all_leaves_as_default` argument

### DIFF
--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -194,6 +194,14 @@ class CellService(ObjectService):
         return self.clear_with_mdx(cube=cube, mdx=mdx_builder.to_mdx(), **kwargs)
 
     def clear_with_mdx(self, cube: str, mdx: str, **kwargs):
+        """ clear a slice in a cube based on an MDX query.
+        Function requires admin permissions, since TM1py uses an unbound TI with a `ViewZeroOut` statement.
+
+        :param cube: name of the cube
+        :param mdx: a valid MDX query
+        :param kwargs:
+        :return:
+        """
         from TM1py import ProcessService
         process_service = ProcessService(self._rest)
         view_service = ViewService(self._rest)

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -694,3 +694,14 @@ def get_dimensions_from_where_clause(mdx: str) -> List[str]:
     where = mdx[mdx.rfind("WHERE(") + 6:-1]
     unique_names = where.split(",")
     return [dimension_name_from_element_unique_name(unique_name) for unique_name in unique_names]
+
+
+def wrap_in_curly_braces(expression: str) -> str:
+    """ Put curly braces around a string
+
+    :param expression:
+    :return:
+    """
+    return "".join(["{" if not expression.startswith("{") else "",
+                    expression,
+                    "}" if not expression.endswith("}") else ""])

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -678,3 +678,19 @@ class CaseAndSpaceInsensitiveSet(collections.abc.MutableSet):
             return NotImplemented
         # Compare insensitively
         return set(self._store.keys()) == set(other._store.keys())
+
+    def __sub__(self, other):
+        result = self.copy()
+        for entry in other:
+            result.remove(entry)
+        return result
+
+
+def get_dimensions_from_where_clause(mdx: str) -> List[str]:
+    mdx = mdx.replace(" ", "").upper()
+    if "WHERE(" not in mdx:
+        return []
+
+    where = mdx[mdx.rfind("WHERE(") + 6:-1]
+    unique_names = where.split(",")
+    return [dimension_name_from_element_unique_name(unique_name) for unique_name in unique_names]

--- a/Tests/Cell.py
+++ b/Tests/Cell.py
@@ -10,7 +10,8 @@ from mdxpy import MdxBuilder, MdxHierarchySet, Member, CalculatedMember
 from TM1py.Exceptions.Exceptions import TM1pyException
 from TM1py.Objects import MDXView, Cube, Dimension, Element, Hierarchy, NativeView, AnonymousSubset, ElementAttribute
 from TM1py.Services import TM1Service
-from TM1py.Utils import Utils, abbreviate_mdx, element_names_from_element_unique_names
+from TM1py.Utils import Utils, abbreviate_mdx, element_names_from_element_unique_names, \
+    case_and_space_insensitive_equals
 
 # Hard coded stuff
 PREFIX = 'TM1py_Tests_Cell_'
@@ -1779,6 +1780,21 @@ class TestDataMethods(unittest.TestCase):
 
         elements = element_names_from_element_unique_names(list(cells.keys())[0])
         self.assertEqual(elements, ("Element 2", "Element 1", "Element 1"))
+
+    def test_complement_mdx_with_all_leaf_selections_happy_case(self):
+        mdx = MdxBuilder.from_cube(CUBE_NAME) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.tm1_subset_all(DIMENSION_NAMES[0])) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.tm1_subset_all(DIMENSION_NAMES[1])) \
+            .to_mdx()
+
+        complemented_mdx = self.tm1.cells.complement_mdx_with_all_leaf_selections(mdx)
+        expected_mdx = MdxBuilder.from_cube(CUBE_NAME) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.tm1_subset_all(DIMENSION_NAMES[0])) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.tm1_subset_all(DIMENSION_NAMES[1])) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.tm1_subset_all(DIMENSION_NAMES[2]).filter_by_level(0)) \
+            .to_mdx()
+
+        self.assertTrue(case_and_space_insensitive_equals(expected_mdx, complemented_mdx))
 
     # Delete Cube and Dimensions
     @classmethod


### PR DESCRIPTION
Add optional `all_leaves_as_default` argument to `clear_with_mdx` function.
If the argument is passed as True, TM1py will accept incomplete MDX queries and complement it with the missing dimensions.
For the missing dimensions all leaves (`TM1FILTERBYLEVEL({TM1SUBSETALL([Product])}, 0)`) will be added to ROWS or COLUMNS.

This approach is fragile to a certain extend. The `not_referenced_dimensions`
are determined by comparing the titles of the dimension composition in the cellset and the WHERE selection in the MDX.

In order to deal with the fragility of the approach, the function is somewhat fussy about the MDX it accepts. The function will abort if
- MDX does not contain selections on ROWS and COLUMNS
- MDX does not contain either `ON 0` or `ON COLUMNS` (casing is ignored)
- MDX does not contain either `ON 1` or `ON ROWS` (casing is ignored)

Fixes #255