### PR TITLE
?s to start of str to remove deprecation warning

### DIFF
--- a/TM1py/Objects/Process.py
+++ b/TM1py/Objects/Process.py
@@ -20,7 +20,7 @@ class Process(TM1Object):
 
     @staticmethod
     def add_generated_string_to_code(code: str) -> str:
-        pattern = r"#\*\*\*\*Begin: Generated Statements(?s)(.*)#\*\*\*\*End: Generated Statements\*\*\*\*"
+        pattern = r"(?s)#\*\*\*\*Begin: Generated Statements(.*)#\*\*\*\*End: Generated Statements\*\*\*\*"
         if re.search(pattern=pattern, string=code):
             return code
         else:


### PR DESCRIPTION
As per the discussion in https://github.com/cubewise-code/tm1py/issues/309

I don't think this change breaks the functionality and suppresses a deprecation warning. 

What do you think? It's not urgent, on Python 3.8 it is still just throwing a warning.

Cheers
Alex