### PR TITLE
Testing/class renaming and removing imports from __init__.py

### DIFF
--- a/Tests/Application.py
+++ b/Tests/Application.py
@@ -30,7 +30,7 @@ DIMENSION_NAMES = [
     PREFIX + 'Dimension3']
 
 
-class TestDataMethods(unittest.TestCase):
+class TestApplicationMethods(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:

--- a/Tests/Cell.py
+++ b/Tests/Cell.py
@@ -47,7 +47,7 @@ DIMENSION_RPS1_NAME = PREFIX + "Dimension" + "_RPS1"
 DIMENSION_RPS2_NAME = PREFIX + "Dimension" + "_RPS2"
 
 
-class TestDataMethods(unittest.TestCase):
+class TestCellMethods(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):

--- a/Tests/Cell.py
+++ b/Tests/Cell.py
@@ -251,6 +251,7 @@ class TestDataMethods(unittest.TestCase):
         response = self.tm1.cubes.cells.write_values(CUBE_NAME, self.cellset)
         self.assertTrue(response.ok)
 
+    @unittest.skip("Failing")
     def test_relative_proportional_spread_happy_case(self):
         self.build_assets_for_relative_proportional_spread_tests()
 
@@ -280,6 +281,7 @@ class TestDataMethods(unittest.TestCase):
         self.assertEqual(next(values), 4)
         self.assertEqual(next(values), 6)
 
+    @unittest.skip("Failing")
     def test_relative_proportional_with_explicit_hierarchies(self):
         self.build_assets_for_relative_proportional_spread_tests()
 
@@ -311,6 +313,7 @@ class TestDataMethods(unittest.TestCase):
         self.assertEqual(next(values), 4)
         self.assertEqual(next(values), 6)
 
+    @unittest.skip("Failing")
     def test_relative_proportional_spread_without_reference_cube(self):
         self.build_assets_for_relative_proportional_spread_tests()
 
@@ -339,6 +342,7 @@ class TestDataMethods(unittest.TestCase):
         self.assertEqual(next(values), 4)
         self.assertEqual(next(values), 6)
 
+    @unittest.skip("Failing")
     def test_relative_proportional_spread_with_different_reference_cube(self):
         self.build_assets_for_relative_proportional_spread_tests()
 
@@ -737,6 +741,7 @@ class TestDataMethods(unittest.TestCase):
                     self.assertNotIn("UniqueName", member)
                     self.assertNotIn("Ordinal", member)
 
+    @unittest.skip("Failing")
     def test_execute_mdx_values(self):
         self.tm1.cells.write_values(CUBE_NAME, self.cellset)
 
@@ -1398,6 +1403,7 @@ class TestDataMethods(unittest.TestCase):
             top=5)
         self.assertEqual(len(raw["Cells"]), 5)
 
+    @unittest.skip("Failing")
     def test_execute_view_values(self):
         cell_values = self.tm1.cubes.cells.execute_view_values(cube_name=CUBE_NAME, view_name=VIEW_NAME, private=False)
 
@@ -1648,6 +1654,7 @@ class TestDataMethods(unittest.TestCase):
             view_name=VIEW_NAME,
             private=False)
 
+    @unittest.skip("Failing")
     def test_write_values_through_cellset(self):
         mdx = MdxBuilder.from_cube(CUBE_NAME) \
             .add_hierarchy_set_to_row_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[0], "element2"))) \
@@ -1681,6 +1688,7 @@ class TestDataMethods(unittest.TestCase):
         value = self.tm1.cubes.cells.get_value("}CubeProperties", "{},LOGGING".format(CUBE_NAME))
         self.assertEqual("YES", value.upper())
 
+    @unittest.skip("Failing")
     def test_read_write_with_custom_encoding(self):
         coordinates = ("d1e1", "d2e2", "d3e3")
         self.tm1.cubes.cells.write_values(STRING_CUBE_NAME, {coordinates: LATIN_1_ENCODED_TEXT}, encoding="latin-1")
@@ -1697,6 +1705,7 @@ class TestDataMethods(unittest.TestCase):
         values = self.tm1.cubes.cells.execute_mdx_values(mdx=mdx, encoding="latin-1")
         self.assertEqual(LATIN_1_ENCODED_TEXT, next(values))
 
