### PR TITLE
Cleaned up cells tests

### DIFF
--- a/Tests/Cell.py
+++ b/Tests/Cell.py
@@ -125,6 +125,8 @@ class TestCellMethods(unittest.TestCase):
         # For tests on string related methods
         cls.build_string_cube()
 
+        cls.build_assets_for_relative_proportional_spread_tests()
+
 
     @classmethod
     def setUp(cls):
@@ -158,7 +160,9 @@ class TestCellMethods(unittest.TestCase):
         """
         cls.tm1.processes.execute_ti_code("CubeClearData('" + cls.cube_name + "');")
         cls.tm1.processes.execute_ti_code("CubeClearData('" + cls.string_cube_name + "');")
-
+        cls.tm1.processes.execute_ti_code("CubeClearData('" + cls.cube_rps1_name + "');")
+        cls.tm1.processes.execute_ti_code("CubeClearData('" + cls.cube_rps2_name + "');")
+    
     @classmethod
     def build_string_cube(cls):
         for d, dimension_name in enumerate(cls.string_dimension_names, start=1):
@@ -351,7 +355,6 @@ class TestCellMethods(unittest.TestCase):
         """
         Tests that relative proportional spread populates a cube with the expected values
         """
-        self.build_assets_for_relative_proportional_spread_tests()
 
         cells = {
             ('e1', 'e1'): 1,
@@ -381,7 +384,6 @@ class TestCellMethods(unittest.TestCase):
         self.assertEqual(values[2], 6)
 
     def test_relative_proportional_with_explicit_hierarchies(self):
-        self.build_assets_for_relative_proportional_spread_tests()
 
         cells = {
             ('e1', 'e1'): 1,
@@ -412,7 +414,6 @@ class TestCellMethods(unittest.TestCase):
         self.assertEqual(values[2], 6)
 
     def test_relative_proportional_spread_without_reference_cube(self):
-        self.build_assets_for_relative_proportional_spread_tests()
 
         cells = {
             ('e1', 'e1'): 1,
@@ -440,7 +441,6 @@ class TestCellMethods(unittest.TestCase):
         self.assertEqual(values[2], 6)
 
     def test_relative_proportional_spread_with_different_reference_cube(self):
-        self.build_assets_for_relative_proportional_spread_tests()
 
         cells = {
             ('e1', 'e1'): 1,

--- a/Tests/Cell.py
+++ b/Tests/Cell.py
@@ -29,7 +29,7 @@ class TestCellMethods(unittest.TestCase):
         cls.config.read(Path(__file__).parent.joinpath('config.ini'))
         cls.tm1 = TM1Service(**cls.config['tm1srv01'])
 
-        # Create fixtures
+        # Fixture names and properties
         cls.prefix = 'TM1py_Tests_Cell_'
         cls.cube_name = cls.prefix + "Cube"
         cls.view_name = cls.prefix + "View"
@@ -58,7 +58,6 @@ class TestCellMethods(unittest.TestCase):
 
         cls.dimension_rps1_name = cls.prefix + "Dimension" + "_RPS1"
         cls.dimension_rps2_name = cls.prefix + "Dimension" + "_RPS2"
-
 
         # Build Dimensions
         for dimension_name in cls.dimension_names:
@@ -457,6 +456,7 @@ class TestCellMethods(unittest.TestCase):
         self.assertEqual(values[1], 4)
         self.assertEqual(values[2], 6)
 
+    @unittest.skip("Failing")
     def test_execute_mdx(self):
         # write cube content
         self.tm1.cubes.cells.write_values(self.cube_name, self.cellset)
@@ -495,6 +495,7 @@ class TestCellMethods(unittest.TestCase):
         self.assertEqual(2000, sum(v["Value"] for v in data.values()))
         self.assertEqual(sum(range(1000)), sum(v["Ordinal"] for v in data.values()))
 
+    @unittest.skip("Failing")
     def test_execute_mdx_without_rows(self):
         # write cube content
         self.tm1.cubes.cells.write_values(self.cube_name, self.cellset)
@@ -520,6 +521,7 @@ class TestCellMethods(unittest.TestCase):
             self.assertIn("[TM1py_Tests_Cell_Dimension2].", coordinates[1])
             self.assertIn("[TM1py_Tests_Cell_Dimension3].", coordinates[2])
 
+    @unittest.skip("Failing")
     def test_execute_mdx_without_columns(self):
         # write cube content
         self.tm1.cubes.cells.write_values(self.cube_name, self.cellset)
@@ -832,6 +834,7 @@ class TestCellMethods(unittest.TestCase):
                     self.assertNotIn("UniqueName", member)
                     self.assertNotIn("Ordinal", member)
 
+    @unittest.skip("Failing")
     def test_execute_mdx_values(self):
         self.tm1.cells.write_values(self.cube_name, self.cellset)
 
@@ -865,6 +868,7 @@ class TestCellMethods(unittest.TestCase):
             2000,
             sum(data))
 
+    @unittest.skip("Failing")
     def test_execute_mdx_csv(self):
         mdx = MdxBuilder.from_cube(self.cube_name) \
             .rows_non_empty() \
@@ -996,6 +1000,7 @@ class TestCellMethods(unittest.TestCase):
         for value in values:
             self.assertEqual(value, 3)
 
+    @unittest.skip("Failing")
     def test_execute_mdx_elements_value_dict(self):
         mdx = MdxBuilder.from_cube(self.cube_name) \
             .rows_non_empty() \
@@ -1172,6 +1177,7 @@ class TestCellMethods(unittest.TestCase):
             set(elements_and_string_values),
             {"d1e1", "d1e2", "d1e3", "d1e4", "String1", "String2", "String3"})
 
+    @unittest.skip("Failing")
     def test_execute_view(self):
         data = self.tm1.cubes.cells.execute_view(cube_name=self.cube_name, view_name=self.view_name, private=False)
 
@@ -1491,6 +1497,7 @@ class TestCellMethods(unittest.TestCase):
             top=5)
         self.assertEqual(len(raw["Cells"]), 5)
 
+    @unittest.skip("Failing")
     def test_execute_view_values(self):
         cell_values = self.tm1.cubes.cells.execute_view_values(cube_name=self.cube_name, view_name=self.view_name, private=False)
 
@@ -1500,6 +1507,7 @@ class TestCellMethods(unittest.TestCase):
         # Check if total value is the same AND coordinates are the same. Handle None.
         self.assertEqual(self.total_value, sum(v for v in cell_values if v))
 
+    @unittest.skip("Failing")
     def test_execute_view_csv(self):
         csv = self.tm1.cubes.cells.execute_view_csv(cube_name=self.cube_name, view_name=self.view_name, private=False)
 
@@ -1518,6 +1526,7 @@ class TestCellMethods(unittest.TestCase):
         # check if sum of retrieved values is sum of written values
         self.assertEqual(self.total_value, sum(values))
 
+    @unittest.skip("Failing")
     def test_execute_view_elements_value_dict(self):
         values = self.tm1.cubes.cells.execute_view_elements_value_dict(
             cube_name=self.cube_name,

--- a/Tests/Cell.py
+++ b/Tests/Cell.py
@@ -21,7 +21,7 @@ class TestCellMethods(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """
-        Establishes a connection to TM1 and creates TM! objects to use across all tests
+        Establishes a connection to TM1 and creates TM1 objects to use across all tests
         """
 
         # Connection to TM1
@@ -126,9 +126,11 @@ class TestCellMethods(unittest.TestCase):
         cls.build_string_cube()
 
 
-
     @classmethod
     def setUp(cls):
+        """
+        Reset data before each test run
+        """
         # set correct version before test, as it is overwritten in a test case
         cls.tm1._tm1_rest.set_version()
 
@@ -149,15 +151,13 @@ class TestCellMethods(unittest.TestCase):
         cls.tm1.cubes.cells.write_values(cls.string_cube_name, cls.cells_in_string_cube)
 
 
-
-
     @classmethod
     def tearDown(cls):
-
+        """
+        Clear data from cubes after each test run
+        """
         cls.tm1.processes.execute_ti_code("CubeClearData('" + cls.cube_name + "');")
         cls.tm1.processes.execute_ti_code("CubeClearData('" + cls.string_cube_name + "');")
-
-
 
     @classmethod
     def build_string_cube(cls):
@@ -261,7 +261,7 @@ class TestCellMethods(unittest.TestCase):
         self.tm1.cubes.cells.write_value(original_value, self.cube_name, ('element1', 'ELEMENT 2', 'EleMent  3'))
 
     def test_write_values(self):
-        cells = dict()
+        cells = {}
         cells["Element 2", "Element4", "Element7"] = 716
 
         self.tm1.cubes.cells.write_values(self.cube_name, cells)
@@ -274,7 +274,7 @@ class TestCellMethods(unittest.TestCase):
         self.assertEqual(self.tm1.cells.execute_mdx_values(mdx=query.to_mdx()), [716])
 
     def test_write(self):
-        cells = dict()
+        cells = {}
         cells["Element 1", "Element4", "Element9"] = 717
         self.tm1.cubes.cells.write(self.cube_name, cells)
 
@@ -287,7 +287,7 @@ class TestCellMethods(unittest.TestCase):
         self.assertEqual(self.tm1.cells.execute_mdx_values(mdx=query.to_mdx()), [717])
 
     def test_write_increment_true(self):
-        cells = dict()
+        cells = {}
         cells["Element 1", "Element5", "Element8"] = 211
 
         self.tm1.cubes.cells.write(self.cube_name, cells)
@@ -302,7 +302,7 @@ class TestCellMethods(unittest.TestCase):
         self.assertEqual(self.tm1.cells.execute_mdx_values(mdx=query.to_mdx()), [422])
 
     def test_write_increment_false(self):
-        cells = dict()
+        cells = {}
         cells["Element 1", "Element5", "Element8"] = 211
 
         self.tm1.cubes.cells.write(self.cube_name, cells)

--- a/Tests/Cell.py
+++ b/Tests/Cell.py
@@ -118,6 +118,22 @@ class TestCellMethods(unittest.TestCase):
                                           ('Element ' + str(e) for e in range(1, 101)),
                                           ('Element ' + str(e) for e in range(1, 101))))
 
+        cls.build_cube_with_rules()
+
+        cls.build_cube_with_consolidations()
+
+        # For tests on string related methods
+        cls.build_string_cube()
+
+
+
+    @classmethod
+    def setUp(cls):
+        # set correct version before test, as it is overwritten in a test case
+        cls.tm1._tm1_rest.set_version()
+
+        # populate data in cube
+
         # cellset of data that shall be written
         cls.cellset = Utils.CaseAndSpaceInsensitiveTuplesDict()
         value = 1
@@ -130,21 +146,18 @@ class TestCellMethods(unittest.TestCase):
         # Fill cube with values
         cls.tm1.cubes.cells.write_values(cls.cube_name, cls.cellset)
 
-        cls.build_cube_with_rules()
+        cls.tm1.cubes.cells.write_values(cls.string_cube_name, cls.cells_in_string_cube)
 
-        cls.build_cube_with_consolidations()
 
-    @classmethod
-    def setUp(cls):
-        # set correct version before test, as it is overwritten in a test case
-        cls.tm1._tm1_rest.set_version()
 
-        # For tests on string related methods
-        cls.build_string_cube()
 
     @classmethod
     def tearDown(cls):
-        cls.remove_string_cube()
+
+        cls.tm1.processes.execute_ti_code("CubeClearData('" + cls.cube_name + "');")
+        cls.tm1.processes.execute_ti_code("CubeClearData('" + cls.string_cube_name + "');")
+
+
 
     @classmethod
     def build_string_cube(cls):
@@ -164,7 +177,6 @@ class TestCellMethods(unittest.TestCase):
         # zero out cube
         cls.tm1.processes.execute_ti_code("CubeClearData('" + cls.string_cube_name + "');")
 
-        cls.tm1.cubes.cells.write_values(cls.string_cube_name, cls.cells_in_string_cube)
 
     @classmethod
     def remove_string_cube(cls):
@@ -456,7 +468,6 @@ class TestCellMethods(unittest.TestCase):
         self.assertEqual(values[1], 4)
         self.assertEqual(values[2], 6)
 
-    @unittest.skip("Failing")
     def test_execute_mdx(self):
         # write cube content
         self.tm1.cubes.cells.write_values(self.cube_name, self.cellset)
@@ -495,7 +506,6 @@ class TestCellMethods(unittest.TestCase):
         self.assertEqual(2000, sum(v["Value"] for v in data.values()))
         self.assertEqual(sum(range(1000)), sum(v["Ordinal"] for v in data.values()))
 
-    @unittest.skip("Failing")
     def test_execute_mdx_without_rows(self):
         # write cube content
         self.tm1.cubes.cells.write_values(self.cube_name, self.cellset)
@@ -521,7 +531,6 @@ class TestCellMethods(unittest.TestCase):
             self.assertIn("[TM1py_Tests_Cell_Dimension2].", coordinates[1])
             self.assertIn("[TM1py_Tests_Cell_Dimension3].", coordinates[2])
 
-    @unittest.skip("Failing")
     def test_execute_mdx_without_columns(self):
         # write cube content
         self.tm1.cubes.cells.write_values(self.cube_name, self.cellset)
@@ -834,7 +843,6 @@ class TestCellMethods(unittest.TestCase):
                     self.assertNotIn("UniqueName", member)
                     self.assertNotIn("Ordinal", member)
 
-    @unittest.skip("Failing")
     def test_execute_mdx_values(self):
         self.tm1.cells.write_values(self.cube_name, self.cellset)
 
@@ -868,7 +876,6 @@ class TestCellMethods(unittest.TestCase):
             2000,
             sum(data))
 
-    @unittest.skip("Failing")
     def test_execute_mdx_csv(self):
         mdx = MdxBuilder.from_cube(self.cube_name) \
             .rows_non_empty() \
@@ -1000,7 +1007,6 @@ class TestCellMethods(unittest.TestCase):
         for value in values:
             self.assertEqual(value, 3)
 
-    @unittest.skip("Failing")
     def test_execute_mdx_elements_value_dict(self):
         mdx = MdxBuilder.from_cube(self.cube_name) \
             .rows_non_empty() \
@@ -1177,7 +1183,6 @@ class TestCellMethods(unittest.TestCase):
             set(elements_and_string_values),
             {"d1e1", "d1e2", "d1e3", "d1e4", "String1", "String2", "String3"})
 
-    @unittest.skip("Failing")
     def test_execute_view(self):
         data = self.tm1.cubes.cells.execute_view(cube_name=self.cube_name, view_name=self.view_name, private=False)
 
@@ -1497,7 +1502,6 @@ class TestCellMethods(unittest.TestCase):
             top=5)
         self.assertEqual(len(raw["Cells"]), 5)
 
-    @unittest.skip("Failing")
     def test_execute_view_values(self):
         cell_values = self.tm1.cubes.cells.execute_view_values(cube_name=self.cube_name, view_name=self.view_name, private=False)
 
@@ -1507,7 +1511,6 @@ class TestCellMethods(unittest.TestCase):
         # Check if total value is the same AND coordinates are the same. Handle None.
         self.assertEqual(self.total_value, sum(v for v in cell_values if v))
 
-    @unittest.skip("Failing")
     def test_execute_view_csv(self):
         csv = self.tm1.cubes.cells.execute_view_csv(cube_name=self.cube_name, view_name=self.view_name, private=False)
 
@@ -1526,7 +1529,6 @@ class TestCellMethods(unittest.TestCase):
         # check if sum of retrieved values is sum of written values
         self.assertEqual(self.total_value, sum(values))
 
-    @unittest.skip("Failing")
     def test_execute_view_elements_value_dict(self):
         values = self.tm1.cubes.cells.execute_view_elements_value_dict(
             cube_name=self.cube_name,

--- a/Tests/Cell.py
+++ b/Tests/Cell.py
@@ -16,37 +16,6 @@ try:
 except ImportError:
     pass
 
-# Hard coded stuff
-PREFIX = 'TM1py_Tests_Cell_'
-CUBE_NAME = PREFIX + "Cube"
-VIEW_NAME = PREFIX + "View"
-DIMENSION_NAMES = [
-    PREFIX + 'Dimension1',
-    PREFIX + 'Dimension2',
-    PREFIX + 'Dimension3']
-STRING_CUBE_NAME = PREFIX + "StringCube"
-STRING_DIMENSION_NAMES = [
-    PREFIX + 'StringDimension1',
-    PREFIX + 'StringDimension2',
-    PREFIX + 'StringDimension3']
-CELLS_IN_STRING_CUBE = {
-    ('d1e1', 'd2e1', 'd3e1'): 'String1',
-    ('d1e2', 'd2e2', 'd3e2'): 'String2',
-    ('d1e3', 'd2e3', 'd3e3'): 'String3'}
-
-LATIN_1_ENCODED_TEXT = "Èd5áÂè"
-
-CUBE_RPS1_NAME = PREFIX + "Cube" + "_RPS1"
-CUBE_RPS2_NAME = PREFIX + "Cube" + "_RPS2"
-
-CUBE_WITH_CONSOLIDATIONS_NAME = CUBE_NAME + "_With_Consolidations"
-DIMENSIONS_WITH_CONSOLIDATIONS_NAMES = [dimension_name + "_With_Consolidations" for dimension_name in DIMENSION_NAMES]
-CUBE_WITH_RULES_NAME = CUBE_NAME + "_With_Rules"
-
-DIMENSION_RPS1_NAME = PREFIX + "Dimension" + "_RPS1"
-DIMENSION_RPS2_NAME = PREFIX + "Dimension" + "_RPS2"
-
-
 class TestCellMethods(unittest.TestCase):
 
     @classmethod
@@ -60,8 +29,39 @@ class TestCellMethods(unittest.TestCase):
         cls.config.read(Path(__file__).parent.joinpath('config.ini'))
         cls.tm1 = TM1Service(**cls.config['tm1srv01'])
 
+        # Create fixtures
+        cls.prefix = 'TM1py_Tests_Cell_'
+        cls.cube_name = cls.prefix + "Cube"
+        cls.view_name = cls.prefix + "View"
+        cls.dimension_names = [ 
+            cls.prefix + 'Dimension1',
+            cls.prefix + 'Dimension2',
+            cls.prefix + 'Dimension3']
+        cls.string_cube_name = cls.prefix + "StringCube"
+        cls.string_dimension_names = [
+            cls.prefix + 'StringDimension1',
+            cls.prefix + 'StringDimension2',
+            cls.prefix + 'StringDimension3']
+        cls.cells_in_string_cube = {
+            ('d1e1', 'd2e1', 'd3e1'): 'String1',
+            ('d1e2', 'd2e2', 'd3e2'): 'String2',
+            ('d1e3', 'd2e3', 'd3e3'): 'String3'}
+
+        cls.latin_1_encoded_text = "Èd5áÂè"
+
+        cls.cube_rps1_name = cls.prefix + "Cube" + "_RPS1"
+        cls.cube_rps2_name = cls.prefix + "Cube" + "_RPS2"
+
+        cls.cube_with_consolidations_name = cls.cube_name + "_With_Consolidations"
+        cls.dimensions_with_consolidations_names = [dimension_name + "_With_Consolidations" for dimension_name in cls.dimension_names]
+        cls.cube_with_rules_name = cls.cube_name + "_With_Rules"
+
+        cls.dimension_rps1_name = cls.prefix + "Dimension" + "_RPS1"
+        cls.dimension_rps2_name = cls.prefix + "Dimension" + "_RPS2"
+
+
         # Build Dimensions
-        for dimension_name in DIMENSION_NAMES:
+        for dimension_name in cls.dimension_names:
             elements = [Element('Element {}'.format(str(j)), 'Numeric') for j in range(1, 1001)]
             element_attributes = [ElementAttribute("Attr1", "String"),
                                   ElementAttribute("Attr2", "Numeric"),
@@ -84,32 +84,32 @@ class TestCellMethods(unittest.TestCase):
             cls.tm1.cubes.cells.write_values(attribute_cube, attribute_values)
 
         # Build Cube
-        cube = Cube(CUBE_NAME, DIMENSION_NAMES)
-        if not cls.tm1.cubes.exists(CUBE_NAME):
+        cube = Cube(cls.cube_name, cls.dimension_names)
+        if not cls.tm1.cubes.exists(cls.cube_name):
             cls.tm1.cubes.create(cube)
 
         # Build cube view
         view = NativeView(
-            cube_name=CUBE_NAME,
-            view_name=VIEW_NAME,
+            cube_name=cls.cube_name,
+            view_name=cls.view_name,
             suppress_empty_columns=True,
             suppress_empty_rows=True)
         view.add_row(
-            dimension_name=DIMENSION_NAMES[0],
+            dimension_name=cls.dimension_names[0],
             subset=AnonymousSubset(
-                dimension_name=DIMENSION_NAMES[0],
-                expression='{[' + DIMENSION_NAMES[0] + '].Members}'))
+                dimension_name=cls.dimension_names[0],
+                expression='{[' + cls.dimension_names[0] + '].Members}'))
         view.add_row(
-            dimension_name=DIMENSION_NAMES[1],
+            dimension_name=cls.dimension_names[1],
             subset=AnonymousSubset(
-                dimension_name=DIMENSION_NAMES[1],
-                expression='{[' + DIMENSION_NAMES[1] + '].Members}'))
+                dimension_name=cls.dimension_names[1],
+                expression='{[' + cls.dimension_names[1] + '].Members}'))
         view.add_column(
-            dimension_name=DIMENSION_NAMES[2],
+            dimension_name=cls.dimension_names[2],
             subset=AnonymousSubset(
-                dimension_name=DIMENSION_NAMES[2],
-                expression='{[' + DIMENSION_NAMES[2] + '].Members}'))
-        if not cls.tm1.cubes.views.exists(CUBE_NAME, view.name, private=False):
+                dimension_name=cls.dimension_names[2],
+                expression='{[' + cls.dimension_names[2] + '].Members}'))
+        if not cls.tm1.cubes.views.exists(cls.cube_name, view.name, private=False):
             cls.tm1.cubes.views.create(
                 view=view,
                 private=False)
@@ -129,23 +129,27 @@ class TestCellMethods(unittest.TestCase):
         cls.total_value = sum(cls.cellset.values())
 
         # Fill cube with values
-        cls.tm1.cubes.cells.write_values(CUBE_NAME, cls.cellset)
-
-        # For tests on string related methods
-        cls.build_string_cube()
+        cls.tm1.cubes.cells.write_values(cls.cube_name, cls.cellset)
 
         cls.build_cube_with_rules()
 
         cls.build_cube_with_consolidations()
 
     @classmethod
-    def setup(cls):
+    def setUp(cls):
         # set correct version before test, as it is overwritten in a test case
         cls.tm1._tm1_rest.set_version()
 
+        # For tests on string related methods
+        cls.build_string_cube()
+
+    @classmethod
+    def tearDown(cls):
+        cls.remove_string_cube()
+
     @classmethod
     def build_string_cube(cls):
-        for d, dimension_name in enumerate(STRING_DIMENSION_NAMES, start=1):
+        for d, dimension_name in enumerate(cls.string_dimension_names, start=1):
             dimension = Dimension(dimension_name)
             hierarchy = Hierarchy(dimension_name, dimension_name)
             for i in range(1, 5, 1):
@@ -155,35 +159,35 @@ class TestCellMethods(unittest.TestCase):
             if not cls.tm1.dimensions.exists(dimension.name):
                 cls.tm1.dimensions.create(dimension)
 
-        cube = Cube(name=STRING_CUBE_NAME, dimensions=STRING_DIMENSION_NAMES)
+        cube = Cube(name=cls.string_cube_name, dimensions=cls.string_dimension_names)
         if not cls.tm1.cubes.exists(cube.name):
             cls.tm1.cubes.create(cube)
         # zero out cube
-        cls.tm1.processes.execute_ti_code("CubeClearData('" + STRING_CUBE_NAME + "');")
+        cls.tm1.processes.execute_ti_code("CubeClearData('" + cls.string_cube_name + "');")
 
-        cls.tm1.cubes.cells.write_values(STRING_CUBE_NAME, CELLS_IN_STRING_CUBE)
+        cls.tm1.cubes.cells.write_values(cls.string_cube_name, cls.cells_in_string_cube)
 
     @classmethod
     def remove_string_cube(cls):
-        if cls.tm1.cubes.exists(cube_name=STRING_CUBE_NAME):
-            cls.tm1.cubes.delete(cube_name=STRING_CUBE_NAME)
-        for dimension_name in STRING_DIMENSION_NAMES:
+        if cls.tm1.cubes.exists(cube_name=cls.string_cube_name):
+            cls.tm1.cubes.delete(cube_name=cls.string_cube_name)
+        for dimension_name in cls.string_dimension_names:
             if cls.tm1.dimensions.exists(dimension_name=dimension_name):
                 cls.tm1.dimensions.delete(dimension_name=dimension_name)
 
     @classmethod
     def build_cube_with_rules(cls):
-        cube = Cube(name=CUBE_WITH_RULES_NAME, dimensions=DIMENSION_NAMES)
-        cube.rules = f"['{DIMENSION_NAMES[0]}':'Element1'] = N: 1;\r\n"
+        cube = Cube(name=cls.cube_with_rules_name, dimensions=cls.dimension_names)
+        cube.rules = f"['{cls.dimension_names[0]}':'Element1'] = N: 1;\r\n"
         cls.tm1.cubes.create(cube)
 
     @classmethod
     def remove_cube_with_rules(cls):
-        cls.tm1.cubes.delete(CUBE_WITH_RULES_NAME)
+        cls.tm1.cubes.delete(cls.cube_with_rules_name)
 
     @classmethod
     def build_cube_with_consolidations(cls):
-        for dimension_name_source, dimension_name_target in zip(DIMENSION_NAMES, DIMENSIONS_WITH_CONSOLIDATIONS_NAMES):
+        for dimension_name_source, dimension_name_target in zip(cls.dimension_names, cls.dimensions_with_consolidations_names):
             dimension = cls.tm1.dimensions.get(dimension_name=dimension_name_source)
             dimension.name = dimension_name_target
             hierarchy = dimension.get_hierarchy(dimension_name_target)
@@ -192,20 +196,20 @@ class TestCellMethods(unittest.TestCase):
             hierarchy.add_element("TOTAL_" + dimension_name_target, "Consolidated")
             cls.tm1.dimensions.create(dimension)
 
-        cube = Cube(name=CUBE_WITH_CONSOLIDATIONS_NAME, dimensions=DIMENSIONS_WITH_CONSOLIDATIONS_NAMES)
+        cube = Cube(name=cls.cube_with_consolidations_name, dimensions=cls.dimensions_with_consolidations_names)
         cls.tm1.cubes.create(cube)
 
     @classmethod
     def remove_cube_with_consolidations(cls):
-        if cls.tm1.cubes.exists(cube_name=CUBE_WITH_CONSOLIDATIONS_NAME):
-            cls.tm1.cubes.delete(cube_name=CUBE_WITH_CONSOLIDATIONS_NAME)
-        for dimension_name in DIMENSIONS_WITH_CONSOLIDATIONS_NAMES:
+        if cls.tm1.cubes.exists(cube_name=cls.cube_with_consolidations_name):
+            cls.tm1.cubes.delete(cube_name=cls.cube_with_consolidations_name)
+        for dimension_name in cls.dimensions_with_consolidations_names:
             if cls.tm1.dimensions.exists(dimension_name=dimension_name):
                 cls.tm1.dimensions.delete(dimension_name=dimension_name)
 
     @classmethod
     def build_assets_for_relative_proportional_spread_tests(cls):
-        for dimension_name in (DIMENSION_RPS1_NAME, DIMENSION_RPS2_NAME):
+        for dimension_name in (cls.dimension_rps1_name, cls.dimension_rps2_name):
             dimension = Dimension(dimension_name)
             hierarchy = Hierarchy(dimension_name, dimension_name)
             hierarchy.add_element(element_name="c1", element_type="Consolidated")
@@ -217,8 +221,8 @@ class TestCellMethods(unittest.TestCase):
             if not cls.tm1.dimensions.exists(dimension.name):
                 cls.tm1.dimensions.create(dimension)
 
-        for cube_name in (CUBE_RPS1_NAME, CUBE_RPS2_NAME):
-            cube = Cube(name=cube_name, dimensions=(DIMENSION_RPS1_NAME, DIMENSION_RPS2_NAME))
+        for cube_name in (cls.cube_rps1_name, cls.cube_rps2_name):
+            cube = Cube(name=cube_name, dimensions=(cls.dimension_rps1_name, cls.dimension_rps2_name))
             if not cls.tm1.cubes.exists(cube.name):
                 cls.tm1.cubes.create(cube)
             # zero out cube
@@ -226,48 +230,48 @@ class TestCellMethods(unittest.TestCase):
 
     @classmethod
     def remove_assets_for_relative_proportional_spread_tests(cls):
-        for cube_name in (CUBE_RPS1_NAME, CUBE_RPS2_NAME):
+        for cube_name in (cls.cube_rps1_name, cls.cube_rps2_name):
             if cls.tm1.cubes.exists(cube_name):
                 cls.tm1.cubes.delete(cube_name=cube_name)
-        for dimension_name in (DIMENSION_RPS1_NAME, DIMENSION_RPS2_NAME):
+        for dimension_name in (cls.dimension_rps1_name, cls.dimension_rps2_name):
             if cls.tm1.dimensions.exists(dimension_name):
                 cls.tm1.dimensions.delete(dimension_name=dimension_name)
 
     def test_write_and_get_value(self):
-        original_value = self.tm1.cubes.cells.get_value(CUBE_NAME, 'Element1,EleMent2,ELEMENT  3')
-        response = self.tm1.cubes.cells.write_value(1, CUBE_NAME, ('element1', 'ELEMENT 2', 'EleMent  3'))
+        original_value = self.tm1.cubes.cells.get_value(self.cube_name, 'Element1,EleMent2,ELEMENT  3')
+        response = self.tm1.cubes.cells.write_value(1, self.cube_name, ('element1', 'ELEMENT 2', 'EleMent  3'))
         self.assertTrue(response.ok)
-        value = self.tm1.cubes.cells.get_value(CUBE_NAME, 'Element1,EleMent2,ELEMENT  3')
+        value = self.tm1.cubes.cells.get_value(self.cube_name, 'Element1,EleMent2,ELEMENT  3')
         self.assertEqual(value, 1)
-        response = self.tm1.cubes.cells.write_value(2, CUBE_NAME, ('element1', 'ELEMENT 2', 'EleMent  3'))
+        response = self.tm1.cubes.cells.write_value(2, self.cube_name, ('element1', 'ELEMENT 2', 'EleMent  3'))
         self.assertTrue(response.ok)
-        value = self.tm1.cubes.cells.get_value(CUBE_NAME, 'Element1,EleMent2,ELEMENT  3')
+        value = self.tm1.cubes.cells.get_value(self.cube_name, 'Element1,EleMent2,ELEMENT  3')
         self.assertEqual(value, 2)
-        self.tm1.cubes.cells.write_value(original_value, CUBE_NAME, ('element1', 'ELEMENT 2', 'EleMent  3'))
+        self.tm1.cubes.cells.write_value(original_value, self.cube_name, ('element1', 'ELEMENT 2', 'EleMent  3'))
 
     def test_write_values(self):
         cells = dict()
         cells["Element 2", "Element4", "Element7"] = 716
 
-        self.tm1.cubes.cells.write_values(CUBE_NAME, cells)
-        query = MdxBuilder.from_cube(CUBE_NAME)
+        self.tm1.cubes.cells.write_values(self.cube_name, cells)
+        query = MdxBuilder.from_cube(self.cube_name)
         query.add_member_tuple_to_columns(
-            f"[{DIMENSION_NAMES[0]}].[Element 2]",
-            f"[{DIMENSION_NAMES[1]}].[Element 4]",
-            f"[{DIMENSION_NAMES[2]}].[Element 7]")
+            f"[{self.dimension_names[0]}].[Element 2]",
+            f"[{self.dimension_names[1]}].[Element 4]",
+            f"[{self.dimension_names[2]}].[Element 7]")
 
         self.assertEqual(self.tm1.cells.execute_mdx_values(mdx=query.to_mdx()), [716])
 
     def test_write(self):
         cells = dict()
         cells["Element 1", "Element4", "Element9"] = 717
-        self.tm1.cubes.cells.write(CUBE_NAME, cells)
+        self.tm1.cubes.cells.write(self.cube_name, cells)
 
-        query = MdxBuilder.from_cube(CUBE_NAME)
+        query = MdxBuilder.from_cube(self.cube_name)
         query.add_member_tuple_to_columns(
-            f"[{DIMENSION_NAMES[0]}].[Element 1]",
-            f"[{DIMENSION_NAMES[1]}].[Element 4]",
-            f"[{DIMENSION_NAMES[2]}].[Element 9]")
+            f"[{self.dimension_names[0]}].[Element 1]",
+            f"[{self.dimension_names[1]}].[Element 4]",
+            f"[{self.dimension_names[2]}].[Element 9]")
 
         self.assertEqual(self.tm1.cells.execute_mdx_values(mdx=query.to_mdx()), [717])
 
@@ -275,14 +279,14 @@ class TestCellMethods(unittest.TestCase):
         cells = dict()
         cells["Element 1", "Element5", "Element8"] = 211
 
-        self.tm1.cubes.cells.write(CUBE_NAME, cells)
-        self.tm1.cubes.cells.write(CUBE_NAME, cells, increment=True)
+        self.tm1.cubes.cells.write(self.cube_name, cells)
+        self.tm1.cubes.cells.write(self.cube_name, cells, increment=True)
 
-        query = MdxBuilder.from_cube(CUBE_NAME)
+        query = MdxBuilder.from_cube(self.cube_name)
         query.add_member_tuple_to_columns(
-            f"[{DIMENSION_NAMES[0]}].[Element 1]",
-            f"[{DIMENSION_NAMES[1]}].[Element 5]",
-            f"[{DIMENSION_NAMES[2]}].[Element 8]")
+            f"[{self.dimension_names[0]}].[Element 1]",
+            f"[{self.dimension_names[1]}].[Element 5]",
+            f"[{self.dimension_names[2]}].[Element 8]")
 
         self.assertEqual(self.tm1.cells.execute_mdx_values(mdx=query.to_mdx()), [422])
 
@@ -290,33 +294,33 @@ class TestCellMethods(unittest.TestCase):
         cells = dict()
         cells["Element 1", "Element5", "Element8"] = 211
 
-        self.tm1.cubes.cells.write(CUBE_NAME, cells)
-        self.tm1.cubes.cells.write(CUBE_NAME, cells, increment=False)
+        self.tm1.cubes.cells.write(self.cube_name, cells)
+        self.tm1.cubes.cells.write(self.cube_name, cells, increment=False)
 
-        query = MdxBuilder.from_cube(CUBE_NAME)
+        query = MdxBuilder.from_cube(self.cube_name)
         query.add_member_tuple_to_columns(
-            f"[{DIMENSION_NAMES[0]}].[Element 1]",
-            f"[{DIMENSION_NAMES[1]}].[Element 5]",
-            f"[{DIMENSION_NAMES[2]}].[Element 8]")
+            f"[{self.dimension_names[0]}].[Element 1]",
+            f"[{self.dimension_names[1]}].[Element 5]",
+            f"[{self.dimension_names[2]}].[Element 8]")
 
         self.assertEqual(self.tm1.cells.execute_mdx_values(mdx=query.to_mdx()), [211])
 
     @skip_if_no_pandas
     def test_write_dataframe(self):
         df = pd.DataFrame({
-            DIMENSION_NAMES[0]: ["element 1", "element 1", "element 1"],
-            DIMENSION_NAMES[1]: ["element 1", "element 2", "element 3"],
-            DIMENSION_NAMES[2]: ["element 5", "element 5", "element 5"],
+            self.dimension_names[0]: ["element 1", "element 1", "element 1"],
+            self.dimension_names[1]: ["element 1", "element 2", "element 3"],
+            self.dimension_names[2]: ["element 5", "element 5", "element 5"],
             "Value": [1, 2, 3]})
-        self.tm1.cubes.cells.write_dataframe(CUBE_NAME, df)
+        self.tm1.cubes.cells.write_dataframe(self.cube_name, df)
 
-        mdx = MdxBuilder.from_cube(CUBE_NAME) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[0], "element 1"))) \
+        mdx = MdxBuilder.from_cube(self.cube_name) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(self.dimension_names[0], "element 1"))) \
             .add_hierarchy_set_to_row_axis(MdxHierarchySet.members([
-            Member.of(DIMENSION_NAMES[1], "element 1"),
-            Member.of(DIMENSION_NAMES[1], "element 2"),
-            Member.of(DIMENSION_NAMES[1], "element 3")])) \
-            .add_member_to_where(Member.of(DIMENSION_NAMES[2], "element 5")).to_mdx()
+            Member.of(self.dimension_names[1], "element 1"),
+            Member.of(self.dimension_names[1], "element 2"),
+            Member.of(self.dimension_names[1], "element 3")])) \
+            .add_member_to_where(Member.of(self.dimension_names[2], "element 5")).to_mdx()
         values = self.tm1.cubes.cells.execute_mdx_values(mdx)
 
         self.assertEqual(list(df["Value"]), values)
@@ -324,13 +328,13 @@ class TestCellMethods(unittest.TestCase):
     @skip_if_no_pandas
     def test_write_dataframe_error(self):
         df = pd.DataFrame({
-            DIMENSION_NAMES[0]: ["element 1", "element 3", "element 5"],
-            DIMENSION_NAMES[1]: ["element 1", "element 2", "element 4"],
-            DIMENSION_NAMES[2]: ["element 1", "element 3", "element 5"],
+            self.dimension_names[0]: ["element 1", "element 3", "element 5"],
+            self.dimension_names[1]: ["element 1", "element 2", "element 4"],
+            self.dimension_names[2]: ["element 1", "element 3", "element 5"],
             "Extra Column": ["element 1", "element2", "element3"],
             "Value": [1, 2, 3]})
         with self.assertRaises(ValueError) as e:
-            self.tm1.cubes.cells.write_dataframe(CUBE_NAME, df)
+            self.tm1.cubes.cells.write_dataframe(self.cube_name, df)
 
     def test_relative_proportional_spread_happy_case(self):
         """
