### PR TITLE
msg_contains should filter rows containing the wildcards

### DIFF
--- a/TM1py/Services/ServerService.py
+++ b/TM1py/Services/ServerService.py
@@ -121,10 +121,11 @@ class ServerService(ObjectService):
 
             if msg_contains:
                 if isinstance(msg_contains, str):
-                    log_filters.append(format_url("contains(Message,'{}')", msg_contains))
+                    log_filters.append(format_url("contains(toupper(Message),toupper('{}'))", msg_contains))
                 else:
-                    msg_filters = [format_url("contains(Message,'{}')", wildcard) for wildcard in msg_contains]
-                    log_filters.append("({})".format(" and ".join(msg_filters)))
+                    msg_filters = [format_url("contains(toupper(Message),toupper('{}'))", wildcard) 
+                                   for wildcard in msg_contains]
+                    log_filters.append("({})".format(" or ".join(msg_filters)))
 
             url += "&$filter={}".format(" and ".join(log_filters))
 

--- a/Tests/ServerService.py
+++ b/Tests/ServerService.py
@@ -274,6 +274,23 @@ class TestServerService(unittest.TestCase):
             yesterdays_date = datetime.date.today() - timedelta(days=1)
             self.assertTrue(entry_date == yesterdays_date)
 
+    def test_get_message_log_with_contains_filter(self):
+
+        wildcards = ['TM1 Server is ready', 'admin host']
+
+        entries = self.tm1.server.get_message_log_entries(reverse=True, msg_contains= wildcards)
+
+        for entry in entries:
+            message = entry['Message']
+            if wildcards[0] in message:
+                self.assertIn(wildcards[0], message)
+            if wildcards[0] not in message:
+                self.assertNotIn(wildcards[0], message)
+            if wildcards[1].upper() in message.upper():
+                self.assertIn(wildcards[1].upper(), message.upper())
+            if wildcards[1] not in message:
+                self.assertNotIn(wildcards[1], message)
+
     def test_session_context_default(self):
         threads = self.tm1.monitoring.get_threads()
         for thread in threads:


### PR DESCRIPTION
#443 fix

wildcards in `msg_contains` should be applied on multiple rows.

Currently it is building `and` conditions and looking for all the wildcards in the same row.