### PR TITLE
Split subsets tests into two and a couple of other things

### DIFF
--- a/TM1py/Objects/Subset.py
+++ b/TM1py/Objects/Subset.py
@@ -106,12 +106,12 @@ class Subset(TM1Object):
     @classmethod
     def from_dict(cls, subset_as_dict: Dict) -> 'Subset':
         return cls(dimension_name=subset_as_dict["UniqueName"][1:subset_as_dict["UniqueName"].find('].[')],
-                   hierarchy_name=subset_as_dict["Hierarchy"]["Name"],
+                   hierarchy_name=subset_as_dict.get("Hierarchy", {}).get("Name"),
                    subset_name=subset_as_dict['Name'],
-                   alias=subset_as_dict['Alias'],
-                   expression=subset_as_dict['Expression'],
-                   elements=[element['Name'] for element in subset_as_dict['Elements']]
-                   if not subset_as_dict['Expression'] else None)
+                   alias=subset_as_dict.get('Alias'),
+                   expression=subset_as_dict.get('Expression'),
+                   elements=[element['Name'] for element in subset_as_dict.get('Elements', [])]
+                   if not subset_as_dict.get('Expression') else None)
 
     @property
     def body(self) -> str:

--- a/Tests/Sandbox.py
+++ b/Tests/Sandbox.py
@@ -3,7 +3,7 @@ import unittest
 from TM1py.Objects import Sandbox
 
 
-class TestDimensionMethods(unittest.TestCase):
+class TestSandboxMethods(unittest.TestCase):
 
     def test_body_include_in_sandbox_dimension_true(self):
         sandbox = Sandbox("sandbox", True)

--- a/Tests/Subset.py
+++ b/Tests/Subset.py
@@ -168,6 +168,7 @@ class TestSubsetMethods(unittest.TestCase):
         """
         Tear down anything as required
         """
+        # nothing to do here
         pass
 
 

--- a/Tests/Subset.py
+++ b/Tests/Subset.py
@@ -1,8 +1,9 @@
 import unittest
 
-from TM1py.Objects import Subset, AnonymousSubset
+from TM1py.Objects import AnonymousSubset, Element, Subset
 
 PREFIX = "TM1py_Tests_Subset_"
+
 
 class TestSubsetMethods(unittest.TestCase):
 
@@ -11,7 +12,7 @@ class TestSubsetMethods(unittest.TestCase):
         """
         Create any class scoped fixtures here.
         """
-        
+
         cls.dimension_name = PREFIX + "dimension"
         cls.hierarchy_name = PREFIX + "hierarchy"
         cls.subset_name_static = PREFIX + "static_subset"
@@ -20,6 +21,51 @@ class TestSubsetMethods(unittest.TestCase):
         cls.subset_name_complete = PREFIX + "complete_subset"
         cls.subset_name_alias = PREFIX + "alias_subset"
         cls.subset_name_anon = PREFIX + "anon_subset"
+        cls.element_name = PREFIX + "element"
+
+        cls.subset_dict = {
+            "Name": "dict_subset",
+            "UniqueName": f"[{cls.dimension_name}]",
+            "Hierarchy": {
+                "Name": f"{cls.hierarchy_name}"
+            },
+            "Alias": "dict_subset" + "_alias",
+            "Elements": [
+                {
+                    "Name": "x"
+                },
+                {
+                    "Name": "y"
+                },
+                {
+                    "Name": "z"
+                }
+            ],
+            "Expression": ""
+        }
+
+        cls.subset_json = '''
+        {
+            "Name": "json_subset",
+            "UniqueName" : "json_subset",
+            "Hierarchy": {
+                "Name": "json_subset"
+            },
+            "Alias": "json_subset_alias",
+            "Elements" : [
+                {
+                    "Name" : "xoy"
+                },
+                {
+                    "Name": "o"
+                },
+                {
+                    "Name": "xxx"
+                }            
+            ],
+            "Expression" : ""
+        }
+        '''
 
     def setUp(self):
         """
@@ -30,7 +76,7 @@ class TestSubsetMethods(unittest.TestCase):
             dimension_name=self.dimension_name,
             subset_name=self.subset_name_static,
             elements=['USD', 'EUR', 'NZD', 'Dum\'my'])
-        
+
         self.dynamic_subset = Subset(
             dimension_name=self.dimension_name,
             subset_name=self.subset_name_dynamic,
@@ -80,32 +126,42 @@ class TestSubsetMethods(unittest.TestCase):
         self.assertTrue(self.anon_subset.is_static)
 
     def test_from_json(self):
-        # test needed - should define a json string in the class
-        self.assertTrue(False)
+        s = Subset.from_json(self.subset_json)
+        self.assertEqual(s.name, "json_subset")
+        self.assertEqual(s.elements, ["xoy", "o", "xxx"])
 
     def test_from_dict(self):
-        # test needed - should define a dict in the class
-        self.assertTrue(False)
+        s = Subset.from_dict(self.subset_dict)
+        self.assertEqual(s.name, "dict_subset")
+        self.assertEqual(s.elements, ["x", "y", "z"])
 
     def test_add_elements(self):
-        # test needed - should this fail for dynamic subsets I wonder?
-        self.assertTrue(False)
+        self.static_subset.add_elements(["AUD", "CHF"])
+        self.assertIn("AUD", self.static_subset.elements)
+        self.assertIn("CHF", self.static_subset.elements)
 
     def test_anonymous_subset(self):
-        # test needed - I guess it's a case of testing it has no name property?
-        self.assertTrue(False)
+        self.assertEqual(self.anon_subset.name, "")
 
     def test_property_setters(self):
-        # test needed
-        self.assertTrue(False)
+        self.minimal_subset.elements = ["1", "2", "3"]
+        self.assertEqual(self.minimal_subset.elements, ["1", "2", "3"])
 
     def test_property_getters(self):
-        # test needed
-        self.assertTrue(False)
+        self.assertEqual(self.complete_subset.name, self.subset_name_complete)
+        self.assertEqual(self.dynamic_subset.name, self.subset_name_dynamic)
+        self.assertEqual(self.static_subset.dimension_name,
+                         self.dimension_name)
+        self.assertEqual(self.minimal_subset.elements, [])
+        self.assertIn("a", self.complete_subset.elements)
 
-    def test_subset_comparisons(self):
-        # test needed - check whether they equal one another or not
-        self.assertTrue(False)
+    def test_subset_equality(self):
+        self.assertNotEqual(self.complete_subset, self.minimal_subset)
+        self.assertNotEqual(self.complete_subset, self.anon_subset)
+        self.assertNotEqual(self.complete_subset, self.static_subset)
+        self.assertNotEqual(self.complete_subset, self.dynamic_subset)
+        static_subset_copy = self.static_subset
+        self.assertEqual(static_subset_copy, self.static_subset)
 
     @classmethod
     def tearDownClass(cls):
@@ -113,6 +169,7 @@ class TestSubsetMethods(unittest.TestCase):
         Tear down anything as required
         """
         pass
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/Subset.py
+++ b/Tests/Subset.py
@@ -1,503 +1,118 @@
-import configparser
 import unittest
