### PR TITLE
get_*_elements_value_dict methods now return CaseAndSpaceInsensitiveDict

### DIFF
--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -598,7 +598,7 @@ class CellService(ObjectService):
 
     def execute_mdx_elements_value_dict(self, mdx: str, top: int = None, skip: int = None, skip_zeros: bool = True,
                                         skip_consolidated_cells: bool = False, skip_rule_derived_cells: bool = False,
-                                        element_separator: str = "|", **kwargs) -> Dict[str, Union[str, float]]:
+                                        element_separator: str = "|", **kwargs) -> CaseAndSpaceInsensitiveDict:
         """ Optimized for performance. Get Dict from MDX Query.
 
         :param mdx: Valid MDX Query
@@ -608,14 +608,17 @@ class CellService(ObjectService):
         :param skip_consolidated_cells: skip consolidated cells in cellset
         :param skip_rule_derived_cells: skip rule derived cells in cellset
         :param element_separator: separator for the dimension element combination
-        :return: Dict  {'2020|Jan|Sales': 2000, '2020|Feb|Sales': 3000}
+        :return: CaseAndSpaceInsensitiveDict {'2020|Jan|Sales': 2000, '2020|Feb|Sales': 3000}
         """
         lines = self.execute_mdx_csv(mdx=mdx, top=top, skip=skip, skip_zeros=skip_zeros,
                                      skip_consolidated_cells=skip_consolidated_cells,
                                      skip_rule_derived_cells=skip_rule_derived_cells,
                                      value_separator=element_separator, **kwargs)
-        return {element_separator.join(entries.split(element_separator)[:-1]): entries.split(element_separator)[-1]
-                for entries in lines.split("\r\n")[1:]}
+        elements_value_dict = CaseAndSpaceInsensitiveDict()
+        for entries in lines.split("\r\n")[1:]:
+            elements_value_dict[
+                element_separator.join(entries.split(element_separator)[:-1])] = entries.split(element_separator)[-1]
+        return elements_value_dict
 
     @require_pandas
     def execute_mdx_dataframe(self, mdx: str, top: int = None, skip: int = None, skip_zeros: bool = True,
@@ -713,7 +716,7 @@ class CellService(ObjectService):
     def execute_view_elements_value_dict(self, cube_name: str, view_name: str, private: bool = False,
                                          top: int = None, skip: int = None, skip_zeros: bool = True,
                                          skip_consolidated_cells: bool = False, skip_rule_derived_cells: bool = False,
-                                         element_separator: str = "|", **kwargs) -> Dict[str, Union[str, float]]:
+                                         element_separator: str = "|", **kwargs) -> CaseAndSpaceInsensitiveDict:
         """ Optimized for performance. Get a Dict(tuple, value) from an existing Cube View
         Context dimensions are omitted in the resulting Dataframe !
         Cells with Zero/null are omitted by default, but still configurable!
@@ -727,14 +730,17 @@ class CellService(ObjectService):
         :param skip_consolidated_cells: skip consolidated cells in cellset
         :param skip_rule_derived_cells: skip rule derived cells in cellset
         :param element_separator: separator for the dimension element combination
-        :return: Dict  {'2020|Jan|Sales': 2000, '2020|Feb|Sales': 3000}
+        :return: CaseAndSpaceInsensitiveDict {'2020|Jan|Sales': 2000, '2020|Feb|Sales': 3000}
         """
         lines = self.execute_view_csv(cube_name=cube_name, view_name=view_name, private=private, top=top, skip=skip,
                                       skip_zeros=skip_zeros, skip_consolidated_cells=skip_consolidated_cells,
                                       skip_rule_derived_cells=skip_rule_derived_cells,
                                       value_separator=element_separator, **kwargs)
-        return {element_separator.join(entries.split(element_separator)[:-1]): entries.split(element_separator)[-1]
-                for entries in lines.split("\r\n")[1:]}
+        elements_value_dict = CaseAndSpaceInsensitiveDict()
+        for entries in lines.split("\r\n")[1:]:
+            elements_value_dict[
+                element_separator.join(entries.split(element_separator)[:-1])] = entries.split(element_separator)[-1]
+        return elements_value_dict
 
     @require_pandas
     def execute_view_dataframe(self, cube_name: str, view_name: str, private: bool = False, top: int = None,

--- a/Tests/Cell.py
+++ b/Tests/Cell.py
@@ -10,7 +10,7 @@ from mdxpy import MdxBuilder, MdxHierarchySet, Member, CalculatedMember
 from TM1py.Exceptions.Exceptions import TM1pyException, TM1pyVersionException
 from TM1py.Objects import MDXView, Cube, Dimension, Element, Hierarchy, NativeView, AnonymousSubset, ElementAttribute
 from TM1py.Services import TM1Service
-from TM1py.Utils import Utils, element_names_from_element_unique_names
+from TM1py.Utils import Utils, element_names_from_element_unique_names, CaseAndSpaceInsensitiveDict
 
 from .TestUtils import skip_if_no_pandas, skip_if_insufficient_version
 
@@ -915,7 +915,7 @@ class TestDataMethods(unittest.TestCase):
         values = self.tm1.cubes.cells.execute_mdx_elements_value_dict(mdx)
 
         # check type
-        self.assertIsInstance(values, dict)
+        self.assertIsInstance(values, CaseAndSpaceInsensitiveDict)
 
         # check coordinates
         coordinates = {key for key, value in values.items()}
@@ -1434,7 +1434,7 @@ class TestDataMethods(unittest.TestCase):
             private=False)
 
         # check type
-        self.assertIsInstance(values, dict)
+        self.assertIsInstance(values, CaseAndSpaceInsensitiveDict)
 
         # check coordinates
         coordinates = {key for key, value in values.items()}
@@ -1455,7 +1455,7 @@ class TestDataMethods(unittest.TestCase):
         self.assertTrue(len(values) == 4)
 
         # check type
-        self.assertIsInstance(values, dict)
+        self.assertIsInstance(values, CaseAndSpaceInsensitiveDict)
 
     @skip_if_no_pandas
     def test_execute_view_dataframe(self):


### PR DESCRIPTION
As discussed on https://github.com/cubewise-code/tm1py/pull/295#issuecomment-670947982 lets convert the return type from `Dict` to `CaseAndSpaceInsensitiveDict`