+    @unittest.skip("Failing")
     def test_read_write_with_custom_encoding_fail_response_encoding(self):
         coordinates = ("d1e1", "d2e2", "d3e3")
         self.tm1.cubes.cells.write_values(STRING_CUBE_NAME, {coordinates: LATIN_1_ENCODED_TEXT}, encoding="latin-1")
@@ -1714,6 +1723,7 @@ class TestDataMethods(unittest.TestCase):
 
         self.assertNotEqual(LATIN_1_ENCODED_TEXT, next(values))
 
+    @unittest.skip("Failing")
     def test_read_write_with_custom_encoding_fail_request_encoding(self):
         coordinates = ("d1e1", "d2e2", "d3e3")
         self.tm1.cubes.cells.write_values(STRING_CUBE_NAME, {coordinates: LATIN_1_ENCODED_TEXT})

--- a/Tests/Cell.py
+++ b/Tests/Cell.py
@@ -741,7 +741,6 @@ class TestDataMethods(unittest.TestCase):
                     self.assertNotIn("UniqueName", member)
                     self.assertNotIn("Ordinal", member)
 
-    @unittest.skip("Failing")
     def test_execute_mdx_values(self):
         self.tm1.cells.write_values(CUBE_NAME, self.cellset)
 
@@ -755,7 +754,7 @@ class TestDataMethods(unittest.TestCase):
         cell_values = self.tm1.cubes.cells.execute_mdx_values(mdx)
         self.assertIsInstance(
             cell_values,
-            types.GeneratorType)
+            list)
         # Check if total value is the same. Handle None.
         self.assertEqual(
             self.total_value,

--- a/Tests/Cell.py
+++ b/Tests/Cell.py
@@ -1,5 +1,4 @@
 import configparser
-import types
 import unittest
 from pathlib import Path
 
@@ -10,7 +9,6 @@ from TM1py.Objects import (AnonymousSubset, Cube, Dimension, Element,
                            ElementAttribute, Hierarchy, MDXView, NativeView)
 from TM1py.Services import TM1Service
 from TM1py.Utils import Utils, element_names_from_element_unique_names, CaseAndSpaceInsensitiveDict
-
 from .TestUtils import skip_if_insufficient_version, skip_if_no_pandas
 
 try:
@@ -22,7 +20,7 @@ except ImportError:
 PREFIX = 'TM1py_Tests_Cell_'
 CUBE_NAME = PREFIX + "Cube"
 VIEW_NAME = PREFIX + "View"
-DIMENSION_NAMES = [ 
+DIMENSION_NAMES = [
     PREFIX + 'Dimension1',
     PREFIX + 'Dimension2',
     PREFIX + 'Dimension3']
@@ -279,7 +277,7 @@ class TestDataMethods(unittest.TestCase):
             Member.of(DIMENSION_RPS2_NAME, "e3")])).to_mdx()
 
         values = self.tm1.cubes.cells.execute_mdx_values(mdx)
-        
+
         self.assertEqual(values[0], 2)
         self.assertEqual(values[1], 4)
         self.assertEqual(values[2], 6)
@@ -389,7 +387,6 @@ class TestDataMethods(unittest.TestCase):
         self.assertEqual(
             self.total_value, sum(v["Value"] for v in data.values() if v["Value"])
         )
-
 
         # MDX with top
         data = self.tm1.cubes.cells.execute_mdx(mdx, top=5)
@@ -974,7 +971,7 @@ class TestDataMethods(unittest.TestCase):
 
         pivot = self.tm1.cubes.cells.execute_mdx_dataframe_pivot(mdx=mdx)
         self.assertEqual(pivot.shape, (7, 8))
-    
+
     @skip_if_no_pandas
     def test_execute_mdx_dataframe_pivot_no_titles(self):
         mdx = MdxBuilder.from_cube(CUBE_NAME) \
@@ -1751,8 +1748,7 @@ class TestDataMethods(unittest.TestCase):
 
         self.tm1.cells.clear_with_mdx(cube=CUBE_NAME, mdx=mdx)
 
-        # this may need looking at
-        value = next(self.tm1.cells.execute_mdx_values(mdx=mdx))
+        value = self.tm1.cells.execute_mdx_values(mdx=mdx)[0]
         self.assertEqual(value, None)
 
     @skip_if_insufficient_version(version="11.7")
@@ -1767,8 +1763,7 @@ class TestDataMethods(unittest.TestCase):
             .to_mdx()
         self.tm1.cells.clear_with_mdx(cube=CUBE_NAME, mdx=mdx)
 
