### PR TITLE
New write_dataframe method in CellService

### DIFF
--- a/TM1py/Services/TM1Service.py
+++ b/TM1py/Services/TM1Service.py
@@ -1,6 +1,8 @@
 import pickle
 
-from TM1py.Services import *
+from TM1py.Services import HierarchyService, SecurityService, ApplicationService, SubsetService, ServerService, \
+    MonitoringService, ProcessService, PowerBiService, AnnotationService, ViewService, RestService, CellService, \
+    ChoreService, DimensionService, CubeService, ElementService
 
 
 class TM1Service:
@@ -27,6 +29,7 @@ class TM1Service:
         self.server = ServerService(self._tm1_rest)
         self.subsets = SubsetService(self._tm1_rest)
         self.applications = ApplicationService(self._tm1_rest)
+        self.views = ViewService(self._tm1_rest)
 
     def logout(self, **kwargs):
         self._tm1_rest.logout(**kwargs)

--- a/TM1py/Services/__init__.py
+++ b/TM1py/Services/__init__.py
@@ -13,5 +13,5 @@ from TM1py.Services.RestService import RestService
 from TM1py.Services.SecurityService import SecurityService
 from TM1py.Services.ServerService import ServerService
 from TM1py.Services.SubsetService import SubsetService
-from TM1py.Services.TM1Service import TM1Service
 from TM1py.Services.ViewService import ViewService
+from TM1py.Services.TM1Service import TM1Service


### PR DESCRIPTION
Function expects same shape as `execute_mdx_dataframe` returns.
Columns must match dimensions in cube. Column names are not relevant.

|    | DATE       | FROM   | TO   | FX RATES MEASURE   |   VALUE |
|---:|:-----------|:-------|:-----|:-------------------|----------:|
|  1 | 2020-01-02 | USD    | INR  | SPOT               |     71.34 |\n|  2 | 2020-01-03 | USD    | INR  | SPOT               |     71.76 |
|  3 | 2020-01-06 | USD    | INR  | SPOT               |     71.86 |
|  4 | 2020-01-07 | USD    | INR  | SPOT               |     71.84 |\n|  5 | 2020-01-08 | USD    | INR  | SPOT               |     71.51 |