@@ -343,21 +347,21 @@ class TestCellMethods(unittest.TestCase):
             ('e1', 'e2'): 2,
             ('e1', 'e3'): 3,
         }
-        self.tm1.cubes.cells.write_values(CUBE_RPS1_NAME, cells)
+        self.tm1.cubes.cells.write_values(self.cube_rps1_name, cells)
 
         self.tm1.cubes.cells.relative_proportional_spread(
             value=12,
-            cube=CUBE_RPS1_NAME,
-            unique_element_names=("[" + DIMENSION_RPS1_NAME + "].[e2]", "[" + DIMENSION_RPS2_NAME + "].[c1]"),
-            reference_cube=CUBE_RPS1_NAME,
-            reference_unique_element_names=("[" + DIMENSION_RPS1_NAME + "].[c1]", "[" + DIMENSION_RPS2_NAME + "].[c1]"))
+            cube=self.cube_rps1_name,
+            unique_element_names=("[" + self.dimension_rps1_name + "].[e2]", "[" + self.dimension_rps2_name + "].[c1]"),
+            reference_cube=self.cube_rps1_name,
+            reference_unique_element_names=("[" + self.dimension_rps1_name + "].[c1]", "[" + self.dimension_rps2_name + "].[c1]"))
 
-        mdx = MdxBuilder.from_cube(CUBE_RPS1_NAME) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(DIMENSION_RPS1_NAME, "e2"))) \
+        mdx = MdxBuilder.from_cube(self.cube_rps1_name) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(self.dimension_rps1_name, "e2"))) \
             .add_hierarchy_set_to_row_axis(MdxHierarchySet.members([
-            Member.of(DIMENSION_RPS2_NAME, "e1"),
-            Member.of(DIMENSION_RPS2_NAME, "e2"),
-            Member.of(DIMENSION_RPS2_NAME, "e3")])).to_mdx()
+            Member.of(self.dimension_rps2_name, "e1"),
+            Member.of(self.dimension_rps2_name, "e2"),
+            Member.of(self.dimension_rps2_name, "e3")])).to_mdx()
 
         values = self.tm1.cubes.cells.execute_mdx_values(mdx)
 
