### PR TITLE
Update from collections.* to collections.abc

### DIFF
--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -537,7 +537,7 @@ class CaseAndSpaceInsensitiveDict(collections.abc.MutableMapping):
     """A case-and-space-insensitive dict-like object with String keys.
 
     Implements all methods and operations of
-    ``collections.MutableMapping`` as well as dict's ``copy``. Also
+    ``collections.abc.MutableMapping`` as well as dict's ``copy``. Also
     provides ``adjusted_items``, ``adjusted_keys``.
 
     All keys are expected to be strings. The structure remembers the
@@ -593,7 +593,7 @@ class CaseAndSpaceInsensitiveDict(collections.abc.MutableMapping):
         )
 
     def __eq__(self, other):
-        if isinstance(other, collections.Mapping):
+        if isinstance(other, collections.abc.Mapping):
             other = CaseAndSpaceInsensitiveDict(other)
         else:
             return NotImplemented
@@ -612,7 +612,7 @@ class CaseAndSpaceInsensitiveTuplesDict(collections.abc.MutableMapping):
     """A case-and-space-insensitive dict-like object with String-Tuples Keys.
 
     Implements all methods and operations of
-    ``collections.MutableMapping`` as well as dict's ``copy``. Also
+    ``collections.abc.MutableMapping`` as well as dict's ``copy``. Also
     provides ``adjusted_items``, ``adjusted_keys``.
 
     All keys are expected to be tuples of strings. The structure remembers the
@@ -669,7 +669,7 @@ class CaseAndSpaceInsensitiveTuplesDict(collections.abc.MutableMapping):
         )
 
     def __eq__(self, other):
-        if isinstance(other, collections.Mapping):
+        if isinstance(other, collections.abc.Mapping):
             other = CaseAndSpaceInsensitiveTuplesDict(other)
         else:
             return NotImplemented
@@ -718,7 +718,7 @@ class CaseAndSpaceInsensitiveSet(collections.abc.MutableSet):
         return str(self._store)
 
     def __eq__(self, other):
-        if isinstance(other, collections.MutableSet):
+        if isinstance(other, collections.abc.MutableSet):
             other = CaseAndSpaceInsensitiveSet(*other)
         else:
             return NotImplemented


### PR DESCRIPTION
Updates references to collections.* to collections.abc in accordance with deprecation warnings:

```
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
```
I think this is fairly straightforward but let me know if I'm missing something :)

All tests in Tests/Utils still pass after the change 