### PR TITLE
Removed unused imports from a couple of tests

### DIFF
--- a/Tests/Other.py
+++ b/Tests/Other.py
@@ -4,7 +4,7 @@ import random
 import unittest
 from base64 import b64encode
 
-from TM1py.Exceptions import TM1pyRestException, TM1pyException
+from TM1py.Exceptions import TM1pyRestException
 from TM1py.Objects import MDXView, User
 from TM1py.Services import TM1Service
 from TM1py.Utils import Utils

--- a/Tests/PowerBiService.py
+++ b/Tests/PowerBiService.py
@@ -2,11 +2,8 @@ import configparser
 import os
 import unittest
 
-import pandas as pd
-from numpy import NaN
-
 from TM1py import MDXView
-from TM1py.Objects import Cube, Dimension, Element, Hierarchy, NativeView, AnonymousSubset, ElementAttribute
+from TM1py.Objects import Cube, Dimension, Element, Hierarchy, ElementAttribute
 from TM1py.Services import TM1Service
 
 # Hard coded stuff


### PR DESCRIPTION
I ran a few linters and found these modules were imported but not used, eg Pandas is imported but used via the power_bi module and doesn't need to be imported in entirety by Tests/PowerBiService.py. 