-from pathlib import Path
 
-from TM1py.Objects import Dimension, Hierarchy, Subset, ElementAttribute, Element
-from TM1py.Services import TM1Service
+from TM1py.Objects import Subset, AnonymousSubset
 
 PREFIX = "TM1py_Tests_Subset_"
-
 
 class TestSubsetMethods(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
         """
-        Establishes a connection to TM1 and creates TM! objects to use across all tests
+        Create any class scoped fixtures here.
         """
-
-        # Connection to TM1
-        cls.config = configparser.ConfigParser()
-        cls.config.read(Path(__file__).parent.joinpath('config.ini'))
-        cls.tm1 = TM1Service(**cls.config['tm1srv01'])
         
-        # Define Names
-        cls.dimension_name = PREFIX + "Dimension"
-        cls.subset_name_static = PREFIX + "static"
-        cls.subset_name_dynamic = PREFIX + "dynamic"
-
-        cls.unfriendly_dimension_name = PREFIX + "Dimension#%AD"
-        cls.unfriendly_subset_name = PREFIX + "Subset#%AD"
-        cls.unfriendly_element_name = PREFIX + "Element#%AD"
+        cls.dimension_name = PREFIX + "dimension"
+        cls.hierarchy_name = PREFIX + "hierarchy"
+        cls.subset_name_static = PREFIX + "static_subset"
+        cls.subset_name_dynamic = PREFIX + "dynamic_subset"
+        cls.subset_name_minimal = PREFIX + "minimal_subset"
+        cls.subset_name_complete = PREFIX + "complete_subset"
+        cls.subset_name_alias = PREFIX + "alias_subset"
+        cls.subset_name_anon = PREFIX + "anon_subset"
 
     def setUp(self):
-        # Instantiate Subsets
+        """
+        Instantiate subsets that will be available to all tests.
+        """
+
         self.static_subset = Subset(
             dimension_name=self.dimension_name,
             subset_name=self.subset_name_static,
             elements=['USD', 'EUR', 'NZD', 'Dum\'my'])
+        
         self.dynamic_subset = Subset(
             dimension_name=self.dimension_name,
             subset_name=self.subset_name_dynamic,
             expression='{ HIERARCHIZE( {TM1SUBSETALL( [' + self.dimension_name + '] )} ) }')
 
-        elements = [Element('USD', 'Numeric'),
-                    Element('EUR', 'Numeric'),
-                    Element('JPY', 'Numeric'),
-                    Element('CNY', 'Numeric'),
-                    Element('GBP', 'Numeric'),
-                    Element('NZD', 'Numeric'),
-                    Element('Dum\'my', 'Numeric')]
-        element_attributes = [ElementAttribute('Currency Name', 'String')]
-        h = Hierarchy(self.dimension_name, self.dimension_name, elements, element_attributes)
-        d = Dimension(self.dimension_name, hierarchies=[h])
-        self.tm1.dimensions.create(d)
+        # subset constructed from only the mandatory arguments
+        self.minimal_subset = Subset(
+            dimension_name=self.dimension_name,
+            subset_name=self.subset_name_minimal
+        )
 
-        elements = [Element(self.unfriendly_element_name, "Numeric")]
-        h = Hierarchy(self.unfriendly_dimension_name, self.unfriendly_dimension_name, elements)
-        d = Dimension(self.unfriendly_dimension_name, hierarchies=[h])
-        self.tm1.dimensions.create(d)
+        # a static subset constructed with optional arguments
+        self.complete_subset = Subset(
+            dimension_name=self.dimension_name,
+            subset_name=self.subset_name_complete,
+            hierarchy_name=self.hierarchy_name,
+            alias=self.subset_name_alias,
+            elements=["a", "b", "c"]
+        )
 
-        for private in (True, False):
-            self.tm1.dimensions.subsets.create(
-                subset=self.static_subset,
-                private=private)
-            self.tm1.dimensions.subsets.create(
-                subset=self.dynamic_subset,
-                private=private)
+        # an instance of the AnonymoustSubset subclass
+        self.anon_subset = AnonymousSubset(
+            dimension_name=self.dimension_name,
+            hierarchy_name=self.hierarchy_name,
+            elements=["x", "y", "z"]
+        )
 
     def tearDown(self):
-        if self.tm1.dimensions.exists(self.dimension_name):
-            self.tm1.dimensions.delete(self.dimension_name)
-        if self.tm1.dimensions.exists(self.unfriendly_dimension_name):
-            self.tm1.dimensions.delete(self.unfriendly_dimension_name)
+        """
+        Remove any artifacts created.
+        """
+        # nothing required here, all objects will be reset by setUp
+        pass
 
     def test_is_dynamic(self):
-        subset = self.tm1.dimensions.subsets.get(
-            subset_name=self.dynamic_subset.name,
-            dimension_name=self.dynamic_subset.dimension_name,
-            private=False)
-        self.assertTrue(subset.is_dynamic)
-        self.assertFalse(subset.is_static)
+        self.assertTrue(self.dynamic_subset.is_dynamic)
+        self.assertFalse(self.static_subset.is_dynamic)
+        self.assertFalse(self.minimal_subset.is_dynamic)
+        self.assertFalse(self.complete_subset.is_dynamic)
+        self.assertFalse(self.anon_subset.is_dynamic)
 
     def test_is_static(self):
-        subset = self.tm1.dimensions.subsets.get(
-            subset_name=self.static_subset.name,
-            dimension_name=self.static_subset.dimension_name,
-            private=False)
-        self.assertTrue(subset.is_static)
-        self.assertFalse(subset.is_dynamic)
+        self.assertFalse(self.dynamic_subset.is_static)
+        self.assertTrue(self.static_subset.is_static)
+        self.assertTrue(self.minimal_subset.is_static)
+        self.assertTrue(self.complete_subset.is_static)
+        self.assertTrue(self.anon_subset.is_static)
 
-    def test_create_and_delete_subset_static_private(self):
-        private = True
-        static_subset = Subset(
-            dimension_name=self.dimension_name,
-            subset_name="subset1",
-            elements=['USD', 'EUR', 'NZD', 'Dum\'my'])
+    def test_from_json(self):
+        # test needed - should define a json string in the class
+        self.assertTrue(False)
 
-        response = self.tm1.dimensions.subsets.create(
-            subset=static_subset,
-            private=private)
-        self.assertTrue(response.ok)
+    def test_from_dict(self):
+        # test needed - should define a dict in the class
+        self.assertTrue(False)
 
-        response = self.tm1.dimensions.hierarchies.subsets.delete(
-            dimension_name=self.dimension_name,
-            subset_name=static_subset.name,
-            private=private)
-        self.assertTrue(response.ok)
+    def test_add_elements(self):
+        # test needed - should this fail for dynamic subsets I wonder?
+        self.assertTrue(False)
 
-    def test_create_and_delete_subset_dynamic_private(self):
-        private = True
-        dynamic_subset = Subset(
-            dimension_name=self.dimension_name,
-            subset_name="subset2",
-            expression='{ HIERARCHIZE( {TM1SUBSETALL( [' + self.dimension_name + '] )} ) }')
+    def test_anonymous_subset(self):
+        # test needed - I guess it's a case of testing it has no name property?
+        self.assertTrue(False)
 
-        response = self.tm1.dimensions.subsets.create(
-            subset=dynamic_subset,
-            private=private)
-        self.assertTrue(response.ok)
+    def test_property_setters(self):
+        # test needed
+        self.assertTrue(False)
 
-        response = self.tm1.dimensions.hierarchies.subsets.delete(
-            dimension_name=self.dimension_name,
-            subset_name=dynamic_subset.name,
-            private=private)
-        self.assertTrue(response.ok)
+    def test_property_getters(self):
+        # test needed
+        self.assertTrue(False)
 
-    def test_create_and_delete_static_subset_public(self):
-        private = False
-        static_subset = Subset(
-            dimension_name=self.dimension_name,
-            subset_name="subset1",
-            elements=['USD', 'EUR', 'NZD', 'Dum\'my'])
-
-        response = self.tm1.dimensions.subsets.create(
-            subset=static_subset,
-            private=private)
-        self.assertTrue(response.ok)
-
-        response = self.tm1.dimensions.hierarchies.subsets.delete(
-            dimension_name=self.dimension_name,
-            subset_name=static_subset.name,
-            private=private)
-        self.assertTrue(response.ok)
-
-    def test_create_and_delete_dynamic_subset_public(self):
-        private = False
-
-        dynamic_subset = Subset(
-            dimension_name=self.dimension_name,
-            subset_name="subset2",
-            expression='{ HIERARCHIZE( {TM1SUBSETALL( [' + self.dimension_name + '] )} ) }')
-
-        response = self.tm1.dimensions.subsets.create(
-            subset=dynamic_subset,
-            private=private)
-        self.assertTrue(response.ok)
-
-        response = self.tm1.dimensions.hierarchies.subsets.delete(
-            dimension_name=self.dimension_name,
-            subset_name=dynamic_subset.name,
-            private=private)
-        self.assertTrue(response.ok)
-
-    def test_exists_private(self):
-        private = True
-        self.assertTrue(self.tm1.dimensions.subsets.exists(
-            subset_name=self.static_subset.name,
-            dimension_name=self.dimension_name,
-            private=private
-        ))
-        self.assertTrue(self.tm1.dimensions.subsets.exists(
-            subset_name=self.dynamic_subset.name,
-            dimension_name=self.dimension_name,
-            private=private
-        ))
-        self.assertFalse(self.tm1.dimensions.subsets.exists(
-            subset_name="wrong",
-            dimension_name=self.dimension_name,
-            private=private
-        ))
-
-    def test_exists_public(self):
-        private = False
-        self.assertTrue(self.tm1.dimensions.subsets.exists(
-            subset_name=self.static_subset.name,
-            dimension_name=self.dimension_name,
-            private=private
-        ))
-        self.assertTrue(self.tm1.dimensions.subsets.exists(
-            subset_name=self.dynamic_subset.name,
-            dimension_name=self.dimension_name,
-            private=private
-        ))
-        self.assertFalse(self.tm1.dimensions.subsets.exists(
-            subset_name="wrong",
-            dimension_name=self.dimension_name,
-            private=private
-        ))
-
-    def test_get_subset_private(self):
-        private = True
-        s = self.tm1.dimensions.hierarchies.subsets.get(
-            dimension_name=self.dimension_name,
-            subset_name=self.subset_name_static,
-            private=private)
-        self.assertEqual(self.static_subset, s)
-        s = self.tm1.dimensions.hierarchies.subsets.get(
-            dimension_name=self.dimension_name,
-            subset_name=self.subset_name_dynamic,
-            private=private)
-        self.assertEqual(self.dynamic_subset, s)
-
-    def test_get_subset_public(self):
-        private = False
-        s = self.tm1.dimensions.hierarchies.subsets.get(
-            dimension_name=self.dimension_name,
-            subset_name=self.subset_name_static,
-            private=private)
-        self.assertEqual(self.static_subset, s)
-        s = self.tm1.dimensions.hierarchies.subsets.get(
-            dimension_name=self.dimension_name,
-            subset_name=self.subset_name_dynamic,
-            private=private)
-        self.assertEqual(self.dynamic_subset, s)
-
-    def test_update_subset_static_private(self):
-        private = True
-        # Get static subset
-        s = self.tm1.dimensions.hierarchies.subsets.get(
-            dimension_name=self.dimension_name,
-            subset_name=self.subset_name_static,
-            private=private)
-        # Check before update
-        self.assertEqual(self.static_subset, s)
-
-        s.add_elements(['NZD'])
-        # Update it
-        self.tm1.dimensions.hierarchies.subsets.update(s, private=private)
-        # Get it again
-        s = self.tm1.dimensions.hierarchies.subsets.get(
-            dimension_name=self.dimension_name,
-            subset_name=self.subset_name_static,
-            private=private)
-        # Check after update
-        self.assertEqual(len(s.elements), 5)
-        self.assertNotEqual(self.static_subset, s)
-
-    def test_update_subset_dynamic_private(self):
-        private = True
-        # Get dynamic subset
-        s = self.tm1.dimensions.hierarchies.subsets.get(
-            dimension_name=self.dimension_name,
-            subset_name=self.subset_name_dynamic,
-            private=private)
-        # Check before update
-        self.assertEqual(self.dynamic_subset, s)
-
-        s.expression = '{{ [{}].[EUR], [{}].[USD] }})'.format(
-            self.dimension_name,
-            self.dimension_name)
-        # Update it
-        self.tm1.dimensions.hierarchies.subsets.update(
-            subset=s,
-            private=private)
-        # Get it again
-        s = self.tm1.dimensions.hierarchies.subsets.get(
-            dimension_name=self.dimension_name,
-            subset_name=self.subset_name_dynamic,
-            private=private)
-        # Check after update
-        self.assertEqual(
-            s.expression,
-            '{{ [{}].[EUR], [{}].[USD] }})'.format(self.dimension_name, self.dimension_name))
-
-        self.assertNotEqual(self.dynamic_subset, s)
-
-    def test_update_subset_static_public(self):
-        private = False
-        # Get static subset
-        subset = self.tm1.dimensions.hierarchies.subsets.get(
-            dimension_name=self.dimension_name,
-            subset_name=self.subset_name_static,
-            private=private)
-        # Check before update
-        self.assertEqual(self.static_subset, subset)
-
-        subset.add_elements(['NZD'])
-        # Update it
-        self.tm1.dimensions.hierarchies.subsets.update(subset, private=private)
-        # Get it again
-        subset = self.tm1.dimensions.hierarchies.subsets.get(
-            dimension_name=self.dimension_name,
-            subset_name=self.subset_name_static,
-            private=private)
-        # Check after update
-        self.assertEqual(len(subset.elements), 5)
-        self.assertNotEqual(self.static_subset, subset)
-
-    def test_update_subset_dynamic_public(self):
-        private = False
-        # Get dynamic subset
-        subset = self.tm1.dimensions.hierarchies.subsets.get(
-            dimension_name=self.dimension_name,
-            subset_name=self.subset_name_dynamic,
-            private=private)
-        # Check before update
-        self.assertEqual(self.dynamic_subset, subset)
-
-        subset.expression = '{{ [{}].[EUR], [{}].[USD] }})'.format(
-            self.dimension_name,
-            self.dimension_name)
-        # Update it
-        self.tm1.dimensions.hierarchies.subsets.update(
-            subset=subset,
-            private=private)
-        # Get it again
-        subset = self.tm1.dimensions.hierarchies.subsets.get(
-            dimension_name=self.dimension_name,
-            subset_name=self.subset_name_dynamic,
-            private=private)
-        # Check after update
-        self.assertEqual(
-            subset.expression,
-            '{{ [{}].[EUR], [{}].[USD] }})'.format(self.dimension_name, self.dimension_name))
-
-        self.assertNotEqual(self.dynamic_subset, subset)
-
-    def test_make_static_private(self):
-        private = True
-        subset = self.tm1.dimensions.subsets.get(
-            subset_name=self.dynamic_subset.name,
-            dimension_name=self.dynamic_subset.dimension_name,
-            private=private)
-        self.assertTrue(subset.is_dynamic)
-        self.tm1.dimensions.hierarchies.subsets.make_static(
-            subset_name=self.dynamic_subset.name,
-            dimension_name=self.dynamic_subset.dimension_name,
-            private=private)
-        subset = self.tm1.dimensions.subsets.get(
-            subset_name=self.dynamic_subset.name,
-            dimension_name=self.dynamic_subset.dimension_name,
-            private=private)
-        self.assertTrue(subset.is_static)
-
-    def test_make_static_public(self):
-        private = False
-        subset = self.tm1.dimensions.subsets.get(
-            subset_name=self.dynamic_subset.name,
-            dimension_name=self.dynamic_subset.dimension_name,
-            private=private)
-        self.assertTrue(subset.is_dynamic)
-        self.tm1.dimensions.hierarchies.subsets.make_static(
-            subset_name=self.dynamic_subset.name,
-            dimension_name=self.dynamic_subset.dimension_name,
-            private=private)
-        subset = self.tm1.dimensions.subsets.get(
-            subset_name=self.dynamic_subset.name,
-            dimension_name=self.dynamic_subset.dimension_name,
-            private=private)
-        self.assertTrue(subset.is_static)
-
-    def test_get_all_names_private(self):
-        private = True
-        subset_names = self.tm1.dimensions.subsets.get_all_names(
-            dimension_name=self.dimension_name,
-            hierarchy_name=self.dimension_name,
-            private=private)
-        self.assertIn(self.subset_name_dynamic, subset_names)
-        self.assertIn(self.subset_name_static, subset_names)
-
-    def test_get_all_names_public(self):
-        private = False
-        subset_names = self.tm1.dimensions.subsets.get_all_names(
-            dimension_name=self.dimension_name,
-            hierarchy_name=self.dimension_name,
-            private=private)
-        self.assertIn(self.subset_name_dynamic, subset_names)
-        self.assertIn(self.subset_name_static, subset_names)
-
-    def test_delete_elements_from_static_subset_public(self):
-        private = False
-        static_subset = Subset(
-            dimension_name=self.dimension_name,
-            subset_name="subset1",
-            elements=['USD', 'EUR', 'NZD', 'Dum\'my'])
-        self.tm1.dimensions.subsets.create(
-            subset=static_subset,
-            private=private)
-        subset = self.tm1.dimensions.subsets.get(
-            dimension_name=static_subset.dimension_name,
-            hierarchy_name=static_subset.hierarchy_name,
-            subset_name=static_subset.name,
-            private=private)
-        self.assertEqual(len(subset.elements), 4)
-
-        self.tm1.dimensions.subsets.delete_elements_from_static_subset(
-            dimension_name=static_subset.dimension_name,
-            hierarchy_name=static_subset.hierarchy_name,
-            subset_name=static_subset.name,
-            private=private)
-        subset = self.tm1.dimensions.subsets.get(
-            dimension_name=static_subset.dimension_name,
-            hierarchy_name=static_subset.hierarchy_name,
-            subset_name=static_subset.name,
-            private=private)
-        self.assertEqual(len(subset.elements), 0)
-
-    def test_delete_elements_from_static_subset_private(self):
-        private = True
-        static_subset = Subset(
-            dimension_name=self.dimension_name,
-            subset_name="subset1",
-            elements=['USD', 'EUR', 'NZD', 'Dum\'my'])
-        self.tm1.dimensions.subsets.create(
-            subset=static_subset,
-            private=private)
-        subset = self.tm1.dimensions.subsets.get(
-            dimension_name=static_subset.dimension_name,
-            hierarchy_name=static_subset.hierarchy_name,
-            subset_name=static_subset.name,
-            private=private)
-        self.assertEqual(len(subset.elements), 4)
-
-        self.tm1.dimensions.subsets.delete_elements_from_static_subset(
-            dimension_name=static_subset.dimension_name,
-            hierarchy_name=static_subset.hierarchy_name,
-            subset_name=static_subset.name,
-            private=private)
-        subset = self.tm1.dimensions.subsets.get(
-            dimension_name=static_subset.dimension_name,
-            hierarchy_name=static_subset.hierarchy_name,
-            subset_name=static_subset.name,
-            private=private)
-        self.assertEqual(len(subset.elements), 0)
-
-    def test_get_element_names_static(self):
-        element_names = self.tm1.subsets.get_element_names(
-            self.dimension_name,
-            self.dimension_name,
-            self.subset_name_static,
-            False)
-
-        self.assertEqual(self.static_subset.elements, element_names)
-
-    def test_get_element_names_dynamic(self):
-        element_names = self.tm1.subsets.get_element_names(
-            self.dimension_name,
-            self.dimension_name,
-            self.subset_name_dynamic,
-            False)
-
-        self.assertEqual(
-            ['USD', 'EUR', 'JPY', 'CNY', 'GBP', 'NZD', "Dum'my"],
-            element_names)
-
-    def test_create_subset_with_url_unfriendly_characters_in_name(self):
-        subset = Subset(
-            subset_name=self.unfriendly_subset_name,
-            dimension_name=self.dimension_name,
-            hierarchy_name=self.dimension_name,
-            elements=[])
-        self.tm1.subsets.create(subset=subset, private=False)
-
-        subset = self.tm1.subsets.get(dimension_name=self.dimension_name, subset_name=self.unfriendly_subset_name)
-        self.assertEqual(self.unfriendly_subset_name, subset.name)
-        self.assertEqual([], subset.elements)
-
-    def test_create_subset_with_url_unfriendly_characters_in_elements_dynamic(self):
-        expression = "{[" + self.unfriendly_dimension_name + "].[" + self.unfriendly_element_name + "]}"
-        subset = Subset(
-            subset_name=self.unfriendly_subset_name,
-            dimension_name=self.unfriendly_dimension_name,
-            hierarchy_name=self.unfriendly_dimension_name,
-            expression=expression)
-        self.tm1.subsets.create(subset=subset, private=False)
-
-        subset = self.tm1.subsets.get(
-            dimension_name=self.unfriendly_dimension_name,
-            subset_name=self.unfriendly_subset_name)
-        self.assertEqual(self.unfriendly_subset_name, subset.name)
-        self.assertEqual(expression, subset.expression)
-
-    def test_create_subset_with_url_unfriendly_characters_in_elements_static(self):
-        subset = Subset(
-            subset_name=self.unfriendly_subset_name,
-            dimension_name=self.unfriendly_dimension_name,
-            hierarchy_name=self.unfriendly_dimension_name,
-            elements=[self.unfriendly_element_name])
-        self.tm1.subsets.create(subset=subset, private=False)
-
-        subset = self.tm1.subsets.get(
-            dimension_name=self.unfriendly_dimension_name,
-            subset_name=self.unfriendly_subset_name)
-        self.assertEqual(self.unfriendly_subset_name, subset.name)
-        self.assertEqual([self.unfriendly_element_name], subset.elements)
+    def test_subset_comparisons(self):
+        # test needed - check whether they equal one another or not
+        self.assertTrue(False)
 
     @classmethod
-    def teardown_class(cls):
-        cls.tm1.logout()
-
+    def tearDownClass(cls):
+        """
+        Tear down anything as required
+        """
+        pass
 
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/SubsetService.py
+++ b/Tests/SubsetService.py
@@ -8,7 +8,7 @@ from TM1py.Services import TM1Service
 PREFIX = "TM1py_Tests_Subset_"
 
 
-class TestSubsetMethods(unittest.TestCase):
+class TestSubsetService(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):

--- a/Tests/SubsetService.py
+++ b/Tests/SubsetService.py
@@ -7,6 +7,7 @@ from TM1py.Services import TM1Service
 
 PREFIX = "TM1py_Tests_Subset_"
 
+
 class TestSubsetMethods(unittest.TestCase):
 
     @classmethod
@@ -19,7 +20,7 @@ class TestSubsetMethods(unittest.TestCase):
         cls.config = configparser.ConfigParser()
         cls.config.read(Path(__file__).parent.joinpath('config.ini'))
         cls.tm1 = TM1Service(**cls.config['tm1srv01'])
-        
+
         # Define Names
         cls.dimension_name = PREFIX + "Dimension"
         cls.subset_name_static = PREFIX + "static"
@@ -48,12 +49,14 @@ class TestSubsetMethods(unittest.TestCase):
                     Element('NZD', 'Numeric'),
                     Element('Dum\'my', 'Numeric')]
         element_attributes = [ElementAttribute('Currency Name', 'String')]
