### PR TITLE
Change pytest.raises to unittest's assertRaises

### DIFF
--- a/Tests/Cell.py
+++ b/Tests/Cell.py
@@ -3,14 +3,15 @@ import types
 import unittest
 from pathlib import Path
 
-from mdxpy import MdxBuilder, MdxHierarchySet, Member, CalculatedMember
+from mdxpy import CalculatedMember, MdxBuilder, MdxHierarchySet, Member
 
 from TM1py.Exceptions.Exceptions import TM1pyException, TM1pyVersionException
-from TM1py.Objects import MDXView, Cube, Dimension, Element, Hierarchy, NativeView, AnonymousSubset, ElementAttribute
+from TM1py.Objects import (AnonymousSubset, Cube, Dimension, Element,
+                           ElementAttribute, Hierarchy, MDXView, NativeView)
 from TM1py.Services import TM1Service
 from TM1py.Utils import Utils, element_names_from_element_unique_names, CaseAndSpaceInsensitiveDict
 
-from .TestUtils import skip_if_no_pandas, skip_if_insufficient_version
+from .TestUtils import skip_if_insufficient_version, skip_if_no_pandas
 
 try:
     import pandas as pd

--- a/Tests/Cell.py
+++ b/Tests/Cell.py
@@ -2,9 +2,7 @@ import configparser
 import types
 import unittest
 from pathlib import Path
-import functools
 
-import pytest
 from mdxpy import MdxBuilder, MdxHierarchySet, Member, CalculatedMember
 
 from TM1py.Exceptions.Exceptions import TM1pyException, TM1pyVersionException
@@ -1785,7 +1783,8 @@ class TestDataMethods(unittest.TestCase):
 
     @skip_if_insufficient_version(version="11.7")
     def test_clear_invalid_element_name(self):
-        with pytest.raises(TM1pyException) as execinfo:
+
+        with self.assertRaises(TM1pyException) as e:
             kwargs = {
                 DIMENSION_NAMES[0]: f"[{DIMENSION_NAMES[0]}].[Element12]",
                 DIMENSION_NAMES[1]: f"[{DIMENSION_NAMES[1]}].[Element17]",
@@ -1795,11 +1794,11 @@ class TestDataMethods(unittest.TestCase):
 
         self.assertEqual(
             "{\"error\":{\"code\":\"248\",\"message\":\"\\\"NotExistingElement\\\" : member not found (rte 81)\"}}",
-            execinfo.value.message)
+            str(e.exception))
 
     @skip_if_insufficient_version(version="11.7")
     def test_clear_with_mdx_invalid_query(self):
