### PR TITLE
wip: Feature/optional pandas

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,18 +33,31 @@ Requirements
 
 - python (3.5 or higher)
 - requests
-- pandas
 - requests_negotiate_sspi
-- TM1 (10.2.2 FP 5 or higher)
+- TM1 11 
+
+
+Optional Requirements
+=======================
+
+- pandas
 
 Install
 =======================
 
+> without pandas
 
-    pip install TM1py
+    pip install tm1py
+    
+> with pandas
+
+    pip install tm1py[pandas]
+    
     
 Usage
 =======================
+
+> on-premise
 
 ``` python
 from TM1py.Services import TM1Service
@@ -55,15 +68,29 @@ with TM1Service(address='localhost', port=8001, user='admin', password='apple', 
         tm1.chores.update(chore)
 ```
 
+> IBM cloud
+
+``` python
+with TM1Service(
+        base_url='https://mycompany.planning-analytics.ibmcloud.com/tm1/api/tm1/',
+        user="non_interactive_user",
+        namespace="LDAP",
+        password="U3lSn5QLwoQZY2",
+        ssl=True,
+        verify=True,
+        async_requests_mode=True) as tm1:
+    for chore in tm1.chores.get_all():
+        chore.reschedule(hours=-1)
+        tm1.chores.update(chore)
+```
+
+
 Samples:
 https://github.com/cubewise-code/TM1py-samples
 
 
 Documentation
 =======================
-
-Code Documentation:
-http://tm1py.readthedocs.io/en/latest/
 
 Detailed Installation instructions and Samples:
 https://github.com/cubewise-code/TM1py-samples

--- a/TM1py/Services/PowerBiService.py
+++ b/TM1py/Services/PowerBiService.py
@@ -1,9 +1,15 @@
 from collections.abc import Iterable
 
-import pandas as pd
-
 from TM1py.Services import CellService
 from TM1py.Services import ElementService
+from TM1py.Utils import require_pandas
+
+try:
+    import pandas as pd
+
+    _has_pandas = True
+except ImportError:
+    _has_pandas = False
 
 
 class PowerBiService:
@@ -16,15 +22,18 @@ class PowerBiService:
         self.cells = CellService(tm1_rest)
         self.elements = ElementService(tm1_rest)
 
-    def execute_mdx(self, mdx, **kwargs) -> pd.DataFrame:
+    @require_pandas
+    def execute_mdx(self, mdx, **kwargs) -> 'pd.DataFrame':
         return self.cells.execute_mdx_dataframe_shaped(mdx, **kwargs)
 
-    def execute_view(self, cube_name, view_name, private, **kwargs) -> pd.DataFrame:
+    @require_pandas
+    def execute_view(self, cube_name, view_name, private, **kwargs) -> 'pd.DataFrame':
         return self.cells.execute_view_dataframe_shaped(cube_name, view_name, private, **kwargs)
 
+    @require_pandas
     def get_member_properties(self, dimension_name, hierarchy_name, member_selection=None,
                               skip_consolidations=True, attributes=None, skip_parents=False,
-                              level_names=None) -> pd.DataFrame:
+                              level_names=None) -> 'pd.DataFrame':
         """
 
         :param dimension_name: Name of the dimension

--- a/setup.py
+++ b/setup.py
@@ -35,9 +35,11 @@ setup(
     ],
     install_requires=[
         'requests',
-        'pandas',
         'pytz',
         'requests_negotiate_sspi;platform_system=="Windows"',
         'mdxpy'],
+    extras_require={
+        "pandas": ["pandas"]
+    },
     python_requires='>=3.5',
 )


### PR DESCRIPTION
Male pandas dependency optional 

- fail silent if pandas import fails
- abort functions with ImportError if pandas is required
- wrap pd.DataFrame type hints in single quotes
- add pandas as extra_require to setup.py
- introduce `require_pandas` decorator for functions
- adjust readme

By default tm1py 1.5.0 will not install pandas.
If pandas install is requested, run: `pip install tm1py[pandas]`

Fixes #214