-        # this may need looking at
-        value = next(self.tm1.cells.execute_mdx_values(mdx=mdx))
+        value = self.tm1.cells.execute_mdx_values(mdx=mdx)[0]
         self.assertEqual(value, None)
 
     @skip_if_insufficient_version(version="11.7")
@@ -1789,8 +1784,7 @@ class TestDataMethods(unittest.TestCase):
             .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[2], "Element32"))) \
             .to_mdx()
 
-        # this may need looking at
-        value = next(self.tm1.cells.execute_mdx_values(mdx=mdx))
+        value = self.tm1.cells.execute_mdx_values(mdx=mdx)[0]
         self.assertEqual(value, None)
 
     @skip_if_insufficient_version(version="11.7")
@@ -1806,7 +1800,7 @@ class TestDataMethods(unittest.TestCase):
 
         self.assertEqual(
             "{\"error\":{\"code\":\"248\",\"message\":\"\\\"NotExistingElement\\\" : member not found (rte 81)\"}}",
-            str(e.exception))
+            str(e.exception.message))
 
     @skip_if_insufficient_version(version="11.7")
     def test_clear_with_mdx_invalid_query(self):
@@ -1820,7 +1814,7 @@ class TestDataMethods(unittest.TestCase):
 
         self.assertEqual(
             "{\"error\":{\"code\":\"248\",\"message\":\"\\\"NotExistingElement\\\" : member not found (rte 81)\"}}",
-            str(e.exception))
+            str(e.exception.message))
 
     def test_clear_with_mdx_unsupported_version(self):
 
@@ -1836,8 +1830,9 @@ class TestDataMethods(unittest.TestCase):
 
             self.tm1.cells.clear_with_mdx(cube=CUBE_NAME, mdx=mdx)
 
-        self.assertEqual(str(e.exception), str(TM1pyVersionException(function = "clear_with_mdx", required_version="11.7")))
-
+        self.assertEqual(
+            str(e.exception),
+            str(TM1pyVersionException(function="clear_with_mdx", required_version="11.7")))
 
     def test_execute_mdx_with_skip(self):
         mdx = MdxBuilder.from_cube(CUBE_NAME) \

--- a/Tests/Cell.py
+++ b/Tests/Cell.py
@@ -78,7 +78,7 @@ class TestDataMethods(unittest.TestCase):
             else:
                 cls.tm1.dimensions.create(dimension)
             attribute_cube = "}ElementAttributes_" + dimension_name
-            attribute_values = dict()
+            attribute_values = {}
             for element in elements:
                 attribute_values[(element.name, "Attr1")] = "TM1py"
                 attribute_values[(element.name, "Attr2")] = "2"
@@ -123,8 +123,8 @@ class TestDataMethods(unittest.TestCase):
 
         # cellset of data that shall be written
         cls.cellset = Utils.CaseAndSpaceInsensitiveTuplesDict()
+        value = 1
         for element1, element2, element3 in cls.target_coordinates:
-            value = 1
             cls.cellset[(element1, element2, element3)] = value
 
         # Sum of all the values that we write in the cube. serves as a checksum.

--- a/Tests/Cell.py
+++ b/Tests/Cell.py
@@ -386,7 +386,10 @@ class TestDataMethods(unittest.TestCase):
 
         data = self.tm1.cubes.cells.execute_mdx(mdx)
         # Check if total value is the same AND coordinates are the same. Handle None
-        self.assertEqual(self.total_value, sum([v["Value"] for v in data.values() if v["Value"]]))
+        self.assertEqual(
+            self.total_value, sum(v["Value"] for v in data.values() if v["Value"])
+        )
+
 
         # MDX with top
         data = self.tm1.cubes.cells.execute_mdx(mdx, top=5)
@@ -406,9 +409,7 @@ class TestDataMethods(unittest.TestCase):
         data = self.tm1.cubes.cells.execute_mdx(mdx, cell_properties=["Value", "Ordinal"])
         self.assertEqual(1000, len(data))
         self.assertEqual(2000, sum(v["Value"] for v in data.values()))
-        self.assertEqual(
-            sum(range(0, 1000)),
-            sum(v["Ordinal"] for v in data.values()))
+        self.assertEqual(sum(range(1000)), sum(v["Ordinal"] for v in data.values()))
 
     def test_execute_mdx_without_rows(self):
         # write cube content
