### PR TITLE
Move skip_if_no_pandas to utils

### DIFF
--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -31,6 +31,7 @@ def require(version):
 
 
 def require_pandas(func):
+
     @functools.wraps(func)
     def wrapper(self, *args, **kwargs):
         try:
@@ -40,6 +41,19 @@ def require_pandas(func):
             raise ImportError(f"Function '{func.__name__}' requires pandas")
 
     return wrapper
+
+def skip_if_no_pandas(func):
+
+    @functools.wraps(func)
+    def wrapper(self, *args, **kwargs):
+        try:
+            import pandas
+            return func(self, *args, **kwargs)
+        except:
+            self.skipTest(f"Test '{func.__name__}' requires pandas")
+
+    return wrapper
+
 
 
 def get_all_servers_from_adminhost(adminhost='localhost') -> List:

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -31,8 +31,7 @@ def require(version):
 
 
 def require_pandas(func):
-
-    @functools.wraps(func)
+    @functools.wraps(func)  
     def wrapper(self, *args, **kwargs):
         try:
             import pandas

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -41,19 +41,6 @@ def require_pandas(func):
 
     return wrapper
 
-def skip_if_no_pandas(func):
-
-    @functools.wraps(func)
-    def wrapper(self, *args, **kwargs):
-        try:
-            import pandas
-            return func(self, *args, **kwargs)
-        except:
-            self.skipTest(f"Test '{func.__name__}' requires pandas")
-
-    return wrapper
-
-
 
 def get_all_servers_from_adminhost(adminhost='localhost') -> List:
     from TM1py.Objects import Server

--- a/Tests/Cell.py
+++ b/Tests/Cell.py
@@ -10,25 +10,12 @@ from mdxpy import MdxBuilder, MdxHierarchySet, Member, CalculatedMember
 from TM1py.Exceptions.Exceptions import TM1pyException, TM1pyVersionException
 from TM1py.Objects import MDXView, Cube, Dimension, Element, Hierarchy, NativeView, AnonymousSubset, ElementAttribute
 from TM1py.Services import TM1Service
-from TM1py.Utils import Utils, element_names_from_element_unique_names
+from TM1py.Utils import Utils, element_names_from_element_unique_names, skip_if_no_pandas
 
 try:
     import pandas as pd
-
-    _has_pandas = True
 except ImportError:
-    _has_pandas = False
-
-def skip_if_no_pandas(func):
-    @functools.wraps(func)
-    def wrapper(self, *args, **kwargs):
-        if not _has_pandas:
-            self.skipTest("Test requires Pandas which is not installed.")
-        else:
-            func(self, *args, **kwargs)
-
-    return wrapper
-
+    pass
 
 # Hard coded stuff
 PREFIX = 'TM1py_Tests_Cell_'

--- a/Tests/Cell.py
+++ b/Tests/Cell.py
@@ -10,7 +10,9 @@ from mdxpy import MdxBuilder, MdxHierarchySet, Member, CalculatedMember
 from TM1py.Exceptions.Exceptions import TM1pyException, TM1pyVersionException
 from TM1py.Objects import MDXView, Cube, Dimension, Element, Hierarchy, NativeView, AnonymousSubset, ElementAttribute
 from TM1py.Services import TM1Service
-from TM1py.Utils import Utils, element_names_from_element_unique_names, skip_if_no_pandas
+from TM1py.Utils import Utils, element_names_from_element_unique_names
+
+from .TestUtils import skip_if_no_pandas
 
 try:
     import pandas as pd

--- a/Tests/TestUtils.py
+++ b/Tests/TestUtils.py
@@ -1,0 +1,13 @@
+import functools
+
+def skip_if_no_pandas(func):
+
+    @functools.wraps(func)
+    def wrapper(self, *args, **kwargs):
+        try:
+            import pandas
+            return func(self, *args, **kwargs)
+        except:
+            self.skipTest(f"Test '{func.__name__}' requires pandas")
+
+    return wrapper

--- a/Tests/Utils.py
+++ b/Tests/Utils.py
@@ -14,26 +14,12 @@ from TM1py.Utils.MDXUtils import DimensionSelection, read_dimension_composition_
     read_dimension_composition_from_mdx_set_or_tuple, read_dimension_composition_from_mdx_set, \
     read_dimension_composition_from_mdx_tuple, split_mdx, _find_case_and_space_insensitive_first_occurrence
 from TM1py.Utils.Utils import dimension_hierarchy_element_tuple_from_unique_name, get_dimensions_from_where_clause, \
-    integerize_version, verify_version
+    integerize_version, verify_version, skip_if_no_pandas
 
 try:
     import pandas as pd
-
-    _has_pandas = True
 except ImportError:
-    _has_pandas = False
-
-
-def skip_if_no_pandas(func):
-    @functools.wraps(func)
-    def wrapper(self, *args, **kwargs):
-        if not _has_pandas:
-            self.skipTest("Test requires Pandas which is not installed.")
-        else:
-            func(self, *args, **kwargs)
-
-    return wrapper
-
+    pass
 
 
 config = configparser.ConfigParser()

--- a/Tests/Utils.py
+++ b/Tests/Utils.py
@@ -14,7 +14,9 @@ from TM1py.Utils.MDXUtils import DimensionSelection, read_dimension_composition_
     read_dimension_composition_from_mdx_set_or_tuple, read_dimension_composition_from_mdx_set, \
     read_dimension_composition_from_mdx_tuple, split_mdx, _find_case_and_space_insensitive_first_occurrence
 from TM1py.Utils.Utils import dimension_hierarchy_element_tuple_from_unique_name, get_dimensions_from_where_clause, \
-    integerize_version, verify_version, skip_if_no_pandas
+    integerize_version, verify_version
+
+from .TestUtils import skip_if_no_pandas
 
 try:
     import pandas as pd


### PR DESCRIPTION
Actually, this might be a more elegant way of handling the pandas checks. I moved the decorator to the same place as ```require_pandas``` and aligned the code. I also removed the globals set in the test files as they aren't necessary.

I think this might be a way to approach a similar decorator for skipping tests were the required version is too low. 

part of https://github.com/cubewise-code/tm1py/issues/301