@@ -373,23 +377,23 @@ class TestCellMethods(unittest.TestCase):
             ('e1', 'e2'): 2,
             ('e1', 'e3'): 3,
         }
-        self.tm1.cubes.cells.write_values(CUBE_RPS1_NAME, cells)
+        self.tm1.cubes.cells.write_values(self.cube_rps1_name, cells)
 
         self.tm1.cubes.cells.relative_proportional_spread(
             value=12,
-            cube=CUBE_RPS1_NAME,
-            unique_element_names=("[" + DIMENSION_RPS1_NAME + "].[" + DIMENSION_RPS1_NAME + "].[e2]",
-                                  "[" + DIMENSION_RPS2_NAME + "].[" + DIMENSION_RPS2_NAME + "].[c1]"),
-            reference_cube=CUBE_RPS1_NAME,
-            reference_unique_element_names=("[" + DIMENSION_RPS1_NAME + "].[" + DIMENSION_RPS1_NAME + "].[c1]",
-                                            "[" + DIMENSION_RPS2_NAME + "].[" + DIMENSION_RPS2_NAME + "].[c1]"))
+            cube=self.cube_rps1_name,
+            unique_element_names=("[" + self.dimension_rps1_name + "].[" + self.dimension_rps1_name + "].[e2]",
+                                  "[" + self.dimension_rps2_name + "].[" + self.dimension_rps2_name + "].[c1]"),
+            reference_cube=self.cube_rps1_name,
+            reference_unique_element_names=("[" + self.dimension_rps1_name + "].[" + self.dimension_rps1_name + "].[c1]",
+                                            "[" + self.dimension_rps2_name + "].[" + self.dimension_rps2_name + "].[c1]"))
 
-        mdx = MdxBuilder.from_cube(CUBE_RPS1_NAME) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(DIMENSION_RPS1_NAME, "e2"))) \
+        mdx = MdxBuilder.from_cube(self.cube_rps1_name) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(self.dimension_rps1_name, "e2"))) \
             .add_hierarchy_set_to_row_axis(MdxHierarchySet.members([
-            Member.of(DIMENSION_RPS2_NAME, "e1"),
-            Member.of(DIMENSION_RPS2_NAME, "e2"),
-            Member.of(DIMENSION_RPS2_NAME, "e3")])).to_mdx()
+            Member.of(self.dimension_rps2_name, "e1"),
+            Member.of(self.dimension_rps2_name, "e2"),
+            Member.of(self.dimension_rps2_name, "e3")])).to_mdx()
 
         values = self.tm1.cubes.cells.execute_mdx_values(mdx)
         self.assertEqual(values[0], 2)
@@ -404,20 +408,20 @@ class TestCellMethods(unittest.TestCase):
             ('e1', 'e2'): 2,
             ('e1', 'e3'): 3,
         }
-        self.tm1.cubes.cells.write_values(CUBE_RPS1_NAME, cells)
+        self.tm1.cubes.cells.write_values(self.cube_rps1_name, cells)
 
         self.tm1.cubes.cells.relative_proportional_spread(
             value=12,
-            cube=CUBE_RPS1_NAME,
-            unique_element_names=("[" + DIMENSION_RPS1_NAME + "].[e2]", "[" + DIMENSION_RPS2_NAME + "].[c1]"),
-            reference_unique_element_names=("[" + DIMENSION_RPS1_NAME + "].[c1]", "[" + DIMENSION_RPS2_NAME + "].[c1]"))
+            cube=self.cube_rps1_name,
+            unique_element_names=("[" + self.dimension_rps1_name + "].[e2]", "[" + self.dimension_rps2_name + "].[c1]"),
+            reference_unique_element_names=("[" + self.dimension_rps1_name + "].[c1]", "[" + self.dimension_rps2_name + "].[c1]"))
 
-        mdx = MdxBuilder.from_cube(CUBE_RPS1_NAME) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(DIMENSION_RPS1_NAME, "e2"))) \
+        mdx = MdxBuilder.from_cube(self.cube_rps1_name) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(self.dimension_rps1_name, "e2"))) \
             .add_hierarchy_set_to_row_axis(MdxHierarchySet.members([
-            Member.of(DIMENSION_RPS2_NAME, "e1"),
-            Member.of(DIMENSION_RPS2_NAME, "e2"),
-            Member.of(DIMENSION_RPS2_NAME, "e3")])).to_mdx()
+            Member.of(self.dimension_rps2_name, "e1"),
+            Member.of(self.dimension_rps2_name, "e2"),
+            Member.of(self.dimension_rps2_name, "e3")])).to_mdx()
 
         values = self.tm1.cubes.cells.execute_mdx_values(mdx)
         self.assertEqual(values[0], 2)
@@ -432,21 +436,21 @@ class TestCellMethods(unittest.TestCase):
             ('e1', 'e2'): 2,
             ('e1', 'e3'): 3,
         }
-        self.tm1.cubes.cells.write_values(CUBE_RPS2_NAME, cells)
+        self.tm1.cubes.cells.write_values(self.cube_rps2_name, cells)
 
         self.tm1.cubes.cells.relative_proportional_spread(
             value=12,
-            cube=CUBE_RPS1_NAME,
-            unique_element_names=("[" + DIMENSION_RPS1_NAME + "].[e2]", "[" + DIMENSION_RPS2_NAME + "].[c1]"),
-            reference_cube=CUBE_RPS2_NAME,
-            reference_unique_element_names=("[" + DIMENSION_RPS1_NAME + "].[c1]", "[" + DIMENSION_RPS2_NAME + "].[c1]"))
+            cube=self.cube_rps1_name,
+            unique_element_names=("[" + self.dimension_rps1_name + "].[e2]", "[" + self.dimension_rps2_name + "].[c1]"),
+            reference_cube=self.cube_rps2_name,
+            reference_unique_element_names=("[" + self.dimension_rps1_name + "].[c1]", "[" + self.dimension_rps2_name + "].[c1]"))
 
-        mdx = MdxBuilder.from_cube(CUBE_RPS1_NAME) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(DIMENSION_RPS1_NAME, "e2"))) \
+        mdx = MdxBuilder.from_cube(self.cube_rps1_name) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(self.dimension_rps1_name, "e2"))) \
             .add_hierarchy_set_to_row_axis(MdxHierarchySet.members([
-            Member.of(DIMENSION_RPS2_NAME, "e1"),
-            Member.of(DIMENSION_RPS2_NAME, "e2"),
-            Member.of(DIMENSION_RPS2_NAME, "e3")])).to_mdx()
+            Member.of(self.dimension_rps2_name, "e1"),
+            Member.of(self.dimension_rps2_name, "e2"),
+            Member.of(self.dimension_rps2_name, "e3")])).to_mdx()
 
         values = self.tm1.cubes.cells.execute_mdx_values(mdx)
         self.assertEqual(values[0], 2)
@@ -455,14 +459,14 @@ class TestCellMethods(unittest.TestCase):
 
     def test_execute_mdx(self):
         # write cube content
-        self.tm1.cubes.cells.write_values(CUBE_NAME, self.cellset)
+        self.tm1.cubes.cells.write_values(self.cube_name, self.cellset)
 
         # MDX Query that gets full cube content with zero suppression
-        mdx = MdxBuilder.from_cube(CUBE_NAME) \
+        mdx = MdxBuilder.from_cube(self.cube_name) \
             .rows_non_empty() \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[0], DIMENSION_NAMES[0])) \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[1], DIMENSION_NAMES[1])) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[2], DIMENSION_NAMES[2])) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(self.dimension_names[0], self.dimension_names[0])) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(self.dimension_names[1], self.dimension_names[1])) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.all_members(self.dimension_names[2], self.dimension_names[2])) \
             .to_mdx()
 
         data = self.tm1.cubes.cells.execute_mdx(mdx)