@@ -425,7 +426,10 @@ class TestDataMethods(unittest.TestCase):
 
         data = self.tm1.cubes.cells.execute_mdx(mdx)
         # Check if total value is the same AND coordinates are the same. Handle None
-        self.assertEqual(self.total_value, sum([v["Value"] for v in data.values() if v["Value"]]))
+        self.assertEqual(
+            self.total_value, sum(v["Value"] for v in data.values() if v["Value"])
+        )
+
         for coordinates in data.keys():
             self.assertEqual(len(coordinates), 3)
             self.assertIn("[TM1py_Tests_Cell_Dimension1].", coordinates[0])
@@ -447,7 +451,10 @@ class TestDataMethods(unittest.TestCase):
 
         data = self.tm1.cubes.cells.execute_mdx(mdx)
         # Check if total value is the same AND coordinates are the same. Handle None
-        self.assertEqual(self.total_value, sum([v["Value"] for v in data.values() if v["Value"]]))
+        self.assertEqual(
+            self.total_value, sum(v["Value"] for v in data.values() if v["Value"])
+        )
+
         for coordinates in data.keys():
             self.assertEqual(len(coordinates), 3)
             self.assertIn("[TM1py_Tests_Cell_Dimension1].", coordinates[0])
@@ -756,9 +763,7 @@ class TestDataMethods(unittest.TestCase):
             cell_values,
             list)
         # Check if total value is the same. Handle None.
-        self.assertEqual(
-            self.total_value,
-            sum([v for v in cell_values if v]))
+        self.assertEqual(self.total_value, sum(v for v in cell_values if v))
         # Define MDX Query with calculated MEMBER
         mdx = "WITH MEMBER[{}].[{}] AS 2 " \
               "SELECT[{}].MEMBERS ON ROWS, " \
@@ -1409,8 +1414,7 @@ class TestDataMethods(unittest.TestCase):
         self.assertIsInstance(cell_values, list)
 
         # Check if total value is the same AND coordinates are the same. Handle None.
-        self.assertEqual(self.total_value,
-                         sum([v for v in cell_values if v]))
+        self.assertEqual(self.total_value, sum(v for v in cell_values if v))
 
     def test_execute_view_csv(self):
         csv = self.tm1.cubes.cells.execute_view_csv(cube_name=CUBE_NAME, view_name=VIEW_NAME, private=False)

--- a/Tests/Cell.py
+++ b/Tests/Cell.py
@@ -251,8 +251,10 @@ class TestDataMethods(unittest.TestCase):
         response = self.tm1.cubes.cells.write_values(CUBE_NAME, self.cellset)
         self.assertTrue(response.ok)
 
-    @unittest.skip("Failing")
     def test_relative_proportional_spread_happy_case(self):
+        """
+        Tests that relative proportional spread populates a cube with the expected values
+        """
         self.build_assets_for_relative_proportional_spread_tests()
 
         cells = {
@@ -277,11 +279,11 @@ class TestDataMethods(unittest.TestCase):
             Member.of(DIMENSION_RPS2_NAME, "e3")])).to_mdx()
 
         values = self.tm1.cubes.cells.execute_mdx_values(mdx)
-        self.assertEqual(next(values), 2)
-        self.assertEqual(next(values), 4)
-        self.assertEqual(next(values), 6)
+        
+        self.assertEqual(values[0], 2)
+        self.assertEqual(values[1], 4)
+        self.assertEqual(values[2], 6)
 
-    @unittest.skip("Failing")
     def test_relative_proportional_with_explicit_hierarchies(self):
         self.build_assets_for_relative_proportional_spread_tests()
 
@@ -309,11 +311,10 @@ class TestDataMethods(unittest.TestCase):
             Member.of(DIMENSION_RPS2_NAME, "e3")])).to_mdx()
 
         values = self.tm1.cubes.cells.execute_mdx_values(mdx)
-        self.assertEqual(next(values), 2)
-        self.assertEqual(next(values), 4)
-        self.assertEqual(next(values), 6)
+        self.assertEqual(values[0], 2)
+        self.assertEqual(values[1], 4)
+        self.assertEqual(values[2], 6)
 
-    @unittest.skip("Failing")
     def test_relative_proportional_spread_without_reference_cube(self):
         self.build_assets_for_relative_proportional_spread_tests()
 
@@ -338,11 +339,10 @@ class TestDataMethods(unittest.TestCase):
             Member.of(DIMENSION_RPS2_NAME, "e3")])).to_mdx()
 
         values = self.tm1.cubes.cells.execute_mdx_values(mdx)
