### PR TITLE
skip a test that fails <=11.7

### DIFF
--- a/Tests/Chore.py
+++ b/Tests/Chore.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from TM1py.Objects import Chore, ChoreStartTime, ChoreFrequency, ChoreTask, Process
 from TM1py.Services import TM1Service
 
+from .TestUtils import skip_if_insufficient_version
+
 # Hard stuff for this test
 PREFIX = "TM1py_Tests_Chore_"
 PROCESS_NAME1 = PREFIX + 'Process1'
@@ -104,6 +106,7 @@ class TestChoreMethods(unittest.TestCase):
         if cls.tm1.chores.exists(CHORE_NAME4):
             cls.tm1.chores.delete(CHORE_NAME4)
 
+    @skip_if_insufficient_version(version="11.7.00002.1")
     def test_create_chore_with_dst(self):
         # create chores
         c4 = Chore(name=CHORE_NAME4,


### PR DESCRIPTION
Another test to skip, as per comment here:

https://github.com/cubewise-code/tm1py/blob/e3e2c69a494d9cec5b2904c11ade3cd673ca9579/Tests/Chore.py#L127

It might just be the assert around the multiple/single commit mode so the test can possibly be split into two to test the rest of the functionality.


https://github.com/cubewise-code/tm1py/issues/301