@@ -483,8 +487,8 @@ class TestCellMethods(unittest.TestCase):
         {{[{}].[{}]}} ON COLUMNS 
         FROM[{}] 
         WHERE([{}].DefaultMember)""".format(
-            DIMENSION_NAMES[1], "Calculated Member", DIMENSION_NAMES[0],
-            DIMENSION_NAMES[1], "Calculated Member", CUBE_NAME, DIMENSION_NAMES[2])
+            self.dimension_names[1], "Calculated Member", self.dimension_names[0],
+            self.dimension_names[1], "Calculated Member", self.cube_name, self.dimension_names[2])
 
         data = self.tm1.cubes.cells.execute_mdx(mdx, cell_properties=["Value", "Ordinal"])
         self.assertEqual(1000, len(data))
@@ -493,13 +497,13 @@ class TestCellMethods(unittest.TestCase):
 
     def test_execute_mdx_without_rows(self):
         # write cube content
-        self.tm1.cubes.cells.write_values(CUBE_NAME, self.cellset)
+        self.tm1.cubes.cells.write_values(self.cube_name, self.cellset)
 
-        mdx = MdxBuilder.from_cube(CUBE_NAME) \
+        mdx = MdxBuilder.from_cube(self.cube_name) \
             .columns_non_empty() \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[0], DIMENSION_NAMES[0])) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[1], DIMENSION_NAMES[1])) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[2], DIMENSION_NAMES[2])) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.all_members(self.dimension_names[0], self.dimension_names[0])) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.all_members(self.dimension_names[1], self.dimension_names[1])) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.all_members(self.dimension_names[2], self.dimension_names[2])) \
             .rows_non_empty() \
             .add_hierarchy_set_to_row_axis(MdxHierarchySet.from_str("", "", "{}")) \
             .to_mdx()
@@ -518,14 +522,14 @@ class TestCellMethods(unittest.TestCase):
 
     def test_execute_mdx_without_columns(self):
         # write cube content
-        self.tm1.cubes.cells.write_values(CUBE_NAME, self.cellset)
+        self.tm1.cubes.cells.write_values(self.cube_name, self.cellset)
 
         # MDX Query that gets full cube content with zero suppression
-        mdx = MdxBuilder.from_cube(CUBE_NAME) \
+        mdx = MdxBuilder.from_cube(self.cube_name) \
             .rows_non_empty().add_hierarchy_set_to_row_axis(
-            MdxHierarchySet.all_members(DIMENSION_NAMES[0], DIMENSION_NAMES[0])) \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[1], DIMENSION_NAMES[1])) \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[2], DIMENSION_NAMES[2])) \
+            MdxHierarchySet.all_members(self.dimension_names[0], self.dimension_names[0])) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(self.dimension_names[1], self.dimension_names[1])) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(self.dimension_names[2], self.dimension_names[2])) \
             .columns_non_empty().add_hierarchy_set_to_column_axis(MdxHierarchySet.from_str("", "", "{}")) \
             .to_mdx()
 
@@ -542,10 +546,10 @@ class TestCellMethods(unittest.TestCase):
             self.assertIn("[TM1py_Tests_Cell_Dimension3].", coordinates[2])
 
     def test_execute_mdx_skip_contexts(self):
-        mdx = MdxBuilder.from_cube(CUBE_NAME) \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[0], "Element1"))) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[1], "Element1"))) \
-            .add_member_to_where("[" + DIMENSION_NAMES[2] + "].[Element1]").to_mdx()
+        mdx = MdxBuilder.from_cube(self.cube_name) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.member(Member.of(self.dimension_names[0], "Element1"))) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(self.dimension_names[1], "Element1"))) \
+            .add_member_to_where("[" + self.dimension_names[2] + "].[Element1]").to_mdx()
 
         data = self.tm1.cubes.cells.execute_mdx(mdx, skip_contexts=True)
 
@@ -554,19 +558,19 @@ class TestCellMethods(unittest.TestCase):
             self.assertEqual(len(coordinates), 2)
             self.assertEqual(
                 Utils.dimension_name_from_element_unique_name(coordinates[0]),
-                DIMENSION_NAMES[0])
+                self.dimension_names[0])
             self.assertEqual(
                 Utils.dimension_name_from_element_unique_name(coordinates[1]),
-                DIMENSION_NAMES[1])
+                self.dimension_names[1])
 
     def test_execute_mdx_skip_consolidated(self):
-        mdx = MdxBuilder.from_cube(CUBE_WITH_CONSOLIDATIONS_NAME) \
+        mdx = MdxBuilder.from_cube(self.cube_with_consolidations_name) \
             .add_hierarchy_set_to_row_axis(MdxHierarchySet.members([
-            Member.of(DIMENSIONS_WITH_CONSOLIDATIONS_NAMES[0], "Total_" + DIMENSIONS_WITH_CONSOLIDATIONS_NAMES[0]),
-            Member.of(DIMENSIONS_WITH_CONSOLIDATIONS_NAMES[0], "Element1")])) \
+            Member.of(self.dimensions_with_consolidations_names[0], "Total_" + self.dimensions_with_consolidations_names[0]),
+            Member.of(self.dimensions_with_consolidations_names[0], "Element1")])) \
             .add_hierarchy_set_to_column_axis(
-            MdxHierarchySet.member(Member.of(DIMENSIONS_WITH_CONSOLIDATIONS_NAMES[1], "Element1"))) \
-            .add_member_to_where("[" + DIMENSIONS_WITH_CONSOLIDATIONS_NAMES[2] + "].[Element1]").to_mdx()
+            MdxHierarchySet.member(Member.of(self.dimensions_with_consolidations_names[1], "Element1"))) \
+            .add_member_to_where("[" + self.dimensions_with_consolidations_names[2] + "].[Element1]").to_mdx()
 
         data = self.tm1.cubes.cells.execute_mdx(mdx, skip_contexts=True, skip_consolidated_cells=True)
 
@@ -575,18 +579,18 @@ class TestCellMethods(unittest.TestCase):
             self.assertEqual(len(coordinates), 2)
             self.assertEqual(
                 Utils.dimension_name_from_element_unique_name(coordinates[0]),
-                DIMENSIONS_WITH_CONSOLIDATIONS_NAMES[0])
+                self.dimensions_with_consolidations_names[0])
             self.assertEqual(
                 Utils.dimension_name_from_element_unique_name(coordinates[1]),
-                DIMENSIONS_WITH_CONSOLIDATIONS_NAMES[1])
+                self.dimensions_with_consolidations_names[1])
 
     def test_execute_mdx_skip_rule_derived(self):
-        mdx = MdxBuilder.from_cube(CUBE_WITH_RULES_NAME) \
+        mdx = MdxBuilder.from_cube(self.cube_with_rules_name) \
             .add_hierarchy_set_to_row_axis(MdxHierarchySet.members([
-            Member.of(DIMENSION_NAMES[0], "Element 1"),
-            Member.of(DIMENSION_NAMES[0], "Element 2")])) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[1], "Element1"))) \
-            .add_member_to_where("[" + DIMENSION_NAMES[2] + "].[Element1]").to_mdx()
+            Member.of(self.dimension_names[0], "Element 1"),
+            Member.of(self.dimension_names[0], "Element 2")])) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(self.dimension_names[1], "Element1"))) \
+            .add_member_to_where("[" + self.dimension_names[2] + "].[Element1]").to_mdx()
 
         data = self.tm1.cubes.cells.execute_mdx(mdx, skip_contexts=True, skip_rule_derived_cells=True)
 
@@ -595,18 +599,18 @@ class TestCellMethods(unittest.TestCase):
             self.assertEqual(len(coordinates), 2)
             self.assertEqual(
                 Utils.dimension_name_from_element_unique_name(coordinates[0]),
-                DIMENSION_NAMES[0])
+                self.dimension_names[0])
             self.assertEqual(
                 Utils.dimension_name_from_element_unique_name(coordinates[1]),
-                DIMENSION_NAMES[1])
+                self.dimension_names[1])
 
     def test_execute_mdx_skip_zeros(self):
-        mdx = MdxBuilder.from_cube(CUBE_NAME) \
+        mdx = MdxBuilder.from_cube(self.cube_name) \
             .add_hierarchy_set_to_row_axis(MdxHierarchySet.members([
-            Member.of(DIMENSION_NAMES[0], "Element 1"),
-            Member.of(DIMENSION_NAMES[0], "Element 2")])) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[1], "Element1"))) \
-            .add_member_to_where("[" + DIMENSION_NAMES[2] + "].[Element1]").to_mdx()
+            Member.of(self.dimension_names[0], "Element 1"),
+            Member.of(self.dimension_names[0], "Element 2")])) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(self.dimension_names[1], "Element1"))) \
+            .add_member_to_where("[" + self.dimension_names[2] + "].[Element1]").to_mdx()
 
         data = self.tm1.cubes.cells.execute_mdx(mdx, skip_contexts=False, skip_zeros=True)
 
@@ -615,19 +619,19 @@ class TestCellMethods(unittest.TestCase):
             self.assertEqual(len(coordinates), 3)
             self.assertEqual(
                 Utils.dimension_name_from_element_unique_name(coordinates[0]),
-                DIMENSION_NAMES[0])
+                self.dimension_names[0])
             self.assertEqual(
                 Utils.dimension_name_from_element_unique_name(coordinates[1]),
-                DIMENSION_NAMES[1])
+                self.dimension_names[1])
             self.assertEqual(
                 Utils.dimension_name_from_element_unique_name(coordinates[2]),
-                DIMENSION_NAMES[2])
+                self.dimension_names[2])
 
     def test_execute_mdx_raw_skip_contexts(self):
-        mdx = MdxBuilder.from_cube(CUBE_NAME) \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[0], "Element1"))) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[1], "Element1"))) \
-            .add_member_to_where("[" + DIMENSION_NAMES[2] + "].[Element1]").to_mdx()
+        mdx = MdxBuilder.from_cube(self.cube_name) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.member(Member.of(self.dimension_names[0], "Element1"))) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(self.dimension_names[1], "Element1"))) \
+            .add_member_to_where("[" + self.dimension_names[2] + "].[Element1]").to_mdx()
 
         raw_response = self.tm1.cubes.cells.execute_mdx_raw(
             mdx,
@@ -638,41 +642,41 @@ class TestCellMethods(unittest.TestCase):
         for axis in raw_response["Axes"]:
             dimension_on_axis = Utils.dimension_name_from_element_unique_name(
                 axis["Tuples"][0]["Members"][0]["UniqueName"])
-            self.assertNotEqual(dimension_on_axis, DIMENSION_NAMES[2])
+            self.assertNotEqual(dimension_on_axis, self.dimension_names[2])
 
     def test_execute_mdx_rows_and_values_one_cell(self):
-        mdx = MdxBuilder.from_cube(CUBE_NAME) \
-            .add_hierarchy_set_to_axis(1, MdxHierarchySet.member(Member.of(DIMENSION_NAMES[0], "Element1"))) \
-            .add_hierarchy_set_to_axis(0, MdxHierarchySet.member(Member.of(DIMENSION_NAMES[1], "Element1"))) \
-            .add_member_to_where("[" + DIMENSION_NAMES[2] + "].[Element1]").to_mdx()
+        mdx = MdxBuilder.from_cube(self.cube_name) \
+            .add_hierarchy_set_to_axis(1, MdxHierarchySet.member(Member.of(self.dimension_names[0], "Element1"))) \
+            .add_hierarchy_set_to_axis(0, MdxHierarchySet.member(Member.of(self.dimension_names[1], "Element1"))) \
+            .add_member_to_where("[" + self.dimension_names[2] + "].[Element1]").to_mdx()
 
         data = self.tm1.cubes.cells.execute_mdx_rows_and_values(mdx, element_unique_names=True)
 
         self.assertEqual(len(data), 1)
         for row, cells in data.items():
             dimension = Utils.dimension_name_from_element_unique_name(row[0])
-            self.assertEqual(dimension, DIMENSION_NAMES[0])
+            self.assertEqual(dimension, self.dimension_names[0])
             self.assertEqual(len(cells), 1)
 
     def test_execute_mdx_rows_and_values_empty_cellset(self):
         # make sure it's empty
-        self.tm1.cubes.cells.write_values(CUBE_NAME, {("Element10", "Element11", "Element13"): 0})
+        self.tm1.cubes.cells.write_values(self.cube_name, {("Element10", "Element11", "Element13"): 0})
 
-        mdx = MdxBuilder.from_cube(CUBE_NAME) \
+        mdx = MdxBuilder.from_cube(self.cube_name) \
             .rows_non_empty() \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[0], "Element10"))) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.member(Member.of(self.dimension_names[0], "Element10"))) \
             .columns_non_empty() \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[1], "Element11"))) \
-            .add_member_to_where("[" + DIMENSION_NAMES[2] + "].[Element13]").to_mdx()
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(self.dimension_names[1], "Element11"))) \
+            .add_member_to_where("[" + self.dimension_names[2] + "].[Element13]").to_mdx()
 
         data = self.tm1.cubes.cells.execute_mdx_rows_and_values(mdx, element_unique_names=True)
         self.assertEqual(len(data), 0)
 
     def test_execute_mdx_rows_and_values_member_names(self):
-        mdx = MdxBuilder.from_cube(CUBE_NAME) \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[0], "Element1"))) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[1], "Element1"))) \
-            .add_member_to_where("[" + DIMENSION_NAMES[2] + "].[Element1]").to_mdx()
+        mdx = MdxBuilder.from_cube(self.cube_name) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.member(Member.of(self.dimension_names[0], "Element1"))) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(self.dimension_names[1], "Element1"))) \
+            .add_member_to_where("[" + self.dimension_names[2] + "].[Element1]").to_mdx()
 
         data = self.tm1.cubes.cells.execute_mdx_rows_and_values(mdx, element_unique_names=False)
 
@@ -682,36 +686,36 @@ class TestCellMethods(unittest.TestCase):
             self.assertEqual(member_name, "Element 1")
 
     def test_execute_mdx_rows_and_values_one_dimension_on_rows(self):
-        mdx = MdxBuilder.from_cube(CUBE_NAME) \
+        mdx = MdxBuilder.from_cube(self.cube_name) \
             .add_hierarchy_set_to_row_axis(MdxHierarchySet.members([
-            Member.of(DIMENSION_NAMES[0], "Element1"),
-            Member.of(DIMENSION_NAMES[0], "Element2")])) \
+            Member.of(self.dimension_names[0], "Element1"),
+            Member.of(self.dimension_names[0], "Element2")])) \
             .add_hierarchy_set_to_column_axis(MdxHierarchySet.members([
-            Member.of(DIMENSION_NAMES[1], "Element1"),
-            Member.of(DIMENSION_NAMES[1], "Element2"),
-            Member.of(DIMENSION_NAMES[1], "Element3")])) \
-            .where("[" + DIMENSION_NAMES[2] + "].[Element1]").to_mdx()
+            Member.of(self.dimension_names[1], "Element1"),
+            Member.of(self.dimension_names[1], "Element2"),
+            Member.of(self.dimension_names[1], "Element3")])) \
+            .where("[" + self.dimension_names[2] + "].[Element1]").to_mdx()
 
         data = self.tm1.cubes.cells.execute_mdx_rows_and_values(mdx)
 
         self.assertEqual(len(data), 2)
         for row, cells in data.items():
             dimension = Utils.dimension_name_from_element_unique_name(row[0])
-            self.assertEqual(dimension, DIMENSION_NAMES[0])
+            self.assertEqual(dimension, self.dimension_names[0])
             self.assertEqual(len(cells), 3)
 
     def test_execute_mdx_rows_and_values_two_dimensions_on_rows(self):
 
-        mdx = MdxBuilder.from_cube(CUBE_NAME).add_hierarchy_set_to_axis(0, MdxHierarchySet.members([
-            Member.of(DIMENSION_NAMES[2], "Element1"),
-            Member.of(DIMENSION_NAMES[2], "Element2"),
-            Member.of(DIMENSION_NAMES[2], "Element3")])) \
+        mdx = MdxBuilder.from_cube(self.cube_name).add_hierarchy_set_to_axis(0, MdxHierarchySet.members([
+            Member.of(self.dimension_names[2], "Element1"),
+            Member.of(self.dimension_names[2], "Element2"),
+            Member.of(self.dimension_names[2], "Element3")])) \
             .add_hierarchy_set_to_axis(1, MdxHierarchySet.members([
-            Member.of(DIMENSION_NAMES[0], "Element1"),
-            Member.of(DIMENSION_NAMES[0], "Element2")])). \
+            Member.of(self.dimension_names[0], "Element1"),
+            Member.of(self.dimension_names[0], "Element2")])). \
             add_hierarchy_set_to_axis(1, MdxHierarchySet.members([
-            Member.of(DIMENSION_NAMES[1], "Element1"),
-            Member.of(DIMENSION_NAMES[1], "Element2")])).to_mdx()
+            Member.of(self.dimension_names[1], "Element1"),
+            Member.of(self.dimension_names[1], "Element2")])).to_mdx()
 
         data = self.tm1.cubes.cells.execute_mdx_rows_and_values(mdx)
 
@@ -719,17 +723,17 @@ class TestCellMethods(unittest.TestCase):
         for row, cells in data.items():
             self.assertEqual(len(row), 2)
             dimension = Utils.dimension_name_from_element_unique_name(row[0])
-            self.assertEqual(dimension, DIMENSION_NAMES[0])
+            self.assertEqual(dimension, self.dimension_names[0])
             dimension = Utils.dimension_name_from_element_unique_name(row[1])
-            self.assertEqual(dimension, DIMENSION_NAMES[1])
+            self.assertEqual(dimension, self.dimension_names[1])
             self.assertEqual(len(cells), 3)
 
     def test_execute_mdx_raw_with_member_properties_with_elem_properties(self):
-        mdx = MdxBuilder.from_cube(CUBE_NAME) \
+        mdx = MdxBuilder.from_cube(self.cube_name) \
             .rows_non_empty() \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[0], DIMENSION_NAMES[0])) \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[1], DIMENSION_NAMES[1])) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[2], DIMENSION_NAMES[2])) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(self.dimension_names[0], self.dimension_names[0])) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(self.dimension_names[1], self.dimension_names[1])) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.all_members(self.dimension_names[2], self.dimension_names[2])) \
             .to_mdx()
 
         raw = self.tm1.cubes.cells.execute_mdx_raw(
@@ -765,11 +769,11 @@ class TestCellMethods(unittest.TestCase):
                     self.assertEqual(element["Attributes"]["Attr2"], 2)
 
     def test_execute_mdx_raw_with_member_properties_without_elem_properties(self):
-        mdx = MdxBuilder.from_cube(CUBE_NAME) \
+        mdx = MdxBuilder.from_cube(self.cube_name) \
             .rows_non_empty() \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[0], DIMENSION_NAMES[0])) \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[1], DIMENSION_NAMES[1])) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[2], DIMENSION_NAMES[2])) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(self.dimension_names[0], self.dimension_names[0])) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(self.dimension_names[1], self.dimension_names[1])) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.all_members(self.dimension_names[2], self.dimension_names[2])) \
             .to_mdx()
 
         raw = self.tm1.cubes.cells.execute_mdx_raw(
@@ -796,11 +800,11 @@ class TestCellMethods(unittest.TestCase):
                     self.assertNotIn("Element", member)
 
     def test_execute_mdx_raw_without_member_properties_with_elem_properties(self):
-        mdx = MdxBuilder.from_cube(CUBE_NAME) \
+        mdx = MdxBuilder.from_cube(self.cube_name) \
             .rows_non_empty() \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[0], DIMENSION_NAMES[0])) \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[1], DIMENSION_NAMES[1])) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[2], DIMENSION_NAMES[2])) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(self.dimension_names[0], self.dimension_names[0])) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(self.dimension_names[1], self.dimension_names[1])) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.all_members(self.dimension_names[2], self.dimension_names[2])) \
             .to_mdx()
 
         raw = self.tm1.cubes.cells.execute_mdx_raw(
@@ -829,13 +833,13 @@ class TestCellMethods(unittest.TestCase):
                     self.assertNotIn("Ordinal", member)
 
     def test_execute_mdx_values(self):
-        self.tm1.cells.write_values(CUBE_NAME, self.cellset)
+        self.tm1.cells.write_values(self.cube_name, self.cellset)
 
-        mdx = MdxBuilder.from_cube(CUBE_NAME) \
+        mdx = MdxBuilder.from_cube(self.cube_name) \
             .columns_non_empty() \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[0], DIMENSION_NAMES[0])) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[1], DIMENSION_NAMES[1])) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[2], DIMENSION_NAMES[2])) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.all_members(self.dimension_names[0], self.dimension_names[0])) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.all_members(self.dimension_names[1], self.dimension_names[1])) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.all_members(self.dimension_names[2], self.dimension_names[2])) \
             .to_mdx()
 
         cell_values = self.tm1.cubes.cells.execute_mdx_values(mdx)
@@ -849,8 +853,8 @@ class TestCellMethods(unittest.TestCase):
               "SELECT[{}].MEMBERS ON ROWS, " \
               "{{[{}].[{}]}} ON COLUMNS " \
               "FROM[{}] " \
-              "WHERE([{}].DefaultMember)".format(DIMENSION_NAMES[1], "Calculated Member", DIMENSION_NAMES[0],
-                                                 DIMENSION_NAMES[1], "Calculated Member", CUBE_NAME, DIMENSION_NAMES[2])
+              "WHERE([{}].DefaultMember)".format(self.dimension_names[1], "Calculated Member", self.dimension_names[0],
+                                                 self.dimension_names[1], "Calculated Member", self.cube_name, self.dimension_names[2])
 
         data = self.tm1.cubes.cells.execute_mdx_values(mdx)
         self.assertEqual(
@@ -862,11 +866,11 @@ class TestCellMethods(unittest.TestCase):
             sum(data))
 
     def test_execute_mdx_csv(self):
-        mdx = MdxBuilder.from_cube(CUBE_NAME) \
+        mdx = MdxBuilder.from_cube(self.cube_name) \
             .rows_non_empty() \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[0], DIMENSION_NAMES[0])) \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[1], DIMENSION_NAMES[1])) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[2], DIMENSION_NAMES[2])) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(self.dimension_names[0], self.dimension_names[0])) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(self.dimension_names[1], self.dimension_names[1])) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.all_members(self.dimension_names[2], self.dimension_names[2])) \
             .to_mdx()
 
         csv = self.tm1.cubes.cells.execute_mdx_csv(mdx)
@@ -874,7 +878,7 @@ class TestCellMethods(unittest.TestCase):
         # check header
         header = csv.split('\r\n')[0]
         self.assertEqual(
-            ",".join(DIMENSION_NAMES + ["Value"]),
+            ",".join(self.dimension_names + ["Value"]),
             header)
 
         # check type
@@ -902,11 +906,11 @@ class TestCellMethods(unittest.TestCase):
             sum(values))
 
     def test_execute_mdx_csv_empty_cellset(self):
-        mdx = MdxBuilder.from_cube(CUBE_NAME) \
+        mdx = MdxBuilder.from_cube(self.cube_name) \
             .rows_non_empty() \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[0], "Element9"))) \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[1], "Element 18"))) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[2], "Element 2"))) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.member(Member.of(self.dimension_names[0], "Element9"))) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.member(Member.of(self.dimension_names[1], "Element 18"))) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(self.dimension_names[2], "Element 2"))) \
             .to_mdx()
 
         csv = self.tm1.cubes.cells.execute_mdx_csv(mdx)
@@ -914,13 +918,13 @@ class TestCellMethods(unittest.TestCase):
         self.assertEqual("", csv)
 
     def test_execute_mdx_csv_skip_rule_derived(self):
-        mdx = MdxBuilder.from_cube(CUBE_WITH_RULES_NAME) \
+        mdx = MdxBuilder.from_cube(self.cube_with_rules_name) \
             .rows_non_empty() \
             .add_hierarchy_set_to_row_axis(
-            MdxHierarchySet.all_members(DIMENSION_NAMES[1], DIMENSION_NAMES[1]).head(100)) \
+            MdxHierarchySet.all_members(self.dimension_names[1], self.dimension_names[1]).head(100)) \
             .add_hierarchy_set_to_column_axis(
-            MdxHierarchySet.all_members(DIMENSION_NAMES[2], DIMENSION_NAMES[2]).head(100)) \
-            .add_member_to_where(Member.of(DIMENSION_NAMES[0], "Element1")) \
+            MdxHierarchySet.all_members(self.dimension_names[2], self.dimension_names[2]).head(100)) \
+            .add_member_to_where(Member.of(self.dimension_names[0], "Element1")) \
             .to_mdx()
 
         csv = self.tm1.cubes.cells.execute_mdx_csv(mdx, skip_rule_derived_cells=True)
@@ -928,12 +932,12 @@ class TestCellMethods(unittest.TestCase):
         self.assertEqual("", csv)
 
     def test_execute_mdx_csv_top(self):
-        mdx = MdxBuilder.from_cube(CUBE_NAME) \
+        mdx = MdxBuilder.from_cube(self.cube_name) \
             .add_hierarchy_set_to_row_axis(
-            MdxHierarchySet.all_members(DIMENSION_NAMES[1], DIMENSION_NAMES[1]).head(10)) \
+            MdxHierarchySet.all_members(self.dimension_names[1], self.dimension_names[1]).head(10)) \
             .add_hierarchy_set_to_column_axis(
-            MdxHierarchySet.all_members(DIMENSION_NAMES[2], DIMENSION_NAMES[2]).head(10)) \
-            .add_member_to_where(Member.of(DIMENSION_NAMES[0], "Element1")) \
+            MdxHierarchySet.all_members(self.dimension_names[2], self.dimension_names[2]).head(10)) \
+            .add_member_to_where(Member.of(self.dimension_names[0], "Element1")) \
             .to_mdx()
 
         csv = self.tm1.cubes.cells.execute_mdx_csv(mdx, top=10, skip_zeros=False)
@@ -942,12 +946,12 @@ class TestCellMethods(unittest.TestCase):
         self.assertEqual(11, len(records))
 
     def test_execute_mdx_csv_skip(self):
-        mdx = MdxBuilder.from_cube(CUBE_NAME) \
+        mdx = MdxBuilder.from_cube(self.cube_name) \
             .add_hierarchy_set_to_row_axis(
-            MdxHierarchySet.all_members(DIMENSION_NAMES[1], DIMENSION_NAMES[1]).head(10)) \
+            MdxHierarchySet.all_members(self.dimension_names[1], self.dimension_names[1]).head(10)) \
             .add_hierarchy_set_to_column_axis(
-            MdxHierarchySet.all_members(DIMENSION_NAMES[2], DIMENSION_NAMES[2]).head(10)) \
-            .add_member_to_where(Member.of(DIMENSION_NAMES[0], "Element1")) \
+            MdxHierarchySet.all_members(self.dimension_names[2], self.dimension_names[2]).head(10)) \
+            .add_member_to_where(Member.of(self.dimension_names[0], "Element1")) \
             .to_mdx()
 
         csv = self.tm1.cubes.cells.execute_mdx_csv(mdx, skip=10, skip_zeros=False)
@@ -957,15 +961,15 @@ class TestCellMethods(unittest.TestCase):
 
     def test_execute_mdx_csv_with_calculated_member(self):
         # MDX Query with calculated MEMBER
-        mdx = MdxBuilder.from_cube(CUBE_NAME).with_member(CalculatedMember.lookup_attribute(
-            DIMENSION_NAMES[1],
-            DIMENSION_NAMES[1],
+        mdx = MdxBuilder.from_cube(self.cube_name).with_member(CalculatedMember.lookup_attribute(
+            self.dimension_names[1],
+            self.dimension_names[1],
             "Calculated Member",
-            DIMENSION_NAMES[0],
+            self.dimension_names[0],
             "Attr3")) \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[0], DIMENSION_NAMES[0])) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(self.dimension_names[0], self.dimension_names[0])) \
             .add_hierarchy_set_to_column_axis(
-            MdxHierarchySet.member(Member.of(DIMENSION_NAMES[1], "Calculated Member"))) \
+            MdxHierarchySet.member(Member.of(self.dimension_names[1], "Calculated Member"))) \
             .to_mdx()
 
         csv = self.tm1.cubes.cells.execute_mdx_csv(mdx)
@@ -973,7 +977,7 @@ class TestCellMethods(unittest.TestCase):
         # check header
         header = csv.split('\r\n')[0]
         self.assertEqual(
-            ",".join(DIMENSION_NAMES[0:2] + ["Value"]),
+            ",".join(self.dimension_names[0:2] + ["Value"]),
             header)
 
         # check coordinates
@@ -993,11 +997,11 @@ class TestCellMethods(unittest.TestCase):
             self.assertEqual(value, 3)
 
     def test_execute_mdx_elements_value_dict(self):
-        mdx = MdxBuilder.from_cube(CUBE_NAME) \
+        mdx = MdxBuilder.from_cube(self.cube_name) \
             .rows_non_empty() \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[0], DIMENSION_NAMES[0])) \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[1], DIMENSION_NAMES[1])) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[2], DIMENSION_NAMES[2])) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(self.dimension_names[0], self.dimension_names[0])) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(self.dimension_names[1], self.dimension_names[1])) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.all_members(self.dimension_names[2], self.dimension_names[2])) \
             .to_mdx()
 
         values = self.tm1.cubes.cells.execute_mdx_elements_value_dict(mdx)
@@ -1015,11 +1019,11 @@ class TestCellMethods(unittest.TestCase):
 
     @skip_if_no_pandas
     def test_execute_mdx_dataframe(self):
-        mdx = MdxBuilder.from_cube(CUBE_NAME) \
+        mdx = MdxBuilder.from_cube(self.cube_name) \
             .rows_non_empty() \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[0], DIMENSION_NAMES[0])) \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[1], DIMENSION_NAMES[1])) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[2], DIMENSION_NAMES[2])) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(self.dimension_names[0], self.dimension_names[0])) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(self.dimension_names[1], self.dimension_names[1])) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.all_members(self.dimension_names[2], self.dimension_names[2])) \
             .to_mdx()
 
         df = self.tm1.cubes.cells.execute_mdx_dataframe(mdx)
@@ -1031,7 +1035,7 @@ class TestCellMethods(unittest.TestCase):
         coordinates = {
             tuple(row)
             for row
-            in df[[*DIMENSION_NAMES]].values}
+            in df[[*self.dimension_names]].values}
         self.assertEqual(
             len(coordinates),
             len(self.target_coordinates))
@@ -1045,11 +1049,11 @@ class TestCellMethods(unittest.TestCase):
 
     @skip_if_no_pandas
     def test_execute_mdx_dataframe_pivot(self):
-        mdx = MdxBuilder.from_cube(CUBE_NAME) \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[0], DIMENSION_NAMES[0]).head(7)) \
+        mdx = MdxBuilder.from_cube(self.cube_name) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(self.dimension_names[0], self.dimension_names[0]).head(7)) \
             .add_hierarchy_set_to_column_axis(
-            MdxHierarchySet.all_members(DIMENSION_NAMES[1], DIMENSION_NAMES[1]).head(8)) \
-            .where(Member.of(DIMENSION_NAMES[2], "Element1")) \
+            MdxHierarchySet.all_members(self.dimension_names[1], self.dimension_names[1]).head(8)) \
+            .where(Member.of(self.dimension_names[2], "Element1")) \
             .to_mdx()
 
         pivot = self.tm1.cubes.cells.execute_mdx_dataframe_pivot(mdx=mdx)
@@ -1057,34 +1061,34 @@ class TestCellMethods(unittest.TestCase):
 
     @skip_if_no_pandas
     def test_execute_mdx_dataframe_pivot_no_titles(self):
-        mdx = MdxBuilder.from_cube(CUBE_NAME) \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[0], DIMENSION_NAMES[0]).head(7)) \
+        mdx = MdxBuilder.from_cube(self.cube_name) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(self.dimension_names[0], self.dimension_names[0]).head(7)) \
             .add_hierarchy_set_to_column_axis(
-            MdxHierarchySet.all_members(DIMENSION_NAMES[1], DIMENSION_NAMES[1]).head(5)) \
+            MdxHierarchySet.all_members(self.dimension_names[1], self.dimension_names[1]).head(5)) \
             .add_hierarchy_set_to_column_axis(
-            MdxHierarchySet.all_members(DIMENSION_NAMES[2], DIMENSION_NAMES[2]).head(5)) \
+            MdxHierarchySet.all_members(self.dimension_names[2], self.dimension_names[2]).head(5)) \
             .to_mdx()
 
         pivot = self.tm1.cubes.cells.execute_mdx_dataframe_pivot(mdx=mdx)
         self.assertEqual(pivot.shape, (7, 5 * 5))
 
     def test_execute_mdx_cellcount(self):
-        mdx = MdxBuilder.from_cube(CUBE_NAME) \
+        mdx = MdxBuilder.from_cube(self.cube_name) \
             .rows_non_empty() \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[0], DIMENSION_NAMES[0])) \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[1], DIMENSION_NAMES[1])) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(self.dimension_names[0], self.dimension_names[0])) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(self.dimension_names[1], self.dimension_names[1])) \
             .columns_non_empty() \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[2], DIMENSION_NAMES[2])) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.all_members(self.dimension_names[2], self.dimension_names[2])) \
             .to_mdx()
 
         cell_count = self.tm1.cubes.cells.execute_mdx_cellcount(mdx)
         self.assertGreater(cell_count, 1000)
 
     def test_execute_mdx_rows_and_values_string_set_one_row_dimension(self):
-        mdx = MdxBuilder.from_cube(STRING_CUBE_NAME) \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.tm1_subset_all(STRING_DIMENSION_NAMES[0])) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.tm1_subset_all(STRING_DIMENSION_NAMES[1])) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.tm1_subset_all(STRING_DIMENSION_NAMES[2])) \
+        mdx = MdxBuilder.from_cube(self.string_cube_name) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.tm1_subset_all(self.string_dimension_names[0])) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.tm1_subset_all(self.string_dimension_names[1])) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.tm1_subset_all(self.string_dimension_names[2])) \
             .to_mdx()
 
         elements_and_string_values = self.tm1.cubes.cells.execute_mdx_rows_and_values_string_set(mdx)
@@ -1094,10 +1098,10 @@ class TestCellMethods(unittest.TestCase):
             {"d1e1", "d1e2", "d1e3", "d1e4", "String1", "String2", "String3"})
 
     def test_execute_mdx_rows_and_values_string_set_two_row_dimensions(self):
-        mdx = MdxBuilder.from_cube(STRING_CUBE_NAME) \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.tm1_subset_all(STRING_DIMENSION_NAMES[0])) \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.tm1_subset_all(STRING_DIMENSION_NAMES[1])) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.tm1_subset_all(STRING_DIMENSION_NAMES[2])) \
+        mdx = MdxBuilder.from_cube(self.string_cube_name) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.tm1_subset_all(self.string_dimension_names[0])) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.tm1_subset_all(self.string_dimension_names[1])) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.tm1_subset_all(self.string_dimension_names[2])) \
             .to_mdx()
 
         elements_and_string_values = self.tm1.cubes.cells.execute_mdx_rows_and_values_string_set(mdx)
@@ -1107,10 +1111,10 @@ class TestCellMethods(unittest.TestCase):
             {"d1e1", "d1e2", "d1e3", "d1e4", "d2e1", "d2e2", "d2e3", "d2e4", "String1", "String2", "String3"})
 
     def test_execute_mdx_rows_and_values_string_set_include_empty(self):
-        mdx = MdxBuilder.from_cube(STRING_CUBE_NAME) \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.tm1_subset_all(STRING_DIMENSION_NAMES[0])) \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.tm1_subset_all(STRING_DIMENSION_NAMES[1])) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.tm1_subset_all(STRING_DIMENSION_NAMES[2])) \
+        mdx = MdxBuilder.from_cube(self.string_cube_name) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.tm1_subset_all(self.string_dimension_names[0])) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.tm1_subset_all(self.string_dimension_names[1])) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.tm1_subset_all(self.string_dimension_names[2])) \
             .to_mdx()
 
         elements_and_string_values = self.tm1.cubes.cells.execute_mdx_rows_and_values_string_set(
@@ -1122,13 +1126,13 @@ class TestCellMethods(unittest.TestCase):
             {"d1e1", "d1e2", "d1e3", "d1e4", "d2e1", "d2e2", "d2e3", "d2e4", "String1", "String2", "String3", ""})
 
     def test_execute_mdx_rows_and_values_string_set_against_numeric_cells(self):
-        mdx = MdxBuilder.from_cube(CUBE_NAME) \
+        mdx = MdxBuilder.from_cube(self.cube_name) \
             .add_hierarchy_set_to_row_axis(
-            MdxHierarchySet.all_members(DIMENSION_NAMES[0], DIMENSION_NAMES[0]).head(10)) \
+            MdxHierarchySet.all_members(self.dimension_names[0], self.dimension_names[0]).head(10)) \
             .add_hierarchy_set_to_row_axis(
-            MdxHierarchySet.all_members(DIMENSION_NAMES[1], DIMENSION_NAMES[1]).head(10)) \
+            MdxHierarchySet.all_members(self.dimension_names[1], self.dimension_names[1]).head(10)) \
             .add_hierarchy_set_to_column_axis(
-            MdxHierarchySet.all_members(DIMENSION_NAMES[2], DIMENSION_NAMES[2]).head(10)) \
+            MdxHierarchySet.all_members(self.dimension_names[2], self.dimension_names[2]).head(10)) \
             .to_mdx()
 
         elements_and_string_values = self.tm1.cubes.cells.execute_mdx_rows_and_values_string_set(
@@ -1149,18 +1153,18 @@ class TestCellMethods(unittest.TestCase):
              'Element 10'})
 
     def test_execute_view_rows_and_values_string_set(self):
-        mdx = MdxBuilder.from_cube(STRING_CUBE_NAME) \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.tm1_subset_all(STRING_DIMENSION_NAMES[0])) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.tm1_subset_all(STRING_DIMENSION_NAMES[2])) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.tm1_subset_all(STRING_DIMENSION_NAMES[1])) \
+        mdx = MdxBuilder.from_cube(self.string_cube_name) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.tm1_subset_all(self.string_dimension_names[0])) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.tm1_subset_all(self.string_dimension_names[2])) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.tm1_subset_all(self.string_dimension_names[1])) \
             .to_mdx()
 
         view_name = "some view"
-        view = MDXView(cube_name=STRING_CUBE_NAME, view_name=view_name, MDX=mdx)
+        view = MDXView(cube_name=self.string_cube_name, view_name=view_name, MDX=mdx)
         self.tm1.cubes.views.create(view, private=False)
 
         elements_and_string_values = self.tm1.cubes.cells.execute_view_rows_and_values_string_set(
-            cube_name=STRING_CUBE_NAME,
+            cube_name=self.string_cube_name,
             view_name=view_name,
             private=False)
 
@@ -1169,7 +1173,7 @@ class TestCellMethods(unittest.TestCase):
             {"d1e1", "d1e2", "d1e3", "d1e4", "String1", "String2", "String3"})
 
     def test_execute_view(self):
-        data = self.tm1.cubes.cells.execute_view(cube_name=CUBE_NAME, view_name=VIEW_NAME, private=False)
+        data = self.tm1.cubes.cells.execute_view(cube_name=self.cube_name, view_name=self.view_name, private=False)
 
         # Check if total value is the same AND coordinates are the same
         check_value = 0
@@ -1185,39 +1189,39 @@ class TestCellMethods(unittest.TestCase):
         self.assertEqual(check_value, self.total_value)
 
         # execute view with top
-        data = self.tm1.cubes.cells.execute_view(cube_name=CUBE_NAME, view_name=VIEW_NAME, private=False, top=3)
+        data = self.tm1.cubes.cells.execute_view(cube_name=self.cube_name, view_name=self.view_name, private=False, top=3)
         self.assertEqual(len(data.keys()), 3)
 
     def test_execute_view_skip_contexts(self):
-        view_name = PREFIX + "View_With_Titles"
-        if not self.tm1.cubes.views.exists(cube_name=CUBE_NAME, view_name=view_name, private=False):
+        view_name = self.prefix + "View_With_Titles"
+        if not self.tm1.cubes.views.exists(cube_name=self.cube_name, view_name=view_name, private=False):
             view = NativeView(
-                cube_name=CUBE_NAME,
+                cube_name=self.cube_name,
                 view_name=view_name,
                 suppress_empty_columns=False,
                 suppress_empty_rows=False)
             view.add_row(
-                dimension_name=DIMENSION_NAMES[0],
+                dimension_name=self.dimension_names[0],
                 subset=AnonymousSubset(
-                    dimension_name=DIMENSION_NAMES[0],
-                    expression='{[' + DIMENSION_NAMES[0] + '].[Element 1]}'))
+                    dimension_name=self.dimension_names[0],
+                    expression='{[' + self.dimension_names[0] + '].[Element 1]}'))
             view.add_column(
-                dimension_name=DIMENSION_NAMES[1],
+                dimension_name=self.dimension_names[1],
                 subset=AnonymousSubset(
-                    dimension_name=DIMENSION_NAMES[1],
-                    expression='{[' + DIMENSION_NAMES[1] + '].[Element 1]}'))
+                    dimension_name=self.dimension_names[1],
+                    expression='{[' + self.dimension_names[1] + '].[Element 1]}'))
             view.add_title(
-                dimension_name=DIMENSION_NAMES[2],
+                dimension_name=self.dimension_names[2],
                 subset=AnonymousSubset(
-                    dimension_name=DIMENSION_NAMES[2],
-                    expression='{[' + DIMENSION_NAMES[2] + '].Members}'),
+                    dimension_name=self.dimension_names[2],
+                    expression='{[' + self.dimension_names[2] + '].Members}'),
                 selection="Element 1")
             self.tm1.cubes.views.create(
                 view=view,
                 private=False)
 
         data = self.tm1.cubes.cells.execute_view(
-            cube_name=CUBE_NAME,
+            cube_name=self.cube_name,
             view_name=view_name,
             private=False,
             skip_contexts=True)
@@ -1227,59 +1231,59 @@ class TestCellMethods(unittest.TestCase):
             self.assertEqual(len(coordinates), 2)
             self.assertEqual(
                 Utils.dimension_name_from_element_unique_name(coordinates[0]),
-                DIMENSION_NAMES[0])
+                self.dimension_names[0])
             self.assertEqual(
                 Utils.dimension_name_from_element_unique_name(coordinates[1]),
-                DIMENSION_NAMES[1])
+                self.dimension_names[1])
 
     def test_execute_view_rows_and_values_one_dimension_on_rows(self):
-        view_name = PREFIX + "MDX_View_With_One_Dim_On_Rows"
-        if not self.tm1.cubes.views.exists(cube_name=CUBE_NAME, view_name=view_name, private=False):
-            mdx = MdxBuilder.from_cube(CUBE_NAME).add_hierarchy_set_to_row_axis(MdxHierarchySet.members([
-                Member.of(DIMENSION_NAMES[0], "Element1"),
-                Member.of(DIMENSION_NAMES[0], "Element2")])) \
+        view_name = self.prefix + "MDX_View_With_One_Dim_On_Rows"
+        if not self.tm1.cubes.views.exists(cube_name=self.cube_name, view_name=view_name, private=False):
+            mdx = MdxBuilder.from_cube(self.cube_name).add_hierarchy_set_to_row_axis(MdxHierarchySet.members([
+                Member.of(self.dimension_names[0], "Element1"),
+                Member.of(self.dimension_names[0], "Element2")])) \
                 .add_hierarchy_set_to_column_axis(MdxHierarchySet.members([
-                Member.of(DIMENSION_NAMES[1], "Element1"),
-                Member.of(DIMENSION_NAMES[1], "Element2"),
-                Member.of(DIMENSION_NAMES[1], "Element3")])) \
-                .where(Member.of(DIMENSION_NAMES[2], "Element1")) \
+                Member.of(self.dimension_names[1], "Element1"),
+                Member.of(self.dimension_names[1], "Element2"),
+                Member.of(self.dimension_names[1], "Element3")])) \
+                .where(Member.of(self.dimension_names[2], "Element1")) \
                 .to_mdx()
 
-            view = MDXView(cube_name=CUBE_NAME, view_name=view_name, MDX=mdx)
+            view = MDXView(cube_name=self.cube_name, view_name=view_name, MDX=mdx)
             self.tm1.cubes.views.create(view, False)
 
         data = self.tm1.cubes.cells.execute_view_rows_and_values(
-            cube_name=CUBE_NAME,
+            cube_name=self.cube_name,
             view_name=view_name,
             private=False)
 
         self.assertEqual(len(data), 2)
         for row, cells in data.items():
             dimension = Utils.dimension_name_from_element_unique_name(row[0])
-            self.assertEqual(dimension, DIMENSION_NAMES[0])
+            self.assertEqual(dimension, self.dimension_names[0])
             self.assertEqual(len(cells), 3)
 
     def test_execute_view_rows_and_values_with_member_names(self):
-        view_name = PREFIX + "MDX_View_With_Member_Names"
-        if not self.tm1.cubes.views.exists(cube_name=CUBE_NAME, view_name=view_name, private=False):
-            mdx = MdxBuilder.from_cube(CUBE_NAME).add_hierarchy_set_to_row_axis(MdxHierarchySet.members([
-                Member.of(DIMENSION_NAMES[0], "Element1"),
-                Member.of(DIMENSION_NAMES[0], "Element2")])) \
+        view_name = self.prefix + "MDX_View_With_Member_Names"
+        if not self.tm1.cubes.views.exists(cube_name=self.cube_name, view_name=view_name, private=False):
+            mdx = MdxBuilder.from_cube(self.cube_name).add_hierarchy_set_to_row_axis(MdxHierarchySet.members([
+                Member.of(self.dimension_names[0], "Element1"),
+                Member.of(self.dimension_names[0], "Element2")])) \
                 .add_hierarchy_set_to_row_axis(MdxHierarchySet.members([
-                Member.of(DIMENSION_NAMES[2], "Element1"),
-                Member.of(DIMENSION_NAMES[2], "Element2")])) \
+                Member.of(self.dimension_names[2], "Element1"),
+                Member.of(self.dimension_names[2], "Element2")])) \
                 .add_hierarchy_set_to_column_axis(MdxHierarchySet.members([
-                Member.of(DIMENSION_NAMES[1], "Element1"),
-                Member.of(DIMENSION_NAMES[1], "Element2"),
-                Member.of(DIMENSION_NAMES[1], "Element3")])) \
-                .where(Member.of(DIMENSION_NAMES[2], "Element1")) \
+                Member.of(self.dimension_names[1], "Element1"),
+                Member.of(self.dimension_names[1], "Element2"),
+                Member.of(self.dimension_names[1], "Element3")])) \
+                .where(Member.of(self.dimension_names[2], "Element1")) \
                 .to_mdx()
 
-            view = MDXView(cube_name=CUBE_NAME, view_name=view_name, MDX=mdx)
+            view = MDXView(cube_name=self.cube_name, view_name=view_name, MDX=mdx)
             self.tm1.cubes.views.create(view, False)
 
         data = self.tm1.cubes.cells.execute_view_rows_and_values(
-            cube_name=CUBE_NAME,
+            cube_name=self.cube_name,
             view_name=view_name,
             private=False,
             element_unique_names=False)
@@ -1293,26 +1297,26 @@ class TestCellMethods(unittest.TestCase):
             self.assertEqual(len(cells), 3)
 
     def test_execute_view_rows_and_values_two_dimensions_on_rows(self):
-        view_name = PREFIX + "MDX_View_With_Two_Dim_On_Rows"
-        if not self.tm1.cubes.views.exists(cube_name=CUBE_NAME, view_name=view_name, private=False):
-            mdx = MdxBuilder.from_cube(CUBE_NAME).add_hierarchy_set_to_row_axis(MdxHierarchySet.members([
-                Member.of(DIMENSION_NAMES[0], "Element1"),
-                Member.of(DIMENSION_NAMES[0], "Element2")])) \
+        view_name = self.prefix + "MDX_View_With_Two_Dim_On_Rows"
+        if not self.tm1.cubes.views.exists(cube_name=self.cube_name, view_name=view_name, private=False):
+            mdx = MdxBuilder.from_cube(self.cube_name).add_hierarchy_set_to_row_axis(MdxHierarchySet.members([
+                Member.of(self.dimension_names[0], "Element1"),
+                Member.of(self.dimension_names[0], "Element2")])) \
                 .add_hierarchy_set_to_row_axis(MdxHierarchySet.members([
-                Member.of(DIMENSION_NAMES[1], "Element1"),
-                Member.of(DIMENSION_NAMES[1], "Element2")])) \
+                Member.of(self.dimension_names[1], "Element1"),
+                Member.of(self.dimension_names[1], "Element2")])) \
                 .add_hierarchy_set_to_column_axis(MdxHierarchySet.members([
-                Member.of(DIMENSION_NAMES[2], "Element1"),
-                Member.of(DIMENSION_NAMES[2], "Element2"),
-                Member.of(DIMENSION_NAMES[2], "Element3")])) \
-                .where(Member.of(DIMENSION_NAMES[2], "Element1")) \
+                Member.of(self.dimension_names[2], "Element1"),
+                Member.of(self.dimension_names[2], "Element2"),
+                Member.of(self.dimension_names[2], "Element3")])) \
+                .where(Member.of(self.dimension_names[2], "Element1")) \
                 .to_mdx()
 
-            view = MDXView(cube_name=CUBE_NAME, view_name=view_name, MDX=mdx)
+            view = MDXView(cube_name=self.cube_name, view_name=view_name, MDX=mdx)
             self.tm1.cubes.views.create(view, False)
 
         data = self.tm1.cubes.cells.execute_view_rows_and_values(
-            cube_name=CUBE_NAME,
+            cube_name=self.cube_name,
             view_name=view_name,
             private=False)
 
@@ -1320,41 +1324,41 @@ class TestCellMethods(unittest.TestCase):
         for row, cells in data.items():
             self.assertEqual(len(row), 2)
             dimension = Utils.dimension_name_from_element_unique_name(row[0])
-            self.assertEqual(dimension, DIMENSION_NAMES[0])
+            self.assertEqual(dimension, self.dimension_names[0])
             dimension = Utils.dimension_name_from_element_unique_name(row[1])
-            self.assertEqual(dimension, DIMENSION_NAMES[1])
+            self.assertEqual(dimension, self.dimension_names[1])
             self.assertEqual(len(cells), 3)
 
     def test_execute_view_raw_skip_contexts(self):
-        view_name = PREFIX + "View_With_Titles"
-        if not self.tm1.cubes.views.exists(cube_name=CUBE_NAME, view_name=view_name, private=False):
+        view_name = self.prefix + "View_With_Titles"
+        if not self.tm1.cubes.views.exists(cube_name=self.cube_name, view_name=view_name, private=False):
             view = NativeView(
-                cube_name=CUBE_NAME,
+                cube_name=self.cube_name,
                 view_name=view_name,
                 suppress_empty_columns=False,
                 suppress_empty_rows=False)
             view.add_row(
-                dimension_name=DIMENSION_NAMES[0],
+                dimension_name=self.dimension_names[0],
                 subset=AnonymousSubset(
-                    dimension_name=DIMENSION_NAMES[0],
-                    expression='{[' + DIMENSION_NAMES[0] + '].[Element 1]}'))
+                    dimension_name=self.dimension_names[0],
+                    expression='{[' + self.dimension_names[0] + '].[Element 1]}'))
             view.add_column(
-                dimension_name=DIMENSION_NAMES[1],
+                dimension_name=self.dimension_names[1],
                 subset=AnonymousSubset(
-                    dimension_name=DIMENSION_NAMES[1],
-                    expression='{[' + DIMENSION_NAMES[1] + '].[Element 1]}'))
+                    dimension_name=self.dimension_names[1],
+                    expression='{[' + self.dimension_names[1] + '].[Element 1]}'))
             view.add_title(
-                dimension_name=DIMENSION_NAMES[2],
+                dimension_name=self.dimension_names[2],
                 subset=AnonymousSubset(
-                    dimension_name=DIMENSION_NAMES[2],
-                    expression='{[' + DIMENSION_NAMES[2] + '].Members}'),
+                    dimension_name=self.dimension_names[2],
+                    expression='{[' + self.dimension_names[2] + '].Members}'),
                 selection="Element 1")
             self.tm1.cubes.views.create(
                 view=view,
                 private=False)
 
         raw_response = self.tm1.cubes.cells.execute_view_raw(
-            cube_name=CUBE_NAME,
+            cube_name=self.cube_name,
             view_name=view_name,
             private=False,
             skip_contexts=True,
@@ -1364,13 +1368,13 @@ class TestCellMethods(unittest.TestCase):
         for axis in raw_response["Axes"]:
             dimension_on_axis = Utils.dimension_name_from_element_unique_name(
                 axis["Tuples"][0]["Members"][0]["UniqueName"])
-            self.assertNotEqual(dimension_on_axis, DIMENSION_NAMES[2])
+            self.assertNotEqual(dimension_on_axis, self.dimension_names[2])
 
     def test_execute_view_raw_with_member_properties_without_elem_properties(self):
         # Member properties and no element properties
         raw = self.tm1.cubes.cells.execute_view_raw(
-            cube_name=CUBE_NAME,
-            view_name=VIEW_NAME,
+            cube_name=self.cube_name,
+            view_name=self.view_name,
             private=False,
             cell_properties=["Value", "RuleDerived"],
             member_properties=["Name", "UniqueName", "Attributes/Attr1", "Attributes/Attr2"])
@@ -1401,8 +1405,8 @@ class TestCellMethods(unittest.TestCase):
 
     def test_execute_view_raw_with_elem_properties_without_member_properties(self):
         raw = self.tm1.cubes.cells.execute_view_raw(
-            cube_name=CUBE_NAME,
-            view_name=VIEW_NAME,
+            cube_name=self.cube_name,
+            view_name=self.view_name,
             private=False,
             cell_properties=["Value", "RuleDerived"],
             elem_properties=["Name", "UniqueName", "Attributes/Attr1", "Attributes/Attr2"])
@@ -1437,8 +1441,8 @@ class TestCellMethods(unittest.TestCase):
 
     def test_execute_view_with_elem_properties_with_member_properties(self):
         raw = self.tm1.cubes.cells.execute_view_raw(
-            cube_name=CUBE_NAME,
-            view_name=VIEW_NAME,
+            cube_name=self.cube_name,
+            view_name=self.view_name,
             private=False,
             cell_properties=["Value", "RuleDerived"],
             elem_properties=["Name", "UniqueName", "Attributes/Attr1", "Attributes/Attr2"],
@@ -1479,8 +1483,8 @@ class TestCellMethods(unittest.TestCase):
     def test_execute_view_raw_with_top(self):
         # check if top works
         raw = self.tm1.cubes.cells.execute_view_raw(
-            cube_name=CUBE_NAME,
-            view_name=VIEW_NAME,
+            cube_name=self.cube_name,
+            view_name=self.view_name,
             private=False,
             cell_properties=["Value", "RuleDerived"],
             elem_properties=["Name", "UniqueName", "Attributes/Attr1", "Attributes/Attr2"],
@@ -1488,7 +1492,7 @@ class TestCellMethods(unittest.TestCase):
         self.assertEqual(len(raw["Cells"]), 5)
 
     def test_execute_view_values(self):
-        cell_values = self.tm1.cubes.cells.execute_view_values(cube_name=CUBE_NAME, view_name=VIEW_NAME, private=False)
+        cell_values = self.tm1.cubes.cells.execute_view_values(cube_name=self.cube_name, view_name=self.view_name, private=False)
 
         # check type
         self.assertIsInstance(cell_values, list)
@@ -1497,7 +1501,7 @@ class TestCellMethods(unittest.TestCase):
         self.assertEqual(self.total_value, sum(v for v in cell_values if v))
 
     def test_execute_view_csv(self):
-        csv = self.tm1.cubes.cells.execute_view_csv(cube_name=CUBE_NAME, view_name=VIEW_NAME, private=False)
+        csv = self.tm1.cubes.cells.execute_view_csv(cube_name=self.cube_name, view_name=self.view_name, private=False)
 
         # check type
         self.assertIsInstance(csv, str)
@@ -1516,8 +1520,8 @@ class TestCellMethods(unittest.TestCase):
 
     def test_execute_view_elements_value_dict(self):
         values = self.tm1.cubes.cells.execute_view_elements_value_dict(
-            cube_name=CUBE_NAME,
-            view_name=VIEW_NAME,
+            cube_name=self.cube_name,
+            view_name=self.view_name,
             private=False)
 
         # check type
@@ -1533,8 +1537,8 @@ class TestCellMethods(unittest.TestCase):
 
     def test_execute_view_elements_value_dict_with_top_argument(self):
         values = self.tm1.cubes.cells.execute_view_elements_value_dict(
-            cube_name=CUBE_NAME,
-            view_name=VIEW_NAME,
+            cube_name=self.cube_name,
+            view_name=self.view_name,
             top=4,
             private=False)
 
@@ -1547,8 +1551,8 @@ class TestCellMethods(unittest.TestCase):
     @skip_if_no_pandas
     def test_execute_view_dataframe(self):
         df = self.tm1.cubes.cells.execute_view_dataframe(
-            cube_name=CUBE_NAME,
-            view_name=VIEW_NAME,
+            cube_name=self.cube_name,
+            view_name=self.view_name,
             private=False)
 
         # check type
@@ -1557,7 +1561,7 @@ class TestCellMethods(unittest.TestCase):
         # check coordinates
         coordinates = {tuple(row)
                        for row
-                       in df[[*DIMENSION_NAMES]].values}
+                       in df[[*self.dimension_names]].values}
         self.assertEqual(len(coordinates), len(self.target_coordinates))
         self.assertTrue(coordinates.issubset(self.target_coordinates))
 
@@ -1568,8 +1572,8 @@ class TestCellMethods(unittest.TestCase):
     @skip_if_no_pandas
     def test_execute_view_dataframe_with_top_argument(self):
         df = self.tm1.cubes.cells.execute_view_dataframe(
-            cube_name=CUBE_NAME,
-            view_name=VIEW_NAME,
+            cube_name=self.cube_name,
+            view_name=self.view_name,
             top=2,
             private=False)
 
@@ -1581,166 +1585,166 @@ class TestCellMethods(unittest.TestCase):
 
     @skip_if_no_pandas
     def test_execute_view_dataframe_pivot_two_row_one_column_dimensions(self):
-        view_name = PREFIX + "Pivot_two_row_one_column_dimensions"
+        view_name = self.prefix + "Pivot_two_row_one_column_dimensions"
         view = NativeView(
-            cube_name=CUBE_NAME,
+            cube_name=self.cube_name,
             view_name=view_name,
             suppress_empty_columns=False,
             suppress_empty_rows=False)
         view.add_row(
-            dimension_name=DIMENSION_NAMES[0],
+            dimension_name=self.dimension_names[0],
             subset=AnonymousSubset(
-                dimension_name=DIMENSION_NAMES[0],
-                expression='{ HEAD ( {[' + DIMENSION_NAMES[0] + '].Members}, 10) } }'))
+                dimension_name=self.dimension_names[0],
+                expression='{ HEAD ( {[' + self.dimension_names[0] + '].Members}, 10) } }'))
         view.add_row(
-            dimension_name=DIMENSION_NAMES[1],
+            dimension_name=self.dimension_names[1],
             subset=AnonymousSubset(
-                dimension_name=DIMENSION_NAMES[1],
-                expression='{ HEAD ( { [' + DIMENSION_NAMES[1] + '].Members}, 10 ) }'))
+                dimension_name=self.dimension_names[1],
+                expression='{ HEAD ( { [' + self.dimension_names[1] + '].Members}, 10 ) }'))
         view.add_column(
-            dimension_name=DIMENSION_NAMES[2],
+            dimension_name=self.dimension_names[2],
             subset=AnonymousSubset(
-                dimension_name=DIMENSION_NAMES[2],
-                expression='{ HEAD ( {[' + DIMENSION_NAMES[2] + '].Members}, 10 ) }'))
+                dimension_name=self.dimension_names[2],
+                expression='{ HEAD ( {[' + self.dimension_names[2] + '].Members}, 10 ) }'))
         self.tm1.cubes.views.create(view, private=False)
 
         pivot = self.tm1.cubes.cells.execute_view_dataframe_pivot(
-            cube_name=CUBE_NAME,
+            cube_name=self.cube_name,
             view_name=view_name)
         self.assertEqual((100, 10), pivot.shape)
 
     @skip_if_no_pandas
     def test_execute_view_dataframe_pivot_one_row_two_column_dimensions(self):
-        view_name = PREFIX + "Pivot_one_row_two_column_dimensions"
+        view_name = self.prefix + "Pivot_one_row_two_column_dimensions"
         view = NativeView(
-            cube_name=CUBE_NAME,
+            cube_name=self.cube_name,
             view_name=view_name,
             suppress_empty_columns=False,
             suppress_empty_rows=False)
         view.add_row(
-            dimension_name=DIMENSION_NAMES[0],
+            dimension_name=self.dimension_names[0],
             subset=AnonymousSubset(
-                dimension_name=DIMENSION_NAMES[0],
-                expression='{ HEAD ( {[' + DIMENSION_NAMES[0] + '].Members}, 10) } }'))
+                dimension_name=self.dimension_names[0],
+                expression='{ HEAD ( {[' + self.dimension_names[0] + '].Members}, 10) } }'))
         view.add_column(
-            dimension_name=DIMENSION_NAMES[1],
+            dimension_name=self.dimension_names[1],
             subset=AnonymousSubset(
-                dimension_name=DIMENSION_NAMES[1],
-                expression='{ HEAD ( { [' + DIMENSION_NAMES[1] + '].Members}, 10 ) }'))
+                dimension_name=self.dimension_names[1],
+                expression='{ HEAD ( { [' + self.dimension_names[1] + '].Members}, 10 ) }'))
         view.add_column(
-            dimension_name=DIMENSION_NAMES[2],
+            dimension_name=self.dimension_names[2],
             subset=AnonymousSubset(
-                dimension_name=DIMENSION_NAMES[2],
-                expression='{ HEAD ( {[' + DIMENSION_NAMES[2] + '].Members}, 10 ) }'))
+                dimension_name=self.dimension_names[2],
+                expression='{ HEAD ( {[' + self.dimension_names[2] + '].Members}, 10 ) }'))
         self.tm1.cubes.views.create(
             view=view,
             private=False)
 
         pivot = self.tm1.cubes.cells.execute_view_dataframe_pivot(
-            cube_name=CUBE_NAME,
+            cube_name=self.cube_name,
             view_name=view_name)
         self.assertEqual((10, 100), pivot.shape)
 
     @skip_if_no_pandas
     def test_execute_view_dataframe_pivot_one_row_one_column_dimensions(self):
-        view_name = PREFIX + "Pivot_one_row_one_column_dimensions"
+        view_name = self.prefix + "Pivot_one_row_one_column_dimensions"
         view = NativeView(
-            cube_name=CUBE_NAME,
+            cube_name=self.cube_name,
             view_name=view_name,
             suppress_empty_columns=False,
             suppress_empty_rows=False)
         view.add_row(
-            dimension_name=DIMENSION_NAMES[0],
+            dimension_name=self.dimension_names[0],
             subset=AnonymousSubset(
-                dimension_name=DIMENSION_NAMES[0],
-                expression='{ HEAD ( {[' + DIMENSION_NAMES[0] + '].Members}, 10) } }'))
+                dimension_name=self.dimension_names[0],
+                expression='{ HEAD ( {[' + self.dimension_names[0] + '].Members}, 10) } }'))
         view.add_column(
-            dimension_name=DIMENSION_NAMES[1],
+            dimension_name=self.dimension_names[1],
             subset=AnonymousSubset(
-                dimension_name=DIMENSION_NAMES[1],
-                expression='{ HEAD ( { [' + DIMENSION_NAMES[1] + '].Members}, 10 ) }'))
+                dimension_name=self.dimension_names[1],
+                expression='{ HEAD ( { [' + self.dimension_names[1] + '].Members}, 10 ) }'))
         view.add_title(
-            dimension_name=DIMENSION_NAMES[2],
+            dimension_name=self.dimension_names[2],
             selection="Element 1",
             subset=AnonymousSubset(
-                dimension_name=DIMENSION_NAMES[2],
+                dimension_name=self.dimension_names[2],
                 elements=("Element 1",)))
         self.tm1.cubes.views.create(view, private=False)
         pivot = self.tm1.cubes.cells.execute_view_dataframe_pivot(
-            cube_name=CUBE_NAME,
+            cube_name=self.cube_name,
             view_name=view_name)
         self.assertEqual((10, 10), pivot.shape)
 
     @skip_if_no_pandas
     def test_execute_mdxview_dataframe_pivot(self):
-        mdx = MdxBuilder.from_cube(CUBE_NAME) \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.default_member(DIMENSION_NAMES[0])) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.default_member(DIMENSION_NAMES[1])) \
-            .where(Member.of(DIMENSION_NAMES[2], "Element1")) \
+        mdx = MdxBuilder.from_cube(self.cube_name) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.default_member(self.dimension_names[0])) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.default_member(self.dimension_names[1])) \
+            .where(Member.of(self.dimension_names[2], "Element1")) \
             .to_mdx()
 
-        view = MDXView(CUBE_NAME, PREFIX + "MDX_VIEW", mdx)
+        view = MDXView(self.cube_name, self.prefix + "MDX_VIEW", mdx)
         self.tm1.cubes.views.create(
             view=view,
             private=False)
 
         pivot = self.tm1.cubes.cells.execute_view_dataframe_pivot(
-            cube_name=CUBE_NAME,
+            cube_name=self.cube_name,
             view_name=view.name,
             private=False)
         self.assertEqual((1, 1), pivot.shape)
 
         self.tm1.cubes.views.delete(
-            cube_name=CUBE_NAME,
+            cube_name=self.cube_name,
             view_name=view.name,
             private=False)
 
     def test_execute_view_cellcount(self):
         cell_count = self.tm1.cubes.cells.execute_view_cellcount(
-            cube_name=CUBE_NAME,
-            view_name=VIEW_NAME,
+            cube_name=self.cube_name,
+            view_name=self.view_name,
             private=False)
         self.assertGreater(cell_count, 1000)
 
     def test_execute_mdx_ui_array(self):
-        mdx = MdxBuilder.from_cube(CUBE_NAME) \
+        mdx = MdxBuilder.from_cube(self.cube_name) \
             .rows_non_empty() \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[0], DIMENSION_NAMES[0])) \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[1], DIMENSION_NAMES[1])) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(self.dimension_names[0], self.dimension_names[0])) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(self.dimension_names[1], self.dimension_names[1])) \
             .columns_non_empty() \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[2], DIMENSION_NAMES[2])) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.all_members(self.dimension_names[2], self.dimension_names[2])) \
             .to_mdx()
 
         self.tm1.cubes.cells.execute_mdx_ui_array(mdx=mdx)
 
     def test_execute_view_ui_array(self):
         self.tm1.cubes.cells.execute_view_ui_array(
-            cube_name=CUBE_NAME,
-            view_name=VIEW_NAME,
+            cube_name=self.cube_name,
+            view_name=self.view_name,
             private=False)
 
     def test_execute_mdx_ui_dygraph(self):
-        mdx = MdxBuilder.from_cube(CUBE_NAME) \
+        mdx = MdxBuilder.from_cube(self.cube_name) \
             .rows_non_empty() \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[0], DIMENSION_NAMES[0])) \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[1], DIMENSION_NAMES[1])) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(self.dimension_names[0], self.dimension_names[0])) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.all_members(self.dimension_names[1], self.dimension_names[1])) \
             .columns_non_empty() \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.all_members(DIMENSION_NAMES[2], DIMENSION_NAMES[2])) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.all_members(self.dimension_names[2], self.dimension_names[2])) \
             .to_mdx()
 
         self.tm1.cubes.cells.execute_mdx_ui_dygraph(mdx=mdx)
 
     def test_execute_view_ui_dygraph(self):
         self.tm1.cubes.cells.execute_view_ui_dygraph(
-            cube_name=CUBE_NAME,
-            view_name=VIEW_NAME,
+            cube_name=self.cube_name,
+            view_name=self.view_name,
             private=False)
 
     def test_write_values_through_cellset(self):
-        mdx = MdxBuilder.from_cube(CUBE_NAME) \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[0], "element2"))) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[1], "element2"))) \
-            .where(Member.of(DIMENSION_NAMES[2], "element2")) \
+        mdx = MdxBuilder.from_cube(self.cube_name) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.member(Member.of(self.dimension_names[0], "element2"))) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(self.dimension_names[1], "element2"))) \
+            .where(Member.of(self.dimension_names[2], "element2")) \
             .to_mdx()
 
         original_value = self.tm1.cubes.cells.execute_mdx_values(mdx)[0]
@@ -1752,10 +1756,10 @@ class TestCellMethods(unittest.TestCase):
         self.assertEqual(values[0], 1.5)
 
     def test_write_values_through_cellset_deactivate_transaction_log(self):
-        mdx = MdxBuilder.from_cube(CUBE_NAME) \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[0], "element2"))) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[1], "element2"))) \
-            .where(Member.of(DIMENSION_NAMES[2], "element2")) \
+        mdx = MdxBuilder.from_cube(self.cube_name) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.member(Member.of(self.dimension_names[0], "element2"))) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(self.dimension_names[1], "element2"))) \
+            .where(Member.of(self.dimension_names[2], "element2")) \
             .to_mdx()
 
         original_value = self.tm1.cubes.cells.execute_mdx_values(mdx)[0]
@@ -1766,13 +1770,13 @@ class TestCellMethods(unittest.TestCase):
         values = self.tm1.cubes.cells.execute_mdx_values(mdx)
 
         self.assertEqual(values[0], 1.5)
-        self.assertFalse(self.tm1.cells.transaction_log_is_active(CUBE_NAME))
+        self.assertFalse(self.tm1.cells.transaction_log_is_active(self.cube_name))
 
     def test_write_values_through_cellset_deactivate_transaction_log_reactivate_transaction_log(self):
-        mdx = MdxBuilder.from_cube(CUBE_NAME) \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[0], "element2"))) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[1], "element2"))) \
-            .where(Member.of(DIMENSION_NAMES[2], "element2")) \
+        mdx = MdxBuilder.from_cube(self.cube_name) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.member(Member.of(self.dimension_names[0], "element2"))) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(self.dimension_names[1], "element2"))) \
+            .where(Member.of(self.dimension_names[2], "element2")) \
             .to_mdx()
 
         original_value = self.tm1.cubes.cells.execute_mdx_values(mdx)[0]
@@ -1787,85 +1791,85 @@ class TestCellMethods(unittest.TestCase):
         values = self.tm1.cubes.cells.execute_mdx_values(mdx)
 
         self.assertEqual(values[0], 1.5)
-        self.assertTrue(self.tm1.cells.transaction_log_is_active(CUBE_NAME))
+        self.assertTrue(self.tm1.cells.transaction_log_is_active(self.cube_name))
 
     def test_deactivate_transaction_log(self):
         self.tm1.cubes.cells.write_value(value="YES",
                                          cube_name="}CubeProperties",
-                                         element_tuple=(CUBE_NAME, "Logging"))
-        self.tm1.cubes.cells.deactivate_transactionlog(CUBE_NAME)
-        value = self.tm1.cubes.cells.get_value("}CubeProperties", "{},LOGGING".format(CUBE_NAME))
+                                         element_tuple=(self.cube_name, "Logging"))
+        self.tm1.cubes.cells.deactivate_transactionlog(self.cube_name)
+        value = self.tm1.cubes.cells.get_value("}CubeProperties", "{},LOGGING".format(self.cube_name))
         self.assertEqual("NO", value.upper())
 
     def test_activate_transaction_log(self):
         self.tm1.cubes.cells.write_value(value="NO",
                                          cube_name="}CubeProperties",
-                                         element_tuple=(CUBE_NAME, "Logging"))
-        self.tm1.cubes.cells.activate_transactionlog(CUBE_NAME)
-        value = self.tm1.cubes.cells.get_value("}CubeProperties", "{},LOGGING".format(CUBE_NAME))
+                                         element_tuple=(self.cube_name, "Logging"))
+        self.tm1.cubes.cells.activate_transactionlog(self.cube_name)
+        value = self.tm1.cubes.cells.get_value("}CubeProperties", "{},LOGGING".format(self.cube_name))
         self.assertEqual("YES", value.upper())
 
     def test_read_write_with_custom_encoding(self):
         coordinates = ("d1e1", "d2e2", "d3e3")
-        self.tm1.cubes.cells.write_values(STRING_CUBE_NAME, {coordinates: LATIN_1_ENCODED_TEXT}, encoding="latin-1")
+        self.tm1.cubes.cells.write_values(self.string_cube_name, {coordinates: self.latin_1_encoded_text}, encoding="latin-1")
 
-        mdx = MdxBuilder.from_cube(STRING_CUBE_NAME) \
+        mdx = MdxBuilder.from_cube(self.string_cube_name) \
             .add_hierarchy_set_to_column_axis(
-            MdxHierarchySet.member(Member.of(STRING_DIMENSION_NAMES[0], coordinates[0]))) \
+            MdxHierarchySet.member(Member.of(self.string_dimension_names[0], coordinates[0]))) \
             .add_hierarchy_set_to_column_axis(
-            MdxHierarchySet.member(Member.of(STRING_DIMENSION_NAMES[1], coordinates[1]))) \
+            MdxHierarchySet.member(Member.of(self.string_dimension_names[1], coordinates[1]))) \
             .add_hierarchy_set_to_column_axis(
-            MdxHierarchySet.member(Member.of(STRING_DIMENSION_NAMES[2], coordinates[2]))) \
+            MdxHierarchySet.member(Member.of(self.string_dimension_names[2], coordinates[2]))) \
             .to_mdx()
 
         values = self.tm1.cubes.cells.execute_mdx_values(mdx=mdx, encoding="latin-1")
-        self.assertEqual(LATIN_1_ENCODED_TEXT, values[0])
+        self.assertEqual(self.latin_1_encoded_text, values[0])
 
     def test_read_write_with_custom_encoding_fail_response_encoding(self):
         coordinates = ("d1e1", "d2e2", "d3e3")
-        self.tm1.cubes.cells.write_values(STRING_CUBE_NAME, {coordinates: LATIN_1_ENCODED_TEXT}, encoding="latin-1")
+        self.tm1.cubes.cells.write_values(self.string_cube_name, {coordinates: self.latin_1_encoded_text}, encoding="latin-1")
 
-        mdx = MdxBuilder.from_cube(STRING_CUBE_NAME) \
+        mdx = MdxBuilder.from_cube(self.string_cube_name) \
             .add_hierarchy_set_to_column_axis(
-            MdxHierarchySet.member(Member.of(STRING_DIMENSION_NAMES[0], coordinates[0]))) \
+            MdxHierarchySet.member(Member.of(self.string_dimension_names[0], coordinates[0]))) \
             .add_hierarchy_set_to_column_axis(
-            MdxHierarchySet.member(Member.of(STRING_DIMENSION_NAMES[1], coordinates[1]))) \
+            MdxHierarchySet.member(Member.of(self.string_dimension_names[1], coordinates[1]))) \
             .add_hierarchy_set_to_column_axis(
-            MdxHierarchySet.member(Member.of(STRING_DIMENSION_NAMES[2], coordinates[2]))) \
+            MdxHierarchySet.member(Member.of(self.string_dimension_names[2], coordinates[2]))) \
             .to_mdx()
 
         values = self.tm1.cubes.cells.execute_mdx_values(mdx=mdx)
 
-        self.assertNotEqual(LATIN_1_ENCODED_TEXT, values[0])
+        self.assertNotEqual(self.latin_1_encoded_text, values[0])
 
     def test_read_write_with_custom_encoding_fail_request_encoding(self):
         coordinates = ("d1e1", "d2e2", "d3e3")
-        self.tm1.cubes.cells.write_values(STRING_CUBE_NAME, {coordinates: LATIN_1_ENCODED_TEXT})
+        self.tm1.cubes.cells.write_values(self.string_cube_name, {coordinates: self.latin_1_encoded_text})
 
-        mdx = MdxBuilder.from_cube(STRING_CUBE_NAME) \
+        mdx = MdxBuilder.from_cube(self.string_cube_name) \
             .add_hierarchy_set_to_column_axis(
-            MdxHierarchySet.member(Member.of(STRING_DIMENSION_NAMES[0], coordinates[0]))) \
+            MdxHierarchySet.member(Member.of(self.string_dimension_names[0], coordinates[0]))) \
             .add_hierarchy_set_to_column_axis(
-            MdxHierarchySet.member(Member.of(STRING_DIMENSION_NAMES[1], coordinates[1]))) \
+            MdxHierarchySet.member(Member.of(self.string_dimension_names[1], coordinates[1]))) \
             .add_hierarchy_set_to_column_axis(
-            MdxHierarchySet.member(Member.of(STRING_DIMENSION_NAMES[2], coordinates[2]))) \
+            MdxHierarchySet.member(Member.of(self.string_dimension_names[2], coordinates[2]))) \
             .to_mdx()
 
         values = self.tm1.cubes.cells.execute_mdx_values(mdx=mdx, encoding="latin-1")
-        self.assertNotEqual(LATIN_1_ENCODED_TEXT, values[0])
+        self.assertNotEqual(self.latin_1_encoded_text, values[0])
 
     @skip_if_insufficient_version(version="11.7")
     def test_clear_with_mdx_happy_case(self):
         cells = {("Element17", "Element21", "Element15"): 1}
-        self.tm1.cells.write_values(CUBE_NAME, cells)
+        self.tm1.cells.write_values(self.cube_name, cells)
 
-        mdx = MdxBuilder.from_cube(CUBE_NAME) \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[0], "Element17"))) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[1], "Element21"))) \
-            .where(Member.of(DIMENSION_NAMES[2], "Element15")) \
+        mdx = MdxBuilder.from_cube(self.cube_name) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.member(Member.of(self.dimension_names[0], "Element17"))) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(self.dimension_names[1], "Element21"))) \
+            .where(Member.of(self.dimension_names[2], "Element15")) \
             .to_mdx()
 
-        self.tm1.cells.clear_with_mdx(cube=CUBE_NAME, mdx=mdx)
+        self.tm1.cells.clear_with_mdx(cube=self.cube_name, mdx=mdx)
 
         value = self.tm1.cells.execute_mdx_values(mdx=mdx)[0]
         self.assertEqual(value, None)
@@ -1873,14 +1877,14 @@ class TestCellMethods(unittest.TestCase):
     @skip_if_insufficient_version(version="11.7")
     def test_clear_with_mdx_all_on_axis0(self):
         cells = {("Element19", "Element11", "Element31"): 1}
-        self.tm1.cells.write_values(CUBE_NAME, cells)
+        self.tm1.cells.write_values(self.cube_name, cells)
 
-        mdx = MdxBuilder.from_cube(CUBE_NAME) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[0], "Element19"))) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[1], "Element11"))) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[2], "Element31"))) \
+        mdx = MdxBuilder.from_cube(self.cube_name) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(self.dimension_names[0], "Element19"))) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(self.dimension_names[1], "Element11"))) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(self.dimension_names[2], "Element31"))) \
             .to_mdx()
-        self.tm1.cells.clear_with_mdx(cube=CUBE_NAME, mdx=mdx)
+        self.tm1.cells.clear_with_mdx(cube=self.cube_name, mdx=mdx)
 
         value = self.tm1.cells.execute_mdx_values(mdx=mdx)[0]
         self.assertEqual(value, None)
@@ -1888,19 +1892,19 @@ class TestCellMethods(unittest.TestCase):
     @skip_if_insufficient_version(version="11.7")
     def test_clear_happy_case(self):
         cells = {("Element12", "Element17", "Element32"): 1}
-        self.tm1.cells.write_values(CUBE_NAME, cells)
+        self.tm1.cells.write_values(self.cube_name, cells)
 
         kwargs = {
-            DIMENSION_NAMES[0]: f"[{DIMENSION_NAMES[0]}].[Element12]",
-            DIMENSION_NAMES[1]: f"{{[{DIMENSION_NAMES[1]}].[Element17]}}",
-            DIMENSION_NAMES[2]: f"[{DIMENSION_NAMES[2]}].[Element32]"
+            self.dimension_names[0]: f"[{self.dimension_names[0]}].[Element12]",
+            self.dimension_names[1]: f"{{[{self.dimension_names[1]}].[Element17]}}",
+            self.dimension_names[2]: f"[{self.dimension_names[2]}].[Element32]"
         }
-        self.tm1.cells.clear(cube=CUBE_NAME, **kwargs)
+        self.tm1.cells.clear(cube=self.cube_name, **kwargs)
 
-        mdx = MdxBuilder.from_cube(CUBE_NAME) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[0], "Element12"))) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[1], "Element17"))) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[2], "Element32"))) \
+        mdx = MdxBuilder.from_cube(self.cube_name) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(self.dimension_names[0], "Element12"))) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(self.dimension_names[1], "Element17"))) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(self.dimension_names[2], "Element32"))) \
             .to_mdx()
 
         value = self.tm1.cells.execute_mdx_values(mdx=mdx)[0]
@@ -1911,11 +1915,11 @@ class TestCellMethods(unittest.TestCase):
 
         with self.assertRaises(TM1pyException) as e:
             kwargs = {
-                DIMENSION_NAMES[0]: f"[{DIMENSION_NAMES[0]}].[Element12]",
-                DIMENSION_NAMES[1]: f"[{DIMENSION_NAMES[1]}].[Element17]",
-                DIMENSION_NAMES[2]: f"[{DIMENSION_NAMES[2]}].[NotExistingElement]"
+                self.dimension_names[0]: f"[{self.dimension_names[0]}].[Element12]",
+                self.dimension_names[1]: f"[{self.dimension_names[1]}].[Element17]",
+                self.dimension_names[2]: f"[{self.dimension_names[2]}].[NotExistingElement]"
             }
-            self.tm1.cells.clear(cube=CUBE_NAME, **kwargs)
+            self.tm1.cells.clear(cube=self.cube_name, **kwargs)
 
         self.assertEqual(
             "{\"error\":{\"code\":\"248\",\"message\":\"\\\"NotExistingElement\\\" : member not found (rte 81)\"}}",
@@ -1926,10 +1930,10 @@ class TestCellMethods(unittest.TestCase):
         with self.assertRaises(TM1pyException) as e:
             mdx = f"""
             SELECT
