### PR TITLE
skip tests in applications that fail on 11.3

### DIFF
--- a/Tests/Application.py
+++ b/Tests/Application.py
@@ -10,6 +10,8 @@ from TM1py import TM1Service, Element, ElementAttribute, Hierarchy, Dimension, C
 from TM1py.Objects.Application import CubeApplication, ApplicationTypes, ChoreApplication, DimensionApplication, \
     FolderApplication, LinkApplication, ProcessApplication, SubsetApplication, ViewApplication, DocumentApplication
 
+from .TestUtils import skip_if_insufficient_version
+
 # Hard coded stuff
 PREFIX = 'TM1py_Tests_Applications_'
 TM1PY_APP_FOLDER = PREFIX + "RootFolder"
@@ -209,9 +211,11 @@ class TestDataMethods(unittest.TestCase):
     def test_dimension_application_private(self):
         self.run_test_dimension_application(private=True)
 
+    @skip_if_insufficient_version(version="11.4")
     def test_dimension_application_public(self):
         self.run_test_dimension_application(private=False)
 
+    @skip_if_insufficient_version(version="11.4")
     def run_test_document_application(self, private):
         with open(Path(__file__).parent.joinpath('resources', 'document.xlsx'), "rb") as file:
             app = DocumentApplication(path=TM1PY_APP_FOLDER, name=DOCUMENT_NAME, content=file.read())


### PR DESCRIPTION
Another little change to skip a couple of further tests that fail on my setup.

Note I couldn't find anything in the release notes to pinpoint this so might just be a point release bug but the error I get is below for reference. It might just be down to the way all the TM1 artifacts are arranged for these tests (which I still want to clean up) but thought it makes sense to use the version skip for now, especially if it's not causing an issue for others.

Cheers
Alex

```
Tests/Application.py:218: in run_test_document_application
    self.tm1.applications.create(application=app, private=private)
TM1py/Services/ApplicationService.py:170: in create
    url = format_url(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

url = "/api/v1/Contents('Applications'){/Contents('TM1py_Tests_Applications_RootFolder')}/Contents('{name}.blob')/Document/Content", args = [], kwargs = {'name': 'TM1py_Tests_Applications_Document'}

    def format_url(url, *args: str, **kwargs: str) -> str:
        """ build url and escape single quotes in args and kwargs
    
        :param url: url with {} placeholders
        :param args: arguments to placeholders
        :return:
        """
        args = [build_url_friendly_object_name(arg) if isinstance(arg, str) else arg
                for arg
                in args]
    
        kwargs = {key: build_url_friendly_object_name(value) if isinstance(value, str) else value
                  for key, value
                  in kwargs.items()}
    
>       return url.format(*args, **kwargs)
E       KeyError: "/Contents('TM1py_Tests_Applications_RootFolder')"
```