### PR TITLE
Fix some imports in Tests

### DIFF
--- a/Tests/PowerBiService.py
+++ b/Tests/PowerBiService.py
@@ -1,5 +1,4 @@
 import configparser
-import os
 import unittest
 from pathlib import Path
 

--- a/Tests/Security.py
+++ b/Tests/Security.py
@@ -1,7 +1,9 @@
 import configparser
 import unittest
 from pathlib import Path
+from base64 import b64encode
 
+from TM1py.Exceptions import TM1pyRestException
 from TM1py.Objects import User
 from TM1py.Objects.User import UserType
 from TM1py.Services import TM1Service


### PR DESCRIPTION
I realised I broke the Security tests by removing a couple of imports erroneously, might have messed up the conflict resolution :|

Also removes unused import of os in the power BI service tests.

Cheers
Alex