### PR TITLE
Skip tests that crash the server on 11.3

### DIFF
--- a/Tests/Process.py
+++ b/Tests/Process.py
@@ -219,6 +219,15 @@ class TestProcessMethods(unittest.TestCase):
         self.assertIn("Variable \"dimsize\" is undefined", errors[0]["Message"])
         self.tm1.processes.delete(p_bad.name)
 
+    @skip_if_insufficient_version(version="11.4")
+    def test_execute_process_with_return_success(self):	
+        process = Process(name=str(uuid.uuid4()))	
+        process.prolog_procedure = "Sleep(100);"	
+
+        success, status, error_log_file = self.tm1.processes.execute_process_with_return(process)	
+        self.assertTrue(success)	
+        self.assertEqual(status, "CompletedSuccessfully")	
+        self.assertIsNone(error_log_file)
 
     def test_execute_process_with_return_compile_error(self):
         process = Process(name=str(uuid.uuid4()))

--- a/Tests/Process.py
+++ b/Tests/Process.py
@@ -227,7 +227,7 @@ class TestProcessMethods(unittest.TestCase):
         self.assertTrue(success)
         self.assertEqual(status, "CompletedSuccessfully")
         self.assertIsNone(error_log_file)
-        
+
     def test_execute_process_with_return_compile_error(self):
         process = Process(name=str(uuid.uuid4()))
         process.prolog_procedure = "sText = 'text';sText = 2;"

--- a/Tests/Process.py
+++ b/Tests/Process.py
@@ -6,15 +6,15 @@ import unittest
 import uuid
 from pathlib import Path
 
-from TM1py.Objects import Process
-from TM1py.Objects import Subset
+from TM1py.Objects import Process, Subset
 from TM1py.Services import TM1Service
+
+from .TestUtils import skip_if_insufficient_version
 
 config = configparser.ConfigParser()
 config.read(Path(__file__).parent.joinpath('config.ini'))
 
 PROCESS_PREFIX = 'TM1py_Tests_'
-
 
 class TestProcessMethods(unittest.TestCase):
     tm1 = None
@@ -100,6 +100,7 @@ class TestProcessMethods(unittest.TestCase):
         cls.tm1.processes.delete(cls.p_odbc.name)
         cls.tm1.processes.delete(cls.p_subset.name)
 
+
     def test_execute_process(self):
         if not self.tm1.processes.exists(self.p_bedrock_server_wait.name):
             self.tm1.processes.create(self.p_bedrock_server_wait)
@@ -120,6 +121,7 @@ class TestProcessMethods(unittest.TestCase):
         # without arguments
         self.tm1.processes.execute(self.p_bedrock_server_wait.name)
 
+    @skip_if_insufficient_version(version="11.4")
     def test_execute_with_return_success(self):
         process = self.p_bedrock_server_wait
         if not self.tm1.processes.exists(process.name):
@@ -166,6 +168,7 @@ class TestProcessMethods(unittest.TestCase):
 
         self.tm1.processes.delete(process.name)
 
+    @skip_if_insufficient_version(version="11.4")
     def test_execute_with_return_with_process_break(self):
         process = Process(name=str(uuid.uuid4()))
         process.prolog_procedure = "sText = 'Something'; ProcessBreak;"
@@ -181,6 +184,7 @@ class TestProcessMethods(unittest.TestCase):
 
         self.tm1.processes.delete(process.name)
 
+    @skip_if_insufficient_version(version="11.4")
     def test_execute_with_return_with_process_quit(self):
         process = Process(name=str(uuid.uuid4()))
         process.prolog_procedure = "sText = 'Something'; ProcessQuit;"
@@ -215,15 +219,6 @@ class TestProcessMethods(unittest.TestCase):
         self.assertIn("Variable \"dimsize\" is undefined", errors[0]["Message"])
         self.tm1.processes.delete(p_bad.name)
 