-        h = Hierarchy(self.dimension_name, self.dimension_name, elements, element_attributes)
+        h = Hierarchy(self.dimension_name, self.dimension_name,
+                      elements, element_attributes)
         d = Dimension(self.dimension_name, hierarchies=[h])
         self.tm1.dimensions.create(d)
 
         elements = [Element(self.unfriendly_element_name, "Numeric")]
-        h = Hierarchy(self.unfriendly_dimension_name, self.unfriendly_dimension_name, elements)
+        h = Hierarchy(self.unfriendly_dimension_name,
+                      self.unfriendly_dimension_name, elements)
         d = Dimension(self.unfriendly_dimension_name, hierarchies=[h])
         self.tm1.dimensions.create(d)
 
@@ -444,12 +447,14 @@ class TestSubsetMethods(unittest.TestCase):
             elements=[])
         self.tm1.subsets.create(subset=subset, private=False)
 
-        subset = self.tm1.subsets.get(dimension_name=self.dimension_name, subset_name=self.unfriendly_subset_name)
+        subset = self.tm1.subsets.get(
+            dimension_name=self.dimension_name, subset_name=self.unfriendly_subset_name)
         self.assertEqual(self.unfriendly_subset_name, subset.name)
         self.assertEqual([], subset.elements)
 
     def test_create_subset_with_url_unfriendly_characters_in_elements_dynamic(self):