-            {{[{DIMENSION_NAMES[0]}].[NotExistingElement]}} ON 0
-            FROM [{CUBE_NAME}]
+            {{[{self.dimension_names[0]}].[NotExistingElement]}} ON 0
+            FROM [{self.cube_name}]
             """
-            self.tm1.cells.clear_with_mdx(cube=CUBE_NAME, mdx=mdx)
+            self.tm1.cells.clear_with_mdx(cube=self.cube_name, mdx=mdx)
 
         self.assertEqual(
             "{\"error\":{\"code\":\"248\",\"message\":\"\\\"NotExistingElement\\\" : member not found (rte 81)\"}}",
@@ -1938,26 +1942,26 @@ class TestCellMethods(unittest.TestCase):
     def test_clear_with_mdx_unsupported_version(self):
 
         with self.assertRaises(TM1pyVersionException) as e:
-            mdx = MdxBuilder.from_cube(CUBE_NAME) \
-                .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[0], "Element19"))) \
-                .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[1], "Element11"))) \
-                .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(DIMENSION_NAMES[2], "Element31"))) \
+            mdx = MdxBuilder.from_cube(self.cube_name) \
+                .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(self.dimension_names[0], "Element19"))) \
+                .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(self.dimension_names[1], "Element11"))) \
+                .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(self.dimension_names[2], "Element31"))) \
                 .to_mdx()
 
             # This needs to be rethought as may influence other tests
             self.tm1._tm1_rest._version = "11.2.00000.27"
 
-            self.tm1.cells.clear_with_mdx(cube=CUBE_NAME, mdx=mdx)
+            self.tm1.cells.clear_with_mdx(cube=self.cube_name, mdx=mdx)
 
         self.assertEqual(
             str(e.exception),
             str(TM1pyVersionException(function="clear_with_mdx", required_version="11.7")))
 
     def test_execute_mdx_with_skip(self):
-        mdx = MdxBuilder.from_cube(CUBE_NAME) \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.tm1_subset_all(DIMENSION_NAMES[0]).head(2)) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.tm1_subset_all(DIMENSION_NAMES[1]).head(2)) \
-            .where(Member.of(DIMENSION_NAMES[2], "Element1")) \
+        mdx = MdxBuilder.from_cube(self.cube_name) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.tm1_subset_all(self.dimension_names[0]).head(2)) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.tm1_subset_all(self.dimension_names[1]).head(2)) \
+            .where(Member.of(self.dimension_names[2], "Element1")) \
             .to_mdx()
 
         cells = self.tm1.cubes.cells.execute_mdx(mdx=mdx, skip=2)
@@ -1970,10 +1974,10 @@ class TestCellMethods(unittest.TestCase):
         self.assertEqual(elements, ("Element 2", "Element 2", "Element 1"))
 
     def test_execute_mdx_with_top_skip(self):
-        mdx = MdxBuilder.from_cube(CUBE_NAME) \
-            .add_hierarchy_set_to_row_axis(MdxHierarchySet.tm1_subset_all(DIMENSION_NAMES[0]).head(2)) \
-            .add_hierarchy_set_to_column_axis(MdxHierarchySet.tm1_subset_all(DIMENSION_NAMES[1]).head(2)) \
-            .where(Member.of(DIMENSION_NAMES[2], "Element1")) \
+        mdx = MdxBuilder.from_cube(self.cube_name) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.tm1_subset_all(self.dimension_names[0]).head(2)) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.tm1_subset_all(self.dimension_names[1]).head(2)) \
+            .where(Member.of(self.dimension_names[2], "Element1")) \
             .to_mdx()
 
         cells = self.tm1.cubes.cells.execute_mdx(mdx=mdx, top=1, skip=2)
@@ -1983,52 +1987,52 @@ class TestCellMethods(unittest.TestCase):
         self.assertEqual(elements, ("Element 2", "Element 1", "Element 1"))
 
     def test_transaction_log_is_active_false(self):
-        self.tm1.cells.deactivate_transactionlog(CUBE_NAME)
+        self.tm1.cells.deactivate_transactionlog(self.cube_name)
 
-        self.assertFalse(self.tm1.cells.transaction_log_is_active(CUBE_NAME))
+        self.assertFalse(self.tm1.cells.transaction_log_is_active(self.cube_name))
 
     def test_transaction_log_is_active_true(self):
-        self.tm1.cells.activate_transactionlog(CUBE_NAME)
+        self.tm1.cells.activate_transactionlog(self.cube_name)
 
-        self.assertTrue(self.tm1.cells.transaction_log_is_active(CUBE_NAME))
+        self.assertTrue(self.tm1.cells.transaction_log_is_active(self.cube_name))
 
     def test_manage_transaction_log_deactivate_reactivate(self):
         self.tm1.cubes.cells.write_values(
-            CUBE_NAME,
+            self.cube_name,
             self.cellset,
             deactivate_transaction_log=True,
             reactivate_transaction_log=True)
 
-        self.assertTrue(self.tm1.cells.transaction_log_is_active(CUBE_NAME))
+        self.assertTrue(self.tm1.cells.transaction_log_is_active(self.cube_name))
 
     def test_manage_transaction_log_not_deactivate_not_reactivate(self):
-        pre_state = self.tm1.cells.transaction_log_is_active(CUBE_NAME)
+        pre_state = self.tm1.cells.transaction_log_is_active(self.cube_name)
 
         self.tm1.cubes.cells.write_values(
-            CUBE_NAME,
+            self.cube_name,
             self.cellset,
             deactivate_transaction_log=False,
             reactivate_transaction_log=False)
 
-        self.assertEqual(pre_state, self.tm1.cells.transaction_log_is_active(CUBE_NAME))
+        self.assertEqual(pre_state, self.tm1.cells.transaction_log_is_active(self.cube_name))
 
     def test_manage_transaction_log_deactivate_not_reactivate(self):
         self.tm1.cubes.cells.write_values(
-            CUBE_NAME,
+            self.cube_name,
             self.cellset,
             deactivate_transaction_log=True,
             reactivate_transaction_log=False)
 
-        self.assertFalse(self.tm1.cells.transaction_log_is_active(CUBE_NAME))
+        self.assertFalse(self.tm1.cells.transaction_log_is_active(self.cube_name))
 
     # Delete Cube and Dimensions
     @classmethod
-    def teardown_class(cls):
-        cls.tm1.cubes.delete(CUBE_NAME)
+    def tearDownClass(cls):
+        cls.tm1.cubes.delete(cls.cube_name)
         cls.remove_string_cube()
         cls.remove_cube_with_rules()
         cls.remove_cube_with_consolidations()
-        for dimension_name in DIMENSION_NAMES:
+        for dimension_name in cls.dimension_names:
             cls.tm1.dimensions.delete(dimension_name)
         cls.remove_assets_for_relative_proportional_spread_tests()
 


### PR DESCRIPTION
Hi Marius

I had a go at tidying up the tests for the cells service. 

* Moved global vars to class properties
* Re-structured fixtures to ensure idempotency

Some of the tests were failing sporadically when I randomised the test order (I use the pytest-randomly plugin for this, which is simple and effective for flagging up these issues). The fixtures could probably do with some further housekeeping but I think this is a good start. Let me know what you think.

Cheers
Alex


(relates to https://github.com/cubewise-code/tm1py/issues/301)