### PR TITLE
Add require version logic to CubeService methods and tests

### DIFF
--- a/TM1py/Services/CubeService.py
+++ b/TM1py/Services/CubeService.py
@@ -10,7 +10,7 @@ from TM1py.Services.CellService import CellService
 from TM1py.Services.ObjectService import ObjectService
 from TM1py.Services.RestService import RestService
 from TM1py.Services.ViewService import ViewService
-from TM1py.Utils import format_url
+from TM1py.Utils import format_url, require
 
 
 class CubeService(ObjectService):
@@ -159,6 +159,7 @@ class CubeService(ObjectService):
             return dimension_names[1:]
         return dimension_names
 
+    @require(version="11.4")
     def get_storage_dimension_order(self, cube_name: str, **kwargs) -> List[str]:
         """ Get the storage dimension order of a cube
 
@@ -169,6 +170,7 @@ class CubeService(ObjectService):
         response = self._rest.GET(url, **kwargs)
         return [dimension["Name"] for dimension in response.json()["value"]]
 
+    @require(version="11.4")
     def update_storage_dimension_order(self, cube_name: str, dimension_names: Iterable[str]) -> float:
         """ Update the storage dimension order of a cube
 
@@ -184,6 +186,7 @@ class CubeService(ObjectService):
         response = self._rest.POST(url=url, data=json.dumps(payload))
         return response.json()["value"]
 
+    @require(version="11.6")
     def load(self, cube_name: str, **kwargs) -> Response:
         """ Load the cube into memory on the server
 
@@ -193,6 +196,7 @@ class CubeService(ObjectService):
         url = format_url("/api/v1/Cubes('{}')/tm1.Load", cube_name)
         return self._rest.POST(url=url, **kwargs)
 
+    @require(version="11.6")
     def unload(self, cube_name: str, **kwargs) -> Response:
         """ Unload the cube from memory
 

--- a/Tests/Cube.py
+++ b/Tests/Cube.py
@@ -8,6 +8,9 @@ from TM1py.Objects import Cube
 from TM1py.Objects import Rules
 from TM1py.Services import TM1Service
 
+from .TestUtils import skip_if_insufficient_version
+
+
 config = configparser.ConfigParser()
 config.read(Path(__file__).parent.joinpath('config.ini'))
 
@@ -113,6 +116,7 @@ class TestCubeMethods(unittest.TestCase):
         all_cubes_after = self.tm1.cubes.get_all_names()
         self.assertEqual(len(all_cubes_before) - 1, len(all_cubes_after))
 
+    @skip_if_insufficient_version(version="11.4")
     def test_get_storage_dimension_order(self):
         dimensions = self.tm1.cubes.get_storage_dimension_order(cube_name=self.cube_name)
         self.assertEqual(dimensions, self.dimension_names)
@@ -121,6 +125,7 @@ class TestCubeMethods(unittest.TestCase):
         number_of_cubes = self.tm1.cubes.get_number_of_cubes()
         self.assertIsInstance(number_of_cubes, int)
 
+    @skip_if_insufficient_version(version="11.4")
     def test_update_storage_dimension_order(self):
         self.tm1.cubes.update_storage_dimension_order(
             cube_name=self.cube_name,
@@ -130,10 +135,12 @@ class TestCubeMethods(unittest.TestCase):
             list(reversed(dimensions)),
             self.dimension_names)
 
+    @skip_if_insufficient_version(version="11.6")
     def test_load(self):
         response = self.tm1.cubes.load(cube_name=self.cube_name)
         self.assertTrue(response.ok)
 
+    @skip_if_insufficient_version(version="11.6")
     def test_unload(self):
         response = self.tm1.cubes.unload(cube_name=self.cube_name)
         self.assertTrue(response.ok)


### PR DESCRIPTION
Going by these [release notes](https://www.ibm.com/support/knowledgecenter/SSD29G_2.0.0/com.ibm.swg.ba.cognos.tm1_rest_api.2.0.0.doc/r_restapi_v1_csdl_whats_new.html#restapi_v1_csdl_whats_new) I've added the require and skip_if_insufficient version decorators where the version isn't supported. 

All four tests were failing for me on 11.3 and will be skipped with these changes. I'm happy to just change the tests for now if you like but thought it might make sense to change CubeService.py at the same time.

Cheers
Alex