### PR TITLE
WIP - First look at Testing/annotations.py

### DIFF
--- a/Tests/Annotation.py
+++ b/Tests/Annotation.py
@@ -13,6 +13,9 @@ class TestAnnotationMethods(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        """
+        Establishes a connection to TM1 and creates a dimensions and a cube to use across all tests
+        """
 
         # Connection to TM1
         config = configparser.ConfigParser()
@@ -40,7 +43,9 @@ class TestAnnotationMethods(unittest.TestCase):
 
     @classmethod
     def setUp(self):
-
+        """
+        Run before each test to create a test annotation
+        """
         random_intersection = self.tm1.cubes.get_random_intersection(self.cube_name, False)
         random_text = "".join([random.choice(string.printable) for _ in range(100)])
 
@@ -52,20 +57,30 @@ class TestAnnotationMethods(unittest.TestCase):
 
     @classmethod
     def tearDown(self):
-
+        """
+        Run at the end of each test to delete all test annotations
+        """
         for a in self.tm1.cubes.annotations.get_all(self.cube_name):
             self.tm1.annotations.delete(a.id)
             
 
     def test_get_all(self):
-
+        """
+        Check that get_all returns a list
+        Check that the list of annotations returned contains the test annotation
+        """
         annotations = self.tm1.cubes.annotations.get_all(self.cube_name)
         self.assertIsInstance(annotations, list)
 
-    def test_create(self):
+        annotation_ids = [a.id for a in annotations] 
+        self.assertIn(self.annotation_id, annotation_ids)
 
-        annotation_count = len(self.tm1.cubes.annotations.get_all(self.cube_name))
-        
+    def test_create(self):
+        """
+        Check that an annotation can be created on the server
+        Check that created annotation has the correct comment_value
+        """
+        annotation_count = len(self.tm1.cubes.annotations.get_all(self.cube_name))        
         random_intersection = self.tm1.cubes.get_random_intersection(self.cube_name, False)
         random_text = "".join([random.choice(string.printable) for _ in range(100)])
 
@@ -83,10 +98,18 @@ class TestAnnotationMethods(unittest.TestCase):
 
 
     def test_get(self):
+        """
+        Check that get returns the test annotation from its id
+        """
         annotation = self.tm1.cubes.annotations.get(self.annotation_id)
         self.assertEqual(annotation.id, self.annotation_id)
 
     def test_update(self):
+        """
+        Check that the test annotation's comment_value can be changed
+        Check that the last_updated date has increased
+        Check that the created date remains the same
+        """
         annotation = self.tm1.cubes.annotations.get(self.annotation_id)  
         new_random_text = "".join([random.choice(string.printable) for _ in range(100)])
         annotation.comment_value = new_random_text
@@ -98,17 +121,21 @@ class TestAnnotationMethods(unittest.TestCase):
         self.assertNotEqual(annotation_updated.last_updated, annotation.last_updated)
         self.assertEqual(annotation_updated.created, annotation.created)
 
-
-
     def test_delete(self):
-        annotation_id = self.tm1.cubes.annotations.get(self.annotation_id).id  
+        """
+        Check that the test annotation can be deleted
+        """
+
+        annotation_id = self.annotation_id
         annotation_count = len(self.tm1.cubes.annotations.get_all(self.cube_name))
         self.tm1.annotations.delete(annotation_id)
         self.assertLess(len(self.tm1.cubes.annotations.get_all(self.cube_name)), annotation_count)
 
-
     @classmethod
     def tearDownClass(cls):
+        """
+        Remove test cube and dimensions and close the connection once all tests have run.
+        """
         cls.tm1.cubes.delete(cube_name=cls.cube_name)
         for dimension_name in cls.dimension_names:
             cls.tm1.dimensions.delete(dimension_name=dimension_name)

--- a/Tests/Annotation.py
+++ b/Tests/Annotation.py
@@ -93,8 +93,12 @@ class TestAnnotationMethods(unittest.TestCase):
 
         self.tm1.cubes.annotations.update(annotation)
         annotation_updated = self.tm1.cubes.annotations.get(self.annotation_id)
+        
         self.assertEqual(annotation_updated.comment_value, new_random_text)
         self.assertNotEqual(annotation_updated.last_updated, annotation.last_updated)
+        self.assertEqual(annotation_updated.created, annotation.created)
+
+
 
     def test_delete(self):
         annotation_id = self.tm1.cubes.annotations.get(self.annotation_id).id  

--- a/Tests/Annotation.py
+++ b/Tests/Annotation.py
@@ -30,16 +30,14 @@ class TestAnnotationMethods(unittest.TestCase):
             hierarchy = Hierarchy(dimension_name=dimension_name,
                                   name=dimension_name,
                                   elements=elements)
-            if not cls.tm1.dimensions.exists(dimension_name):
-                dimension = Dimension(dimension_name, [hierarchy])
-                cls.tm1.dimensions.create(dimension)
+            dimension = Dimension(dimension_name, [hierarchy])
+            cls.tm1.dimensions.update_or_create(dimension)
 
         # Build Cube
         cls.cube_name = "TM1py_tests_annotations"
 
-        if not cls.tm1.cubes.exists(cls.cube_name):
-            cube = Cube(cls.cube_name, cls.dimension_names)
-            cls.tm1.cubes.create(cube)
+        cube = Cube(cls.cube_name, cls.dimension_names)
+        cls.tm1.cubes.update_or_create(cube)
 
         # Adds a single annotation to the cube
         cls.create_annotation()

--- a/Tests/Annotation.py
+++ b/Tests/Annotation.py
@@ -74,9 +74,9 @@ class TestAnnotationMethods(unittest.TestCase):
                                 dimensional_context=random_intersection)
 
         self.tm1.annotations.create(annotation)
