### PR TITLE
Replace assertEquals with assertEqual

### DIFF
--- a/Tests/Subset.py
+++ b/Tests/Subset.py
@@ -240,7 +240,7 @@ class TestSubsetMethods(unittest.TestCase):
             subset_name=self.subset_name_static,
             private=private)
         # Check after update
-        self.assertEquals(len(s.elements), 5)
+        self.assertEqual(len(s.elements), 5)
         self.assertNotEqual(self.static_subset, s)
 
     def test_update_subset_dynamic_private(self):
@@ -266,7 +266,7 @@ class TestSubsetMethods(unittest.TestCase):
             subset_name=self.subset_name_dynamic,
             private=private)
         # Check after update
-        self.assertEquals(
+        self.assertEqual(
             s.expression,
             '{{ [{}].[EUR], [{}].[USD] }})'.format(self.dimension_name, self.dimension_name))
 
@@ -291,7 +291,7 @@ class TestSubsetMethods(unittest.TestCase):
             subset_name=self.subset_name_static,
             private=private)
         # Check after update
-        self.assertEquals(len(subset.elements), 5)
+        self.assertEqual(len(subset.elements), 5)
         self.assertNotEqual(self.static_subset, subset)
 
     def test_update_subset_dynamic_public(self):
@@ -317,7 +317,7 @@ class TestSubsetMethods(unittest.TestCase):
             subset_name=self.subset_name_dynamic,
             private=private)
         # Check after update
-        self.assertEquals(
+        self.assertEqual(
             subset.expression,
             '{{ [{}].[EUR], [{}].[USD] }})'.format(self.dimension_name, self.dimension_name))
 

--- a/Tests/Utils.py
+++ b/Tests/Utils.py
@@ -321,7 +321,7 @@ class TestMDXUtils(unittest.TestCase):
             private_views, public_views = self.tm1.cubes.views.get_all(cube_name)
             for view in private_views + public_views:
                 mdx = view.MDX
-                self.assertEquals(
+                self.assertEqual(
                     cube_name.upper().replace(" ", ""),
                     MDXUtils.read_cube_name_from_mdx(mdx))
 


### PR DESCRIPTION
Removes deprecation warnings thrown in 5 tests. 

A first little step for https://github.com/cubewise-code/tm1py/issues/301