-    # Unbound Tests
-    def test_execute_process_with_return_success(self):
-        process = Process(name=str(uuid.uuid4()))
-        process.prolog_procedure = "Sleep(100);"
-
-        success, status, error_log_file = self.tm1.processes.execute_process_with_return(process)
-        self.assertTrue(success)
-        self.assertEqual(status, "CompletedSuccessfully")
-        self.assertIsNone(error_log_file)
 
     def test_execute_process_with_return_compile_error(self):
         process = Process(name=str(uuid.uuid4()))
@@ -243,6 +238,7 @@ class TestProcessMethods(unittest.TestCase):
         self.assertEqual(status, "CompletedWithMessages")
         self.assertIsNotNone(error_log_file)
 
+    @skip_if_insufficient_version(version="11.4")
     def test_execute_process_with_return_with_process_break(self):
         process = Process(name=str(uuid.uuid4()))
         process.prolog_procedure = "sText = 'Something'; ProcessBreak;"
@@ -252,6 +248,7 @@ class TestProcessMethods(unittest.TestCase):
         self.assertEqual(status, "CompletedSuccessfully")
         self.assertIsNone(error_log_file)
 
+    @skip_if_insufficient_version(version="11.4")
     def test_execute_process_with_return_with_process_quit(self):
         process = Process(name=str(uuid.uuid4()))
         process.prolog_procedure = "sText = 'Something'; ProcessQuit;"
@@ -278,7 +275,6 @@ class TestProcessMethods(unittest.TestCase):
         self.assertTrue(len(errors) == 1)
         self.assertIn("Variable \"dimsize\" is undefined", errors[0]["Message"])
 
-    # Get Process
     def test_get_process(self):
         p_ascii_orig = copy.deepcopy(self.p_ascii)
         p_none_orig = copy.deepcopy(self.p_none)
@@ -299,7 +295,6 @@ class TestProcessMethods(unittest.TestCase):
         p5 = self.tm1.processes.get(p_subset_orig.name)
         self.assertEqual(p5.body, p_subset_orig.body)
 
-    # Update process
     def test_update_process(self):
         # get
         p = self.tm1.processes.get(self.p_ascii.name)
@@ -329,7 +324,6 @@ class TestProcessMethods(unittest.TestCase):
 
         self.tm1.processes.delete(process.name)
 
-    # Delete process
     def test_delete_process(self):
         process = self.p_bedrock_server_wait
         process.name = str(uuid.uuid4())

--- a/Tests/Process.py
+++ b/Tests/Process.py
@@ -100,7 +100,6 @@ class TestProcessMethods(unittest.TestCase):
         cls.tm1.processes.delete(cls.p_odbc.name)
         cls.tm1.processes.delete(cls.p_subset.name)
 
-
     def test_execute_process(self):
         if not self.tm1.processes.exists(self.p_bedrock_server_wait.name):
             self.tm1.processes.create(self.p_bedrock_server_wait)
@@ -220,15 +219,15 @@ class TestProcessMethods(unittest.TestCase):
         self.tm1.processes.delete(p_bad.name)
 
     @skip_if_insufficient_version(version="11.4")
-    def test_execute_process_with_return_success(self):	
-        process = Process(name=str(uuid.uuid4()))	
-        process.prolog_procedure = "Sleep(100);"	
+    def test_execute_process_with_return_success(self):
+        process = Process(name=str(uuid.uuid4()))
+        process.prolog_procedure = "Sleep(100);"
 
-        success, status, error_log_file = self.tm1.processes.execute_process_with_return(process)	
-        self.assertTrue(success)	
-        self.assertEqual(status, "CompletedSuccessfully")	
+        success, status, error_log_file = self.tm1.processes.execute_process_with_return(process)
+        self.assertTrue(success)
+        self.assertEqual(status, "CompletedSuccessfully")
         self.assertIsNone(error_log_file)
-
+        
     def test_execute_process_with_return_compile_error(self):
         process = Process(name=str(uuid.uuid4()))
         process.prolog_procedure = "sText = 'text';sText = 2;"


### PR DESCRIPTION
These tests cause the server being tested to crash (11.3). I think it's safe to mark them as requiring a greater version.

What do you think?

Cheers
Alex