### PR TITLE
Adding new methods and fixing element count methods

### DIFF
--- a/TM1py/Services/CubeService.py
+++ b/TM1py/Services/CubeService.py
@@ -202,6 +202,24 @@ class CubeService(ObjectService):
         url = format_url("/api/v1/Cubes('{}')/tm1.Unload", cube_name)
         return self._rest.POST(url=url, **kwargs)
 
+    def lock(self, cube_name: str, **kwargs) -> Response:
+        """ Locks the cube to prevent any users from modifying it
+
+        :param cube_name:
+        :return:
+        """
+        url = format_url("/api/v1/Cubes('{}')/tm1.Lock", cube_name)
+        return self._rest.POST(url=url, **kwargs)
+
+    def unlock(self, cube_name: str, **kwargs) -> Response:
+        """ Unlocks the cube to allow modifications
+
+        :param cube_name:
+        :return:
+        """
+        url = format_url("/api/v1/Cubes('{}')/tm1.Unlock", cube_name)
+        return self._rest.POST(url=url, **kwargs)
+
     def get_random_intersection(self, cube_name: str, unique_names: bool = False) -> List[str]:
         """ Get a random Intersection in a cube
         used mostly for regression testing.

--- a/TM1py/Services/CubeService.py
+++ b/TM1py/Services/CubeService.py
@@ -80,6 +80,12 @@ class CubeService(ObjectService):
         cubes = [Cube.from_dict(cube_as_dict=cube) for cube in response.json()['value']]
         return cubes
 
+    def get_number_of_cubes(self, **kwargs) -> int:
+        url = format_url(
+            "/api/v1/Cubes/$count")
+        response = self._rest.GET(url, **kwargs)
+        return int(response.text)
+
     def update(self, cube: Cube, **kwargs) -> Response:
         """ Update existing cube on TM1 Server
 

--- a/TM1py/Services/DimensionService.py
+++ b/TM1py/Services/DimensionService.py
@@ -121,6 +121,14 @@ class DimensionService(ObjectService):
         dimension_names = list(entry['Name'] for entry in response.json()['value'])
         return dimension_names
 
+    def get_number_of_dimensions(self, **kwargs) -> int:
+        """Ask TM1 Server for the total number of dimensions
+
+        :return: Number of dimensions
+        """
+        response = self._rest.GET(url='/api/v1/Dimensions/$count', **kwargs)
+        return int(response.text)
+
     def execute_mdx(self, dimension_name: str, mdx: str, **kwargs) -> List:
         """ Execute MDX against Dimension. 
         Requires }ElementAttributes_ Cube of the dimension to exist !

--- a/TM1py/Services/ElementService.py
+++ b/TM1py/Services/ElementService.py
@@ -130,7 +130,7 @@ class ElementService(ObjectService):
         return self.get_element_identifiers(dimension_name, hierarchy_name, mdx_elements, **kwargs)
 
     def get_elements_by_level(self, dimension_name: str, hierarchy_name: str, level: int,
-                              **kwargs) -> List:
+                              **kwargs) -> List[str]:
         """ Get all element names by level in a hierarchy
 
         :param dimension_name: Name of the dimension

--- a/TM1py/Services/ElementService.py
+++ b/TM1py/Services/ElementService.py
@@ -96,27 +96,27 @@ class ElementService(ObjectService):
 
     def get_number_of_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> int:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?&$count&$top=0",
+            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements/$count",
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
-        return int(response.json()["@odata.count"])
+        return int(response.text)
 
     def get_number_of_consolidated_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> int:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$filter=Type eq 3&$count&$top=0",
+            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements/$count?$filter=Type eq 3",
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
-        return int(response.json()["@odata.count"])
+        return int(response.text)
 
     def get_number_of_leaf_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> int:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$filter=Type ne 3&$count&$top=0",
+            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements/$count?$filter=Type ne 3",
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
-        return int(response.json()["@odata.count"])
+        return int(response.text)
 
     def get_all_leaf_element_identifiers(self, dimension_name: str, hierarchy_name: str,
                                          **kwargs) -> CaseAndSpaceInsensitiveSet:
