### PR TITLE
Update the depth variable to capture the correct level of elements

### DIFF
--- a/TM1py/Services/ElementService.py
+++ b/TM1py/Services/ElementService.py
@@ -410,7 +410,7 @@ class ElementService(ObjectService):
         :param leaves_only: Only Leaf Elements or all Elements
         :return:
         """
-        depth = max_depth if max_depth else 99
+        depth = max_depth - 1 if max_depth else 99
         # members to return
         members = []
         # build url

--- a/TM1py/Services/ElementService.py
+++ b/TM1py/Services/ElementService.py
@@ -430,7 +430,7 @@ class ElementService(ObjectService):
             elif element["Type"] == "Consolidated":
                 if "Components" in element:
                     for component in element["Components"]:
-                        if not leaves_only:
+                        if not leaves_only and component["Type"] == "Consolidated":
                             members.append(component["Name"])
                         get_members(component)
 


### PR DESCRIPTION
Fixes #381 

From the below image:
![94752629-25aadb80-03cf-11eb-909d-518403eef1be](https://user-images.githubusercontent.com/60260968/94770173-905d1680-03d1-11eb-886c-4dee78e93c77.png)


```python
consol_ele2 = tm1.elements.get_members_under_consolidation(tempdim, tempdim, "Total", 1, False)
consol_ele2 = tm1.elements.get_members_under_consolidation(tempdim, tempdim, "Total", 2, False)
```

will now return:
```python
['A', 'C', 'D', 'B']
['A', 'A1', 'A2', 'C', 'C1', 'C2', 'D', 'B', 'C', 'B', 'B1', 'B2', 'B3']
```