-
         self.assertGreater(len(self.tm1.cubes.annotations.get_all(self.cube_name)), annotation_count)
-        
+        annotation_new = self.tm1.annotations.get(annotation.id)
+        self.assertEqual(annotation, annotation_new)
 
     def test_get(self):
         annotation = self.tm1.cubes.annotations.get(self.annotation_id)

--- a/Tests/Annotation.py
+++ b/Tests/Annotation.py
@@ -9,23 +9,20 @@ from TM1py import Element, Hierarchy, Dimension, Cube
 from TM1py.Objects import Annotation
 from TM1py.Services import TM1Service
 
-config = configparser.ConfigParser()
-config.read(Path(__file__).parent.joinpath('config.ini'))
-
 
 class TestAnnotationMethods(unittest.TestCase):
-    tm1 = TM1Service(**config['tm1srv01'])
-
-    # create cube
-    cube_name = "TM1py_tests_annotations"
-    dimension_names = ("TM1py_tests_annotations_dimension1",
-                       "TM1py_tests_annotations_dimension2",
-                       "TM1py_tests_annotations_dimension3")
 
     @classmethod
     def setup_class(cls):
+
         # Connection to TM1
+        config = configparser.ConfigParser()
+        config.read(Path(__file__).parent.joinpath('config.ini'))
         cls.tm1 = TM1Service(**config['tm1srv01'])
+
+        cls.dimension_names = ("TM1py_tests_annotations_dimension1",
+                               "TM1py_tests_annotations_dimension2",
+                               "TM1py_tests_annotations_dimension3")
 
         # Build Dimensions
         for dimension_name in cls.dimension_names:
@@ -33,15 +30,18 @@ class TestAnnotationMethods(unittest.TestCase):
             hierarchy = Hierarchy(dimension_name=dimension_name,
                                   name=dimension_name,
                                   elements=elements)
-            dimension = Dimension(dimension_name, [hierarchy])
-            if not cls.tm1.dimensions.exists(dimension.name):
+            if not cls.tm1.dimensions.exists(dimension_name):
+                dimension = Dimension(dimension_name, [hierarchy])
                 cls.tm1.dimensions.create(dimension)
 
         # Build Cube
-        cube = Cube(cls.cube_name, cls.dimension_names)
+        cls.cube_name = "TM1py_tests_annotations"
+
         if not cls.tm1.cubes.exists(cls.cube_name):
+            cube = Cube(cls.cube_name, cls.dimension_names)
             cls.tm1.cubes.create(cube)
 
+        # Adds a single annotation to the cube
         cls.create_annotation()
 
     @classmethod

--- a/Tests/Annotation.py
+++ b/Tests/Annotation.py
@@ -13,7 +13,7 @@ from TM1py.Services import TM1Service
 class TestAnnotationMethods(unittest.TestCase):
 
     @classmethod
-    def setup_class(cls):
+    def setUpClass(cls):
 
         # Connection to TM1
         config = configparser.ConfigParser()

--- a/Tests/Annotation.py
+++ b/Tests/Annotation.py
@@ -49,7 +49,16 @@ class TestAnnotationMethods(unittest.TestCase):
                                 dimensional_context=random_intersection)
         
         self.annotation_id = self.tm1.cubes.annotations.create(annotation).json().get("ID")
+
+    @classmethod
+    def tearDown(self):
+        annotations = self.tm1.cubes.annotations.get_all(self.cube_name)
         
+        for a in annotations:
+            if a.id == self.annotation_id:
+                self.tm1.annotations.delete(self.annotation_id)
+            
+
     def test_get_all(self):
         annotations = self.tm1.cubes.annotations.get_all(self.cube_name)
         self.assertGreater(len(annotations), 0)
@@ -67,7 +76,7 @@ class TestAnnotationMethods(unittest.TestCase):
         self.tm1.annotations.create(annotation)
 
         self.assertGreater(len(self.tm1.cubes.annotations.get_all(self.cube_name)), annotation_count)
-
+        
 
     def test_get(self):
         annotation = self.tm1.cubes.annotations.get(self.annotation_id)
@@ -88,6 +97,7 @@ class TestAnnotationMethods(unittest.TestCase):
         annotation_count = len(self.tm1.cubes.annotations.get_all(self.cube_name))
         self.tm1.annotations.delete(annotation_id)
         self.assertLess(len(self.tm1.cubes.annotations.get_all(self.cube_name)), annotation_count)
+
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
As part of https://github.com/cubewise-code/tm1py/issues/301, I've had a look at the tests for the annotations service as a starting point because it was a relatively simple class. It's still a bit rough but I thought I'd put it out there before getting too carried away. 

What I tried to do:

* Manage the fixtures a bit more cleanly and tried to ensure everything is cleaned up after each run
* Mapped the tests to the individual methods in the AnnotationsService (ie 5 tests instead of 3)
* Tested that each test could be run independently 
* Checked coverage
* Added some simple docstrings to explain what each bit is trying to do

A couple of things to note:

* The fixture creation and naming conventions could still be improved and possibly moved into helper functions shared across all test classes
* I've used more than one assert in each test but tried to relate them all to the method call being tested. We can split these into separate tests if you prefer
* Coverage shows that the ```move``` method of the Annotation object never gets called. I'm guessing this doesn't get used that often anyway. We could write a separate set of tests for all the objects but I guess that's not a huge priority...

Let me know what you think :)