-        with pytest.raises(TM1pyException) as execinfo:
+        with self.assertRaises(TM1pyException) as e:
             mdx = f"""
             SELECT
             {{[{DIMENSION_NAMES[0]}].[NotExistingElement]}} ON 0
@@ -1809,21 +1808,24 @@ class TestDataMethods(unittest.TestCase):
 
         self.assertEqual(
             "{\"error\":{\"code\":\"248\",\"message\":\"\\\"NotExistingElement\\\" : member not found (rte 81)\"}}",
-            execinfo.value.message)
+            str(e.exception))
 
     def test_clear_with_mdx_unsupported_version(self):
-        with pytest.raises(TM1pyVersionException) as exec_info:
+
+        with self.assertRaises(TM1pyVersionException) as e:
             mdx = MdxBuilder.from_cube(CUBE_NAME) \
                 .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[0], "Element19"))) \
                 .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[1], "Element11"))) \
                 .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[2], "Element31"))) \
                 .to_mdx()
+
+            # This needs to be rethought as may influence other tests
             self.tm1._tm1_rest._version = "11.2.00000.27"
+
             self.tm1.cells.clear_with_mdx(cube=CUBE_NAME, mdx=mdx)
 
-        self.assertEqual(
-            f"Function 'clear_with_mdx' requires TM1 server version >= '11.7'",
-            str(exec_info.value))
+        self.assertEqual(str(e.exception), str(TM1pyVersionException(function = "clear_with_mdx", required_version="11.7")))
+
 
     def test_execute_mdx_with_skip(self):
         mdx = MdxBuilder.from_cube(CUBE_NAME) \

--- a/Tests/Hierarchy.py
+++ b/Tests/Hierarchy.py
@@ -3,7 +3,7 @@ import unittest
 from pathlib import Path
 
 from TM1py import Element
-from TM1py.Exceptions import TM1pyRestException, TM1pyException
+from TM1py.Exceptions import TM1pyException, TM1pyRestException
 from TM1py.Objects import Dimension, Hierarchy, Subset
 from TM1py.Services import TM1Service
 

--- a/Tests/Hierarchy.py
+++ b/Tests/Hierarchy.py
@@ -3,7 +3,7 @@ import unittest
 from pathlib import Path
 
 from TM1py import Element
-from TM1py.Exceptions import TM1pyException, TM1pyRestException
+from TM1py.Exceptions import TM1pyException
 from TM1py.Objects import Dimension, Hierarchy, Subset
 from TM1py.Services import TM1Service
 

--- a/Tests/Hierarchy.py
+++ b/Tests/Hierarchy.py
@@ -2,10 +2,8 @@ import configparser
 import unittest
 from pathlib import Path
 
-import pytest
-
 from TM1py import Element
-from TM1py.Exceptions import TM1pyRestException
+from TM1py.Exceptions import TM1pyRestException, TM1pyException
 from TM1py.Objects import Dimension, Hierarchy, Subset
 from TM1py.Services import TM1Service
 
@@ -370,9 +368,10 @@ class TestHierarchyMethods(unittest.TestCase):
         self.assertEqual(hierarchy.edges[("Total Years", "No Year")], 1)
 
     def test_add_edges_fail_existing(self):
-        edges = {("Total Years", "1989"): 1}
-        with pytest.raises(TM1pyRestException):
+        with self.assertRaises(TM1pyException) as e:
+            edges = {("Total Years", "1989"): 1}
             self.tm1.dimensions.hierarchies.add_edges(DIMENSION_NAME, DIMENSION_NAME, edges)
+        
 
     def test_is_balanced_false(self):
         is_balanced = self.tm1.dimensions.hierarchies.is_balanced(DIMENSION_NAME, DIMENSION_NAME)

--- a/Tests/Security.py
+++ b/Tests/Security.py
@@ -2,8 +2,6 @@ import configparser
 import unittest
 from pathlib import Path
 
-import pytest
-
 from TM1py.Objects import User
 from TM1py.Objects.User import UserType
 from TM1py.Services import TM1Service
@@ -83,12 +81,12 @@ class TestSecurityMethods(unittest.TestCase):
         self.assertNotIn(self.group_name2, groups)
 
     def test_user_type_invalid_type(self):
-        with pytest.raises(ValueError):
-            user = User("not_relevant", groups=["ADMIN"], user_type=3)
+        with self.assertRaises(ValueError) as e:
+            self.tm1.security.create_user(User("not_relevant", groups=["ADMIN"], user_type=3))
 
     def test_user_type_invalid_str(self):
-        with pytest.raises(ValueError):
-            user = User("not_relevant", groups=["ADMIN"], user_type="not_a_valid_type")
+        with self.assertRaises(ValueError) as e:
+            self.tm1.security.create_user(User("not_relevant", groups=["ADMIN"], user_type="not_a_valid_type"))
 
     def test_user_type_derive_user_from_groups(self):
         user = User("not_relevant", groups=["Marketing"], user_type=None)


### PR DESCRIPTION
I noticed a couple of the tests use pytest. I like pytest but since we're using unittest for 99% of the tests, I think it makes sense to replace these pytest methods with equivalent unittest logic.

What do you think?

Cheers
Alex