### PR TITLE
Add decorator to skip tests where version insufficient

### DIFF
--- a/Tests/Cell.py
+++ b/Tests/Cell.py
@@ -12,7 +12,7 @@ from TM1py.Objects import MDXView, Cube, Dimension, Element, Hierarchy, NativeVi
 from TM1py.Services import TM1Service
 from TM1py.Utils import Utils, element_names_from_element_unique_names
 
-from .TestUtils import skip_if_no_pandas
+from .TestUtils import skip_if_no_pandas, skip_if_insufficient_version
 
 try:
     import pandas as pd
@@ -1730,6 +1730,7 @@ class TestDataMethods(unittest.TestCase):
         values = self.tm1.cubes.cells.execute_mdx_values(mdx=mdx, encoding="latin-1")
         self.assertNotEqual(LATIN_1_ENCODED_TEXT, next(values))
 
+    @skip_if_insufficient_version(version="11.7")
     def test_clear_with_mdx_happy_case(self):
         cells = {("Element17", "Element21", "Element15"): 1}
         self.tm1.cells.write_values(CUBE_NAME, cells)
@@ -1745,6 +1746,7 @@ class TestDataMethods(unittest.TestCase):
         value = next(self.tm1.cells.execute_mdx_values(mdx=mdx))
         self.assertEqual(value, None)
 
+    @skip_if_insufficient_version(version="11.7")
     def test_clear_with_mdx_all_on_axis0(self):
         cells = {("Element19", "Element11", "Element31"): 1}
         self.tm1.cells.write_values(CUBE_NAME, cells)
@@ -1759,6 +1761,7 @@ class TestDataMethods(unittest.TestCase):
         value = next(self.tm1.cells.execute_mdx_values(mdx=mdx))
         self.assertEqual(value, None)
 
+    @skip_if_insufficient_version(version="11.7")
     def test_clear_happy_case(self):
         cells = {("Element12", "Element17", "Element32"): 1}
         self.tm1.cells.write_values(CUBE_NAME, cells)
@@ -1779,6 +1782,7 @@ class TestDataMethods(unittest.TestCase):
         value = next(self.tm1.cells.execute_mdx_values(mdx=mdx))
         self.assertEqual(value, None)
 
+    @skip_if_insufficient_version(version="11.7")
     def test_clear_invalid_element_name(self):
         with pytest.raises(TM1pyException) as execinfo:
             kwargs = {
@@ -1792,6 +1796,7 @@ class TestDataMethods(unittest.TestCase):
             "{\"error\":{\"code\":\"248\",\"message\":\"\\\"NotExistingElement\\\" : member not found (rte 81)\"}}",
             execinfo.value.message)
 
+    @skip_if_insufficient_version(version="11.7")
     def test_clear_with_mdx_invalid_query(self):
         with pytest.raises(TM1pyException) as execinfo:
             mdx = f"""

--- a/Tests/TestUtils.py
+++ b/Tests/TestUtils.py
@@ -1,14 +1,18 @@
 import functools
+
 from TM1py.Utils.Utils import verify_version
+
 
 def skip_if_no_pandas(func):
     """ 
     Checks whether pandas is installed and skips the test if not
     """
+
     @functools.wraps(func)
     def wrapper(self, *args, **kwargs):
         try:
             import pandas
+
             return func(self, *args, **kwargs)
         except:
             return self.skipTest(f"Test '{func.__name__}' requires pandas")
@@ -25,7 +29,9 @@ def skip_if_insufficient_version(version):
         @functools.wraps(func)
         def wrapper(self, *args, **kwargs):
             if not verify_version(required_version=version, version=self.tm1.version):
-                return self.skipTest(f"Function '{ func.__name__, }' requires TM1 server version >= '{ version }'")
+                return self.skipTest(
+                    f"Function '{ func.__name__, }' requires TM1 server version >= '{ version }'"
+                )
             else:
                 return func(self, *args, **kwargs)
 

--- a/Tests/TestUtils.py
+++ b/Tests/TestUtils.py
@@ -1,13 +1,34 @@
 import functools
+from TM1py.Utils.Utils import verify_version
 
 def skip_if_no_pandas(func):
-
+    """ 
+    Checks whether pandas is installed and skips the test if not
+    """
     @functools.wraps(func)
     def wrapper(self, *args, **kwargs):
         try:
             import pandas
             return func(self, *args, **kwargs)
         except:
-            self.skipTest(f"Test '{func.__name__}' requires pandas")
+            return self.skipTest(f"Test '{func.__name__}' requires pandas")
 
     return wrapper
+
+
+def skip_if_insufficient_version(version):
+    """ 
+    Checks whether TM1 version is high enough and skips the test if not
+    """
+
+    def wrap(func):
+        @functools.wraps(func)
+        def wrapper(self, *args, **kwargs):
+            if not verify_version(required_version=version, version=self.tm1.version):
+                return self.skipTest(f"Function '{ func.__name__, }' requires TM1 server version >= '{ version }'")
+            else:
+                return func(self, *args, **kwargs)
+
+        return wrapper
+
+    return wrap


### PR DESCRIPTION
I've added another decorator that skips test where the version isn't high enough and applied it to some tests.