### PR TITLE
Skipped tests requiring pandas

### DIFF
--- a/Tests/Cell.py
+++ b/Tests/Cell.py
@@ -14,7 +14,7 @@ from TM1py.Utils import Utils, element_names_from_element_unique_names
 
 try:
     import pandas as pd
-    
+
     _has_pandas = True
 except ImportError:
     _has_pandas = False
@@ -935,7 +935,7 @@ class TestDataMethods(unittest.TestCase):
         values = [float(value) for _, value in values.items()]
         self.assertEqual(self.total_value, sum(values))
 
-    @unittest.skip
+    @skip_if_no_pandas
     def test_execute_mdx_dataframe(self):
         mdx = MdxBuilder.from_cube(CUBE_NAME) \
             .rows_non_empty() \
@@ -1488,7 +1488,7 @@ class TestDataMethods(unittest.TestCase):
         values = df[["Value"]].values
         self.assertEqual(self.total_value, sum(values))
 
-    @unittest.skip
+    @skip_if_no_pandas
     def test_execute_view_dataframe_with_top_argument(self):
         df = self.tm1.cubes.cells.execute_view_dataframe(
             cube_name=CUBE_NAME,

--- a/Tests/Cell.py
+++ b/Tests/Cell.py
@@ -14,12 +14,12 @@ from TM1py.Utils import Utils, element_names_from_element_unique_names
 
 try:
     import pandas as pd
-
+    
     _has_pandas = True
 except ImportError:
     _has_pandas = False
 
-def skipIfNoPandas(func):
+def skip_if_no_pandas(func):
     @functools.wraps(func)
     def wrapper(self, *args, **kwargs):
         if not _has_pandas:
@@ -965,7 +965,7 @@ class TestDataMethods(unittest.TestCase):
             self.total_value,
             sum(values))
 
-    @skipIfNoPandas
+    @skip_if_no_pandas
     def test_execute_mdx_dataframe_pivot(self):
         mdx = MdxBuilder.from_cube(CUBE_NAME) \
             .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[0], DIMENSION_NAMES[0]).head(7)) \
@@ -977,7 +977,7 @@ class TestDataMethods(unittest.TestCase):
         pivot = self.tm1.cubes.cells.execute_mdx_dataframe_pivot(mdx=mdx)
         self.assertEqual(pivot.shape, (7, 8))
     
-    @skipIfNoPandas
+    @skip_if_no_pandas
     def test_execute_mdx_dataframe_pivot_no_titles(self):
         mdx = MdxBuilder.from_cube(CUBE_NAME) \
             .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[0], DIMENSION_NAMES[0]).head(7)) \
@@ -1467,7 +1467,7 @@ class TestDataMethods(unittest.TestCase):
         # check type
         self.assertIsInstance(values, dict)
 
-    @skipIfNoPandas
+    @skip_if_no_pandas
     def test_execute_view_dataframe(self):
         df = self.tm1.cubes.cells.execute_view_dataframe(
             cube_name=CUBE_NAME,
@@ -1502,7 +1502,7 @@ class TestDataMethods(unittest.TestCase):
         # check type
         self.assertIsInstance(df, pd.DataFrame)
 
-    @skipIfNoPandas
+    @skip_if_no_pandas
     def test_execute_view_dataframe_pivot_two_row_one_column_dimensions(self):
         view_name = PREFIX + "Pivot_two_row_one_column_dimensions"
         view = NativeView(
@@ -1532,7 +1532,7 @@ class TestDataMethods(unittest.TestCase):
             view_name=view_name)
         self.assertEqual((100, 10), pivot.shape)
 
-    @skipIfNoPandas
+    @skip_if_no_pandas
     def test_execute_view_dataframe_pivot_one_row_two_column_dimensions(self):
         view_name = PREFIX + "Pivot_one_row_two_column_dimensions"
         view = NativeView(
@@ -1564,7 +1564,7 @@ class TestDataMethods(unittest.TestCase):
             view_name=view_name)
         self.assertEqual((10, 100), pivot.shape)
 
-    @skipIfNoPandas
+    @skip_if_no_pandas
     def test_execute_view_dataframe_pivot_one_row_one_column_dimensions(self):
         view_name = PREFIX + "Pivot_one_row_one_column_dimensions"
         view = NativeView(
@@ -1594,7 +1594,7 @@ class TestDataMethods(unittest.TestCase):
             view_name=view_name)
         self.assertEqual((10, 10), pivot.shape)
 
-    @skipIfNoPandas
+    @skip_if_no_pandas
     def test_execute_mdxview_dataframe_pivot(self):
         mdx = MdxBuilder.from_cube(CUBE_NAME) \
             .add_hierarchy_set_to_row_axis(MdxHierarchySet.default_member(DIMENSION_NAMES[0])) \

--- a/Tests/Utils.py
+++ b/Tests/Utils.py
@@ -24,7 +24,7 @@ except ImportError:
     _has_pandas = False
 
 
-def skipIfNoPandas(func):
+def skip_if_no_pandas(func):
     @functools.wraps(func)
     def wrapper(self, *args, **kwargs):
         if not _has_pandas:
@@ -256,7 +256,7 @@ class TestMDXUtils(unittest.TestCase):
         self.assertTrue("[dim1].[hier2].[elem2]" in element_unique_names)
         self.assertTrue("[dim1].[hier3].[elem3]" in element_unique_names)
 
-    @skipIfNoPandas
+    @skip_if_no_pandas
     def test_build_pandas_multiindex_dataframe_from_cellset(self):
         
         rows = [DimensionSelection(dimension_name=self.dim1_name),
@@ -283,7 +283,7 @@ class TestMDXUtils(unittest.TestCase):
         self.assertTrue(len(cellset.keys()) == 1000)
         self.assertIsInstance(cellset, Utils.CaseAndSpaceInsensitiveTuplesDict)
 
-    @skipIfNoPandas
+    @skip_if_no_pandas
     def test_build_pandas_dataframe_from_cellset(self):
         
         rows = [DimensionSelection(dimension_name=self.dim1_name),
@@ -316,7 +316,7 @@ class TestMDXUtils(unittest.TestCase):
         self.assertTrue(len(cellset.keys()) == 1000)
         self.assertIsInstance(cellset, Utils.CaseAndSpaceInsensitiveTuplesDict)
 
-    @skipIfNoPandas
+    @skip_if_no_pandas
     def test_build_pandas_dataframe_empty_cellset(self):
 
         self.tm1.cubes.cells.write_value(


### PR DESCRIPTION
I really like the move to making pandas optional and wanted to make sure the tests could still run too when pandas isn't installed.

This PR uses the import logic from Utils/Utils.py and adds a decorator to skip the relevant tests. Tests can now be run without pandas installed without throwing an error and the tests are skipped with a message.