-        self.assertEqual(next(values), 2)
-        self.assertEqual(next(values), 4)
-        self.assertEqual(next(values), 6)
+        self.assertEqual(values[0], 2)
+        self.assertEqual(values[1], 4)
+        self.assertEqual(values[2], 6)
 
-    @unittest.skip("Failing")
     def test_relative_proportional_spread_with_different_reference_cube(self):
         self.build_assets_for_relative_proportional_spread_tests()
 
@@ -368,9 +368,9 @@ class TestDataMethods(unittest.TestCase):
             Member.of(DIMENSION_RPS2_NAME, "e3")])).to_mdx()
 
         values = self.tm1.cubes.cells.execute_mdx_values(mdx)
-        self.assertEqual(next(values), 2)
-        self.assertEqual(next(values), 4)
-        self.assertEqual(next(values), 6)
+        self.assertEqual(values[0], 2)
+        self.assertEqual(values[1], 4)
+        self.assertEqual(values[2], 6)
 
     def test_execute_mdx(self):
         # write cube content
@@ -1403,12 +1403,11 @@ class TestDataMethods(unittest.TestCase):
             top=5)
         self.assertEqual(len(raw["Cells"]), 5)
 
-    @unittest.skip("Failing")
     def test_execute_view_values(self):
         cell_values = self.tm1.cubes.cells.execute_view_values(cube_name=CUBE_NAME, view_name=VIEW_NAME, private=False)
 
         # check type
-        self.assertIsInstance(cell_values, types.GeneratorType)
+        self.assertIsInstance(cell_values, list)
 
         # Check if total value is the same AND coordinates are the same. Handle None.
         self.assertEqual(self.total_value,
@@ -1654,7 +1653,6 @@ class TestDataMethods(unittest.TestCase):
             view_name=VIEW_NAME,
             private=False)
 
-    @unittest.skip("Failing")
     def test_write_values_through_cellset(self):
         mdx = MdxBuilder.from_cube(CUBE_NAME) \
             .add_hierarchy_set_to_row_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[0], "element2"))) \
@@ -1662,13 +1660,13 @@ class TestDataMethods(unittest.TestCase):
             .where(Member.of(DIMENSION_NAMES[2], "element2")) \
             .to_mdx()
 
-        original_value = next(self.tm1.cubes.cells.execute_mdx_values(mdx))
+        original_value = self.tm1.cubes.cells.execute_mdx_values(mdx)[0]
 
         self.tm1.cubes.cells.write_values_through_cellset(mdx, (1.5,))
 
         # check value on coordinate in cube
         values = self.tm1.cubes.cells.execute_mdx_values(mdx)
-        self.assertEqual(next(values), 1.5)
+        self.assertEqual(values[0], 1.5)
 
         self.tm1.cubes.cells.write_values_through_cellset(mdx, (original_value,))
 
@@ -1688,7 +1686,6 @@ class TestDataMethods(unittest.TestCase):
         value = self.tm1.cubes.cells.get_value("}CubeProperties", "{},LOGGING".format(CUBE_NAME))
         self.assertEqual("YES", value.upper())
 
-    @unittest.skip("Failing")
     def test_read_write_with_custom_encoding(self):
         coordinates = ("d1e1", "d2e2", "d3e3")
         self.tm1.cubes.cells.write_values(STRING_CUBE_NAME, {coordinates: LATIN_1_ENCODED_TEXT}, encoding="latin-1")
@@ -1703,9 +1700,8 @@ class TestDataMethods(unittest.TestCase):
             .to_mdx()
 
         values = self.tm1.cubes.cells.execute_mdx_values(mdx=mdx, encoding="latin-1")
-        self.assertEqual(LATIN_1_ENCODED_TEXT, next(values))
+        self.assertEqual(LATIN_1_ENCODED_TEXT, values[0])
 
-    @unittest.skip("Failing")
     def test_read_write_with_custom_encoding_fail_response_encoding(self):
         coordinates = ("d1e1", "d2e2", "d3e3")
         self.tm1.cubes.cells.write_values(STRING_CUBE_NAME, {coordinates: LATIN_1_ENCODED_TEXT}, encoding="latin-1")
@@ -1721,9 +1717,8 @@ class TestDataMethods(unittest.TestCase):
 
         values = self.tm1.cubes.cells.execute_mdx_values(mdx=mdx)
 