-        expression = "{[" + self.unfriendly_dimension_name + "].[" + self.unfriendly_element_name + "]}"
+        expression = "{[" + self.unfriendly_dimension_name + \
+            "].[" + self.unfriendly_element_name + "]}"
         subset = Subset(
             subset_name=self.unfriendly_subset_name,
             dimension_name=self.unfriendly_dimension_name,

--- a/Tests/SubsetService.py
+++ b/Tests/SubsetService.py
@@ -1,0 +1,486 @@
+import configparser
+import unittest
+from pathlib import Path
+
+from TM1py.Objects import Dimension, Hierarchy, Subset, ElementAttribute, Element
+from TM1py.Services import TM1Service
+
+PREFIX = "TM1py_Tests_Subset_"
+
+class TestSubsetMethods(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Establishes a connection to TM1 and creates TM! objects to use across all tests
+        """
+
+        # Connection to TM1
+        cls.config = configparser.ConfigParser()
+        cls.config.read(Path(__file__).parent.joinpath('config.ini'))
+        cls.tm1 = TM1Service(**cls.config['tm1srv01'])
+        
+        # Define Names
+        cls.dimension_name = PREFIX + "Dimension"
+        cls.subset_name_static = PREFIX + "static"
+        cls.subset_name_dynamic = PREFIX + "dynamic"
+
+        cls.unfriendly_dimension_name = PREFIX + "Dimension#%AD"
+        cls.unfriendly_subset_name = PREFIX + "Subset#%AD"
+        cls.unfriendly_element_name = PREFIX + "Element#%AD"
+
+    def setUp(self):
+        # Instantiate Subsets
+        self.static_subset = Subset(
+            dimension_name=self.dimension_name,
+            subset_name=self.subset_name_static,
+            elements=['USD', 'EUR', 'NZD', 'Dum\'my'])
+        self.dynamic_subset = Subset(
+            dimension_name=self.dimension_name,
+            subset_name=self.subset_name_dynamic,
+            expression='{ HIERARCHIZE( {TM1SUBSETALL( [' + self.dimension_name + '] )} ) }')
+
+        elements = [Element('USD', 'Numeric'),
+                    Element('EUR', 'Numeric'),
+                    Element('JPY', 'Numeric'),
+                    Element('CNY', 'Numeric'),
+                    Element('GBP', 'Numeric'),
+                    Element('NZD', 'Numeric'),
+                    Element('Dum\'my', 'Numeric')]
+        element_attributes = [ElementAttribute('Currency Name', 'String')]
+        h = Hierarchy(self.dimension_name, self.dimension_name, elements, element_attributes)
+        d = Dimension(self.dimension_name, hierarchies=[h])
+        self.tm1.dimensions.create(d)
+
+        elements = [Element(self.unfriendly_element_name, "Numeric")]
+        h = Hierarchy(self.unfriendly_dimension_name, self.unfriendly_dimension_name, elements)
+        d = Dimension(self.unfriendly_dimension_name, hierarchies=[h])
+        self.tm1.dimensions.create(d)
+
+        for private in (True, False):
+            self.tm1.dimensions.subsets.create(
+                subset=self.static_subset,
+                private=private)
+            self.tm1.dimensions.subsets.create(
+                subset=self.dynamic_subset,
+                private=private)
+
+    def tearDown(self):
+        if self.tm1.dimensions.exists(self.dimension_name):
+            self.tm1.dimensions.delete(self.dimension_name)
+        if self.tm1.dimensions.exists(self.unfriendly_dimension_name):
+            self.tm1.dimensions.delete(self.unfriendly_dimension_name)
+
+    def test_create_and_delete_subset_static_private(self):
+        private = True
+        static_subset = Subset(
+            dimension_name=self.dimension_name,
+            subset_name="subset1",
+            elements=['USD', 'EUR', 'NZD', 'Dum\'my'])
+
+        response = self.tm1.dimensions.subsets.create(
+            subset=static_subset,
+            private=private)
+        self.assertTrue(response.ok)
+
+        response = self.tm1.dimensions.hierarchies.subsets.delete(
+            dimension_name=self.dimension_name,
+            subset_name=static_subset.name,
+            private=private)
+        self.assertTrue(response.ok)
+
+    def test_create_and_delete_subset_dynamic_private(self):
+        private = True
+        dynamic_subset = Subset(
+            dimension_name=self.dimension_name,
+            subset_name="subset2",
+            expression='{ HIERARCHIZE( {TM1SUBSETALL( [' + self.dimension_name + '] )} ) }')
+
+        response = self.tm1.dimensions.subsets.create(
+            subset=dynamic_subset,
+            private=private)
+        self.assertTrue(response.ok)
+
+        response = self.tm1.dimensions.hierarchies.subsets.delete(
+            dimension_name=self.dimension_name,
+            subset_name=dynamic_subset.name,
+            private=private)
+        self.assertTrue(response.ok)
+
+    def test_create_and_delete_static_subset_public(self):
+        private = False
+        static_subset = Subset(
+            dimension_name=self.dimension_name,
+            subset_name="subset1",
+            elements=['USD', 'EUR', 'NZD', 'Dum\'my'])
+
+        response = self.tm1.dimensions.subsets.create(
+            subset=static_subset,
+            private=private)
+        self.assertTrue(response.ok)
+
+        response = self.tm1.dimensions.hierarchies.subsets.delete(
+            dimension_name=self.dimension_name,
+            subset_name=static_subset.name,
+            private=private)
+        self.assertTrue(response.ok)
+
+    def test_create_and_delete_dynamic_subset_public(self):
+        private = False
+
+        dynamic_subset = Subset(
+            dimension_name=self.dimension_name,
+            subset_name="subset2",
+            expression='{ HIERARCHIZE( {TM1SUBSETALL( [' + self.dimension_name + '] )} ) }')
+
+        response = self.tm1.dimensions.subsets.create(
+            subset=dynamic_subset,
+            private=private)
+        self.assertTrue(response.ok)
+
+        response = self.tm1.dimensions.hierarchies.subsets.delete(
+            dimension_name=self.dimension_name,
+            subset_name=dynamic_subset.name,
+            private=private)
+        self.assertTrue(response.ok)
+
+    def test_exists_private(self):
+        private = True
+        self.assertTrue(self.tm1.dimensions.subsets.exists(
+            subset_name=self.static_subset.name,
+            dimension_name=self.dimension_name,
+            private=private
+        ))
+        self.assertTrue(self.tm1.dimensions.subsets.exists(
+            subset_name=self.dynamic_subset.name,
+            dimension_name=self.dimension_name,
+            private=private
+        ))
+        self.assertFalse(self.tm1.dimensions.subsets.exists(
+            subset_name="wrong",
+            dimension_name=self.dimension_name,
+            private=private
+        ))
+
+    def test_exists_public(self):
+        private = False
+        self.assertTrue(self.tm1.dimensions.subsets.exists(
+            subset_name=self.static_subset.name,
+            dimension_name=self.dimension_name,
+            private=private
+        ))
+        self.assertTrue(self.tm1.dimensions.subsets.exists(
+            subset_name=self.dynamic_subset.name,
+            dimension_name=self.dimension_name,
+            private=private
+        ))
+        self.assertFalse(self.tm1.dimensions.subsets.exists(
+            subset_name="wrong",
+            dimension_name=self.dimension_name,
+            private=private
+        ))
+
+    def test_get_subset_private(self):
+        private = True
+        s = self.tm1.dimensions.hierarchies.subsets.get(
+            dimension_name=self.dimension_name,
+            subset_name=self.subset_name_static,
+            private=private)
+        self.assertEqual(self.static_subset, s)
+        s = self.tm1.dimensions.hierarchies.subsets.get(
+            dimension_name=self.dimension_name,
+            subset_name=self.subset_name_dynamic,
+            private=private)
+        self.assertEqual(self.dynamic_subset, s)
+
+    def test_get_subset_public(self):
+        private = False
+        s = self.tm1.dimensions.hierarchies.subsets.get(
+            dimension_name=self.dimension_name,
+            subset_name=self.subset_name_static,
+            private=private)
+        self.assertEqual(self.static_subset, s)
+        s = self.tm1.dimensions.hierarchies.subsets.get(
+            dimension_name=self.dimension_name,
+            subset_name=self.subset_name_dynamic,
+            private=private)
+        self.assertEqual(self.dynamic_subset, s)
+
+    def test_update_subset_static_private(self):
+        private = True
+        # Get static subset
+        s = self.tm1.dimensions.hierarchies.subsets.get(
+            dimension_name=self.dimension_name,
+            subset_name=self.subset_name_static,
+            private=private)
+        # Check before update
+        self.assertEqual(self.static_subset, s)
+
+        s.add_elements(['NZD'])
+        # Update it
+        self.tm1.dimensions.hierarchies.subsets.update(s, private=private)
+        # Get it again
+        s = self.tm1.dimensions.hierarchies.subsets.get(
+            dimension_name=self.dimension_name,
+            subset_name=self.subset_name_static,
+            private=private)
+        # Check after update
+        self.assertEqual(len(s.elements), 5)
+        self.assertNotEqual(self.static_subset, s)
+
+    def test_update_subset_dynamic_private(self):
+        private = True
+        # Get dynamic subset
+        s = self.tm1.dimensions.hierarchies.subsets.get(
+            dimension_name=self.dimension_name,
+            subset_name=self.subset_name_dynamic,
+            private=private)
+        # Check before update
+        self.assertEqual(self.dynamic_subset, s)
+
+        s.expression = '{{ [{}].[EUR], [{}].[USD] }})'.format(
+            self.dimension_name,
+            self.dimension_name)
+        # Update it
+        self.tm1.dimensions.hierarchies.subsets.update(
+            subset=s,
+            private=private)
+        # Get it again
+        s = self.tm1.dimensions.hierarchies.subsets.get(
+            dimension_name=self.dimension_name,
+            subset_name=self.subset_name_dynamic,
+            private=private)
+        # Check after update
+        self.assertEqual(
+            s.expression,
+            '{{ [{}].[EUR], [{}].[USD] }})'.format(self.dimension_name, self.dimension_name))
+
+        self.assertNotEqual(self.dynamic_subset, s)
+
+    def test_update_subset_static_public(self):
+        private = False
+        # Get static subset
+        subset = self.tm1.dimensions.hierarchies.subsets.get(
+            dimension_name=self.dimension_name,
+            subset_name=self.subset_name_static,
+            private=private)
+        # Check before update
+        self.assertEqual(self.static_subset, subset)
+
+        subset.add_elements(['NZD'])
+        # Update it
+        self.tm1.dimensions.hierarchies.subsets.update(subset, private=private)
+        # Get it again
+        subset = self.tm1.dimensions.hierarchies.subsets.get(
+            dimension_name=self.dimension_name,
+            subset_name=self.subset_name_static,
+            private=private)
+        # Check after update
+        self.assertEqual(len(subset.elements), 5)
+        self.assertNotEqual(self.static_subset, subset)
+
+    def test_update_subset_dynamic_public(self):
+        private = False
+        # Get dynamic subset
+        subset = self.tm1.dimensions.hierarchies.subsets.get(
+            dimension_name=self.dimension_name,
+            subset_name=self.subset_name_dynamic,
+            private=private)
+        # Check before update
+        self.assertEqual(self.dynamic_subset, subset)
+
+        subset.expression = '{{ [{}].[EUR], [{}].[USD] }})'.format(
+            self.dimension_name,
+            self.dimension_name)
+        # Update it
+        self.tm1.dimensions.hierarchies.subsets.update(
+            subset=subset,
+            private=private)
+        # Get it again
+        subset = self.tm1.dimensions.hierarchies.subsets.get(
+            dimension_name=self.dimension_name,
+            subset_name=self.subset_name_dynamic,
+            private=private)
+        # Check after update
+        self.assertEqual(
+            subset.expression,
+            '{{ [{}].[EUR], [{}].[USD] }})'.format(self.dimension_name, self.dimension_name))
+
+        self.assertNotEqual(self.dynamic_subset, subset)
+
+    def test_make_static_private(self):
+        private = True
+        subset = self.tm1.dimensions.subsets.get(
+            subset_name=self.dynamic_subset.name,
+            dimension_name=self.dynamic_subset.dimension_name,
+            private=private)
+        self.assertTrue(subset.is_dynamic)
+        self.tm1.dimensions.hierarchies.subsets.make_static(
+            subset_name=self.dynamic_subset.name,
+            dimension_name=self.dynamic_subset.dimension_name,
+            private=private)
+        subset = self.tm1.dimensions.subsets.get(
+            subset_name=self.dynamic_subset.name,
+            dimension_name=self.dynamic_subset.dimension_name,
+            private=private)
+        self.assertTrue(subset.is_static)
+
+    def test_make_static_public(self):
+        private = False
+        subset = self.tm1.dimensions.subsets.get(
+            subset_name=self.dynamic_subset.name,
+            dimension_name=self.dynamic_subset.dimension_name,
+            private=private)
+        self.assertTrue(subset.is_dynamic)
+        self.tm1.dimensions.hierarchies.subsets.make_static(
+            subset_name=self.dynamic_subset.name,
+            dimension_name=self.dynamic_subset.dimension_name,
+            private=private)
+        subset = self.tm1.dimensions.subsets.get(
+            subset_name=self.dynamic_subset.name,
+            dimension_name=self.dynamic_subset.dimension_name,
+            private=private)
+        self.assertTrue(subset.is_static)
+
+    def test_get_all_names_private(self):
+        private = True
+        subset_names = self.tm1.dimensions.subsets.get_all_names(
+            dimension_name=self.dimension_name,
+            hierarchy_name=self.dimension_name,
+            private=private)
+        self.assertIn(self.subset_name_dynamic, subset_names)
+        self.assertIn(self.subset_name_static, subset_names)
+
+    def test_get_all_names_public(self):
+        private = False
+        subset_names = self.tm1.dimensions.subsets.get_all_names(
+            dimension_name=self.dimension_name,
+            hierarchy_name=self.dimension_name,
+            private=private)
+        self.assertIn(self.subset_name_dynamic, subset_names)
+        self.assertIn(self.subset_name_static, subset_names)
+
+    def test_delete_elements_from_static_subset_public(self):
+        private = False
+        static_subset = Subset(
+            dimension_name=self.dimension_name,
+            subset_name="subset1",
+            elements=['USD', 'EUR', 'NZD', 'Dum\'my'])
+        self.tm1.dimensions.subsets.create(
+            subset=static_subset,
+            private=private)
+        subset = self.tm1.dimensions.subsets.get(
+            dimension_name=static_subset.dimension_name,
+            hierarchy_name=static_subset.hierarchy_name,
+            subset_name=static_subset.name,
+            private=private)
+        self.assertEqual(len(subset.elements), 4)
+
+        self.tm1.dimensions.subsets.delete_elements_from_static_subset(
+            dimension_name=static_subset.dimension_name,
+            hierarchy_name=static_subset.hierarchy_name,
+            subset_name=static_subset.name,
+            private=private)
+        subset = self.tm1.dimensions.subsets.get(
+            dimension_name=static_subset.dimension_name,
+            hierarchy_name=static_subset.hierarchy_name,
+            subset_name=static_subset.name,
+            private=private)
+        self.assertEqual(len(subset.elements), 0)
+
+    def test_delete_elements_from_static_subset_private(self):
+        private = True
+        static_subset = Subset(
+            dimension_name=self.dimension_name,
+            subset_name="subset1",
+            elements=['USD', 'EUR', 'NZD', 'Dum\'my'])
+        self.tm1.dimensions.subsets.create(
+            subset=static_subset,
+            private=private)
+        subset = self.tm1.dimensions.subsets.get(
+            dimension_name=static_subset.dimension_name,
+            hierarchy_name=static_subset.hierarchy_name,
+            subset_name=static_subset.name,
+            private=private)
+        self.assertEqual(len(subset.elements), 4)
+
+        self.tm1.dimensions.subsets.delete_elements_from_static_subset(
+            dimension_name=static_subset.dimension_name,
+            hierarchy_name=static_subset.hierarchy_name,
+            subset_name=static_subset.name,
+            private=private)
+        subset = self.tm1.dimensions.subsets.get(
+            dimension_name=static_subset.dimension_name,
+            hierarchy_name=static_subset.hierarchy_name,
+            subset_name=static_subset.name,
+            private=private)
+        self.assertEqual(len(subset.elements), 0)
+
+    def test_get_element_names_static(self):
+        element_names = self.tm1.subsets.get_element_names(
+            self.dimension_name,
+            self.dimension_name,
+            self.subset_name_static,
+            False)
+
+        self.assertEqual(self.static_subset.elements, element_names)
+
+    def test_get_element_names_dynamic(self):
+        element_names = self.tm1.subsets.get_element_names(
+            self.dimension_name,
+            self.dimension_name,
+            self.subset_name_dynamic,
+            False)
+
+        self.assertEqual(
+            ['USD', 'EUR', 'JPY', 'CNY', 'GBP', 'NZD', "Dum'my"],
+            element_names)
+
+    def test_create_subset_with_url_unfriendly_characters_in_name(self):
+        subset = Subset(
+            subset_name=self.unfriendly_subset_name,
+            dimension_name=self.dimension_name,
+            hierarchy_name=self.dimension_name,
+            elements=[])
+        self.tm1.subsets.create(subset=subset, private=False)
+
+        subset = self.tm1.subsets.get(dimension_name=self.dimension_name, subset_name=self.unfriendly_subset_name)
+        self.assertEqual(self.unfriendly_subset_name, subset.name)
+        self.assertEqual([], subset.elements)
+
+    def test_create_subset_with_url_unfriendly_characters_in_elements_dynamic(self):
+        expression = "{[" + self.unfriendly_dimension_name + "].[" + self.unfriendly_element_name + "]}"
+        subset = Subset(
+            subset_name=self.unfriendly_subset_name,
+            dimension_name=self.unfriendly_dimension_name,
+            hierarchy_name=self.unfriendly_dimension_name,
+            expression=expression)
+        self.tm1.subsets.create(subset=subset, private=False)
+
+        subset = self.tm1.subsets.get(
+            dimension_name=self.unfriendly_dimension_name,
+            subset_name=self.unfriendly_subset_name)
+        self.assertEqual(self.unfriendly_subset_name, subset.name)
+        self.assertEqual(expression, subset.expression)
+
+    def test_create_subset_with_url_unfriendly_characters_in_elements_static(self):
+        subset = Subset(
+            subset_name=self.unfriendly_subset_name,
+            dimension_name=self.unfriendly_dimension_name,
+            hierarchy_name=self.unfriendly_dimension_name,
+            elements=[self.unfriendly_element_name])
+        self.tm1.subsets.create(subset=subset, private=False)
+
+        subset = self.tm1.subsets.get(
+            dimension_name=self.unfriendly_dimension_name,
+            subset_name=self.unfriendly_subset_name)
+        self.assertEqual(self.unfriendly_subset_name, subset.name)
+        self.assertEqual([self.unfriendly_element_name], subset.elements)
+
+    @classmethod
+    def teardown_class(cls):
+        cls.tm1.logout()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Tests/__init__.py
+++ b/Tests/__init__.py
@@ -11,9 +11,12 @@ from Tests.MonitoringService import TestMonitoringMethods
 from Tests.PowerBiService import TestPowerBiService
 from Tests.Process import TestProcessMethods
 from Tests.RestService import TestRestServiceMethods
+from Tests.Sandbox import TestSandboxMethods
+from Tests.SandboxService import TestSandboxService
 from Tests.Security import TestSecurityMethods
 from Tests.Server import TestServerMethods
 from Tests.Subset import TestSubsetMethods
+from Tests.SubsetService import TestSubsetService
 from Tests.TIObfuscator import TestTIObfuscatorMethods
 from Tests.TM1pyDict import TestCaseAndSpaceInsensitiveDict, TestCaseAndSpaceInsensitiveSet, TestCaseAndSpaceInsensitiveTuplesDict
 from Tests.Utils import TestUtilsMethods


### PR DESCRIPTION
Hi Marius

I was looking at the subset code and tried a few things:

* split tests into Subset.py (just tests the objects) and SubsetService.py (tests the service)
* aligned the Subset from_dict method with the constructor to support missing values for optional args
* renamed the class in ```Tests/Sandbox.py```
* updated the ```Tests/__init__.py``` to include a few new files

Let me know what you think  :)

Cheers
Alex