@@ -128,6 +128,23 @@ class ElementService(ObjectService):
         """
         mdx_elements = f"{{ Tm1FilterByLevel ( {{ Tm1SubsetAll ([{dimension_name}].[{hierarchy_name}]) }} , 0 ) }}"
         return self.get_element_identifiers(dimension_name, hierarchy_name, mdx_elements, **kwargs)
+
+    def get_elements_by_level(self, dimension_name: str, hierarchy_name: str, level: int,
+                              **kwargs) -> List:
+        """ Get all element names by level in a hierarchy
+
+        :param dimension_name: Name of the dimension
+        :param hierarchy_name: Name of the hierarchy
+        :param level: Level to filter
+        :return: List of element names
+        """
+        url = format_url(
+            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Level eq {}",
+            dimension_name,
+            hierarchy_name,
+            level)
+        response = self._rest.GET(url, **kwargs)
+        return [e["Name"] for e in response.json()['value']]
 
     def get_all_element_identifiers(self, dimension_name: str, hierarchy_name: str,
                                     **kwargs) -> CaseAndSpaceInsensitiveSet:

--- a/Tests/Cube.py
+++ b/Tests/Cube.py
@@ -117,6 +117,10 @@ class TestCubeMethods(unittest.TestCase):
         dimensions = self.tm1.cubes.get_storage_dimension_order(cube_name=self.cube_name)
         self.assertEqual(dimensions, self.dimension_names)
 
+    def test_get_number_of_cubes(self):
+        number_of_cubes = self.tm1.cubes.get_number_of_cubes()
+        self.assertIsInstance(number_of_cubes, int)
+
     def test_update_storage_dimension_order(self):
         self.tm1.cubes.update_storage_dimension_order(
             cube_name=self.cube_name,

--- a/Tests/Cube.py
+++ b/Tests/Cube.py
@@ -138,6 +138,15 @@ class TestCubeMethods(unittest.TestCase):
         response = self.tm1.cubes.unload(cube_name=self.cube_name)
         self.assertTrue(response.ok)
 
+    def test_lock(self):
+        response = self.tm1.cubes.lock(cube_name=self.cube_name)
+        self.assertTrue(response.ok)
+
+    def test_unlock(self):
+        self.tm1.cubes.lock(cube_name=self.cube_name)
+        response = self.tm1.cubes.unlock(cube_name=self.cube_name)
+        self.assertTrue(response.ok)
+
     def test_check_rules_without_errors(self):
         errors = self.tm1.cubes.check_rules(cube_name=self.cube_name)
         self.assertEqual(0, len(errors))

--- a/Tests/Dimension.py
+++ b/Tests/Dimension.py
@@ -156,6 +156,10 @@ class TestDimensionMethods(unittest.TestCase):
     def test_get_all_names(self):
         self.assertIn(DIMENSION_NAME, self.tm1.dimensions.get_all_names())
 
+    def test_get_number_of_dimensions(self):
+        number_of_dimensions = self.tm1.dimensions.get_number_of_dimensions()
+        self.assertIsInstance(number_of_dimensions, int)
+
     def test_execute_mdx(self):
         mdx = "{TM1SubsetAll(" + DIMENSION_NAME + ")}"
         elements = self.tm1.dimensions.execute_mdx(DIMENSION_NAME, mdx)

--- a/Tests/Element.py
+++ b/Tests/Element.py
@@ -268,28 +268,40 @@ class TestElementMethods(unittest.TestCase):
         self.assertEqual(expected_identifiers, set(identifiers))
 
     def test_get_element_identifiers_with_string(self):
-        exepected_identifiers = {'1988/89', '1989/90', '1990/91', '1991/92', *self.years}
+        expected_identifiers = {'1988/89', '1989/90', '1990/91', '1991/92', *self.years}
         elements = "{" + ",".join(["[" + DIMENSION_NAME + "].[" + year + "]" for year in self.years]) + "}"
         identifiers = self.tm1.dimensions.hierarchies.elements.get_element_identifiers(
             dimension_name=DIMENSION_NAME,
             hierarchy_name=HIERARCHY_NAME,
             elements=elements)
-        self.assertEqual(exepected_identifiers, set(identifiers))
+        self.assertEqual(expected_identifiers, set(identifiers))
 
     def test_get_all_element_identifiers(self):
-        exepected_identifiers = {'1988/89', '1989/90', '1990/91', '1991/92', 'Total Years', 'All Consolidations',
+        expected_identifiers = {'1988/89', '1989/90', '1990/91', '1991/92', 'Total Years', 'All Consolidations',
                                  *self.years}
         identifiers = self.tm1.dimensions.hierarchies.elements.get_all_element_identifiers(
             DIMENSION_NAME,
             HIERARCHY_NAME)
-        self.assertEqual(exepected_identifiers, set(identifiers))
+        self.assertEqual(expected_identifiers, set(identifiers))
 
     def test_get_all_leaf_element_identifiers(self):
-        exepected_identifiers = {'1988/89', '1989/90', '1990/91', '1991/92', *self.years}
+        expected_identifiers = {'1988/89', '1989/90', '1990/91', '1991/92', *self.years}
         identifiers = self.tm1.dimensions.hierarchies.elements.get_all_leaf_element_identifiers(
             DIMENSION_NAME,
             HIERARCHY_NAME)
-        self.assertEqual(exepected_identifiers, set(identifiers))
+        self.assertEqual(expected_identifiers, set(identifiers))
+
+    def test_get_elements_by_level(self):
+        expected_elements = ['No Year', '1989', '1990', '1991', '1992']
+        elements = self.tm1.dimensions.hierarchies.elements.get_elements_by_level(
+            DIMENSION_NAME, HIERARCHY_NAME, 0)
+
+        self.assertEqual(elements, expected_elements)
+
+        expected_elements = ['Total Years']
+        elements = self.tm1.dimensions.hierarchies.elements.get_elements_by_level(
+            DIMENSION_NAME, HIERARCHY_NAME, 1)
+        self.assertEqual(elements, expected_elements)
 
     def test_get_number_of_elements(self):
         number_of_elements = self.tm1.dimensions.hierarchies.elements.get_number_of_elements(


### PR DESCRIPTION
Methods `get_number_of_elements`, `get_number_of_consolidated_elements` and `get_number_of_leaf_elements` are throwing errors.


**Code to replicate:**

```python
from TM1py.Services import TM1Service
tm1 = TM1Service()

month_elements = tm1.elements.get_number_of_elements('Month', 'Month')
```
**Output:** `KeyError: '@odata.count'`


**Added new methods:**

`get_elements_by_level`
`get_number_of_cubes`

```python
from TM1py.Services import TM1Service
tm1 = TM1Service()

month_elements = tm1.elements.get_elements_by_level('Month', 'Month', 2)
```
**Output:** `['Q1', 'Q2', 'Q3', 'Q4']`