-        self.assertNotEqual(LATIN_1_ENCODED_TEXT, next(values))
+        self.assertNotEqual(LATIN_1_ENCODED_TEXT, values[0])
 
-    @unittest.skip("Failing")
     def test_read_write_with_custom_encoding_fail_request_encoding(self):
         coordinates = ("d1e1", "d2e2", "d3e3")
         self.tm1.cubes.cells.write_values(STRING_CUBE_NAME, {coordinates: LATIN_1_ENCODED_TEXT})
@@ -1738,7 +1733,7 @@ class TestDataMethods(unittest.TestCase):
             .to_mdx()
 
         values = self.tm1.cubes.cells.execute_mdx_values(mdx=mdx, encoding="latin-1")
-        self.assertNotEqual(LATIN_1_ENCODED_TEXT, next(values))
+        self.assertNotEqual(LATIN_1_ENCODED_TEXT, values[0])
 
     @skip_if_insufficient_version(version="11.7")
     def test_clear_with_mdx_happy_case(self):
@@ -1753,6 +1748,7 @@ class TestDataMethods(unittest.TestCase):
 
         self.tm1.cells.clear_with_mdx(cube=CUBE_NAME, mdx=mdx)
 
+        # this may need looking at
         value = next(self.tm1.cells.execute_mdx_values(mdx=mdx))
         self.assertEqual(value, None)
 
@@ -1768,6 +1764,7 @@ class TestDataMethods(unittest.TestCase):
             .to_mdx()
         self.tm1.cells.clear_with_mdx(cube=CUBE_NAME, mdx=mdx)
 
+        # this may need looking at
         value = next(self.tm1.cells.execute_mdx_values(mdx=mdx))
         self.assertEqual(value, None)
 
@@ -1789,6 +1786,7 @@ class TestDataMethods(unittest.TestCase):
             .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[2], "Element32"))) \
             .to_mdx()
 
+        # this may need looking at
         value = next(self.tm1.cells.execute_mdx_values(mdx=mdx))
         self.assertEqual(value, None)
 

--- a/Tests/Chore.py
+++ b/Tests/Chore.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from TM1py.Objects import Chore, ChoreStartTime, ChoreFrequency, ChoreTask, Process
 from TM1py.Services import TM1Service
 
+from .TestUtils import skip_if_insufficient_version
+
 # Hard stuff for this test
 PREFIX = "TM1py_Tests_Chore_"
 PROCESS_NAME1 = PREFIX + 'Process1'
@@ -104,6 +106,7 @@ class TestChoreMethods(unittest.TestCase):
         if cls.tm1.chores.exists(CHORE_NAME4):
             cls.tm1.chores.delete(CHORE_NAME4)
 
+    @skip_if_insufficient_version(version="11.7.00002.1")
     def test_create_chore_with_dst(self):
         # create chores
         c4 = Chore(name=CHORE_NAME4,

--- a/Tests/__init__.py
+++ b/Tests/__init__.py
@@ -1,23 +1,5 @@
-from Tests.Annotation import TestAnnotationMethods
-from Tests.Cell import TestDataMethods
-from Tests.Chore import TestChoreMethods
-from Tests.Cube import TestCubeMethods
-from Tests.Dimension import TestDimensionMethods
-from Tests.Element import TestElementMethods
-from Tests.Hierarchy import TestHierarchyMethods
-from Tests.MDXUtils import TestMDXUtils
-from Tests.PowerBiService import TestPowerBiService
-from Tests.Process import TestProcessMethods
-from Tests.Security import TestSecurityMethods
-from Tests.Server import TestServerMethods
-from Tests.Subset import TestSubsetMethods
-from Tests.TIObfuscator import TestTIObfuscatorMethods
-from Tests.Utils import TestUtilsMethods
-from Tests.View import TestViewMethods
-
 """ Notes on TM1py Tests
 - specify your instance coordinates in the config.ini file
 - `EnableSandboxDimension` config parameter must be set to `F` for the target TM1 instance
 - use PyCharm to run the pytests in this folder
-
 """


### PR DESCRIPTION
Hi

A little cleanup to give test classes unique names.

Also included is removing imports from Tests/__init__.py. Do we need these there? Removing them doesn't seem to impact my testing workflow (pytest from command line and within vscode). Removing them avoids processing the files and allows you to run the tests in eg Cells.py even if eg Annotations.py has errors. 

Cheers
Alex
