### PR TITLE
Support for Git

### DIFF
--- a/TM1py/Objects/Git.py
+++ b/TM1py/Objects/Git.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+
+from TM1py.Objects.GitCommit import GitCommit
+from TM1py.Objects.GitRemote import GitRemote
+
+
+class Git():
+    """ Abstraction of Git object
+    """
+    def __init__(self, url: str, deployment: str, force: bool, deployed_commit: GitCommit, remote: GitRemote, config: dict = None):
+        """ Initialize GIT object
+        :param url: file or http(s) path to GIT repository
+        :param deployment: name of selected deployment group
+        :param force: whether or not Git context was forced
+        :param deployed_commit: GitCommit object of the currently deployed commit
+        :param remote: GitRemote object of the current remote
+        :param config: Dictionary containing git configuration parameters
+
+        """
+        self._url = url
+        self._deployment = deployment
+        self._force = force
+        self._deployed_commit = deployed_commit
+        self._remote = remote
+        self._config = config
+
+    @property
+    def url(self) -> str:
+        return self._url
+
+    @property
+    def force(self) -> bool:
+        return self._force
+
+    @property
+    def config(self) -> dict:
+        return self._config
+
+    @property
+    def deployment(self) -> str:
+        return self._deployment
+
+    @property
+    def deployed_commit(self) -> GitCommit:
+        return self._deployed_commit
+
+    @property
+    def remote(self) -> GitRemote:
+        return self._remote

--- a/TM1py/Objects/GitCommit.py
+++ b/TM1py/Objects/GitCommit.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+
+class GitCommit():
+    """ Abstraction of Git Commit
+    """
+    def __init__(self, commit_id: str, summary: str, author: str):
+        """ Initialize GitCommit object
+        :param commit_id: id of the commit
+        :param summary: commit message
+        :param author: the author of the commit
+        """
+        self._commit_id = commit_id
+        self._summary = summary
+        self._author = author
+        
+    @property
+    def commit_id(self) -> str:
+        return self._commit_id
+
+    @property
+    def summary(self) -> str:
+        return self._summary
+
+    @property
+    def author(self) -> str:
+        return self._author

--- a/TM1py/Objects/GitPlan.py
+++ b/TM1py/Objects/GitPlan.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+from typing import List
+
+from TM1py.Objects.GitCommit import GitCommit
+
+
+class GitPlan():
+    """ Base GitPlan abstraction
+    """
+    def __init__(self, plan_id: str, branch: str, force: bool):
+        """ Initialize GitPlan object
+        :param plan_id: id of the Plan
+        :param branch: current branch
+        :param force: force git context reset
+        """
+        self._plan_id = plan_id
+        self._branch = branch
+        self._force = force
+
+    @property
+    def plan_id(self) -> str:
+        return self._plan_id
+
+    @property
+    def branch(self) -> str:
+        return self._branch
+
+    @property
+    def force(self) -> bool:
+        return self._force
+
+
+class GitPushPlan(GitPlan):
+    """ GitPushPlan abstraction based on GitPlan
+    """
+
+    def __init__(self, plan_id: str, branch: str, force: bool, new_branch: str, new_commit: GitCommit, parent_commit: GitCommit, source_files : List[str]):
+        """ Initialize GitPushPlan object
+        :param plan_id: id of the PushPlan
+        :param branch: current branch to base the pushplan on
+        :param force: force git context reset
+        :param new_branch: the new branch that will be pushed to
+        :param new_commit: GitCommit of the new commit
+        :param parent_commit: The current commit in the branch
+        :param soruce_files: list of included files in the push
+        """
+        self._new_branch = new_branch
+        self._new_commit = new_commit
+        self._parent_commit = parent_commit
+        self._source_files = source_files
+
+        super().__init__(plan_id=plan_id, branch=branch, force=force)
+
+    @property
+    def new_branch(self) -> str:
+        return self._new_branch
+
+    @property
+    def new_commit(self) -> GitCommit:
+        return self._new_commit
+
+    @property
+    def parent_commit(self) -> GitCommit:
+        return self._parent_commit
+
+    @property
+    def source_files(self) -> List[str]:
+        return self._source_files
+
+
+class GitPullPlan(GitPlan):
+    """ GitPushPlan abstraction based on GitPlan
+    """
+
+    def __init__(self, plan_id: str, branch: str, force: bool, commit: GitCommit, operations: List[str]):
+        """ Initialize GitPushPlan object
+        :param pland_id: id of the PullPlan
+        :param branch: current branch to base the pullplan on
+        :param force: force git context reset
+        :param commit: GitCommit of the commit to pull
+        :param operations: list of changes made upon pulling
+        """
+        self._commit = commit
+        self._operations = operations
+
+        super().__init__(plan_id=plan_id, branch=branch, force=force)
+
+    @property
+    def commit(self) -> GitCommit:
+        return self._commit
+
+    @property
+    def operations(self) -> List[str]:
+        return self._operations

--- a/TM1py/Objects/GitRemote.py
+++ b/TM1py/Objects/GitRemote.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from typing import List
+
+from TM1py.Objects.TM1Object import TM1Object
+
+
+class GitRemote(TM1Object):
+    """ Abstraction of GitRemote
+    """
+
+    def __init__(self, connected: bool, branches: List[str], tags: List[str]):
+        """ Initialize GitRemote object
+        :param connected: is Git connected to remote
+        :param branches: list of remote branches
+        :param tags: list of remote tags
+        """
+        self._connected = connected
+        self._branches = branches
+        self._tags = tags
+
+    @property
+    def connected(self) -> bool:
+        return self._connected
+
+    @property
+    def branches(self) -> List[str]:
+        return self._branches
+    @property
+    def tags(self) -> List[str]:
+        return self._tags

--- a/TM1py/Services/GitService.py
+++ b/TM1py/Services/GitService.py
@@ -1,0 +1,275 @@
+# -*- coding: utf-8 -*-
+import json
+from typing import List
+
+from TM1py.Services.ObjectService import ObjectService
+from TM1py.Services.RestService import RestService, Response
+from TM1py.Objects.GitRemote import GitRemote
+from TM1py.Objects.Git import Git
+from TM1py.Objects.GitCommit import GitCommit
+from TM1py.Objects.GitPlan import GitPushPlan, GitPullPlan, GitPlan
+from TM1py.Utils.Utils import format_url
+
+
+class GitService(ObjectService):
+    """ Service to interact with GIT
+    """
+    def __init__(self, rest: RestService):
+        super().__init__(rest)
+
+    def from_json(self, json_response: str) -> Git:
+        deployed_commit = GitCommit(
+            commit_id=json_response["DeployedCommit"].get("ID"),
+            summary=json_response["DeployedCommit"].get("Summary"),
+            author=json_response["DeployedCommit"].get("Author")
+            )
+
+        remote = GitRemote(
+            connected=json_response["Remote"].get("Connected"),
+            branches=json_response["Remote"].get("Branches"),
+            tags=json_response["Remote"].get("Tags"),
+            )
+
+        git = Git(
+            url=json_response["URL"],
+            deployment=json_response["Deployment"],
+            force=json_response["Deployment"],
+            deployed_commit=deployed_commit,
+            remote=remote)
+
+        return git
+
+    def git_init(self, git_url: str, deployment: str, username: str = None, password: str = None, public_key: str = None,
+                private_key: str = None, passphrase: str = None, force: bool = None, config: dict = None,  **kwargs) -> Git:
+        """ Initialize GIT service, returns Git object
+        :param git_url: file or http(s) path to GIT repository
+        :param deployment: name of selected deployment group
+        :param username: GIT username
+        :param password: GIT password
+        :param public_key: SSH public key, available from PAA V2.0.9.4
+        :param private_key: SSH private key, available from PAA V2.0.9.4
+        :param passphrase: Passphrase for decrypting private key, if set
+        :param force: reset git context on True
+        :param config: Dictionary containing git configuration parameters
+        """
+        url = "/api/v1/GitInit"
+        body = {}
+        body['URL'] = git_url
+        body['Deployment'] = deployment
+
+        if username is not None:
+            body['Username'] = username
+        if password is not None:
+            body['Password'] = password
+        if public_key is not None:
+            body['PublicKey'] = public_key
+        if private_key is not None:
+            body['PrivateKey'] = private_key
+        if passphrase is not None:
+            body['Passphrase'] = passphrase
+        if force is not None:
+            body['Force'] = force
+        if config is not None:
+            body['Config'] = config
+        
+        for key, value in kwargs.items():
+            body[key] = value
+
+        body_json = json.dumps(body)
+        response = self._rest.POST(url=url, data=body_json)
+        return self.from_json(response.json())
+
+    def git_uninit(self, force=False):
+        """ Unitialize GIT service
+        :param Force: clean up gitcontext when True
+        """
+        url = "/api/v1/GitUninit"
+        body = json.dumps(force)
+        return self._rest.POST(url=url, data=body)
+
+    def git_status(self, username: str = None, password: str = None, public_key: str = None, private_key: str = None,
+                    passphrase: str = None, **kwargs) -> Git:
+        """ Get GIT status, returns Git object
+        :param Username: GIT username
+        :param Password: GIT password
+        :param PublicKey: SSH public key, available from PAA V2.0.9.4
+        :param PrivateKey: SSH private key, available from PAA V2.0.9.4
+        :param Passphrase: Passphrase for decrypting private key, if set
+        """
+        url = "/api/v1/GitStatus"
+        body = {}
+
+        if username is not None:
+            body['Username'] = username
+        if password is not None:
+            body['Password'] = password
+        if public_key is not None:
+            body['PublicKey'] = public_key
+        if private_key is not None:
+            body['PrivateKey'] = private_key
+        if passphrase is not None:
+            body['Passphrase'] = passphrase
+        
+        for key, value in kwargs.items():
+            body[key] = value
+
+        body_json = json.dumps(body)
+        response = self._rest.POST(url=url, data=body_json)
+
+        return self.from_json(response.json())
+
+    def git_push(self, message: str, author: str, email: str, branch: str = None, new_branch: str = None, force: bool = None, username: str = None,
+                    password: str = None, public_key: str = None, private_key: str = None, passphrase: str = None, execute: bool = None,
+                    **kwargs) -> Response:
+        """ Creates a gitpush plan, returns response
+        :param message: Commit message
+        :param author: Name of commit author
+        :param email: Email of commit author
+        :param branch: The branch which last commit will be used as parent commit for new branch. Must be empty if GIT repo is empty
+        :param new_branch: If specified, creates a new branch and pushes the commit onto it. If not specified, pushes to the branch specified in "Branch"
+        :param force: A flag passed in for evaluating preconditions
+        :param username: GIT username
+        :param password: GIT password
+        :param public_key: SSH public key, available from PAA V2.0.9.4
+        :param private_key: SSH private key, available from PAA V2.0.9.4
+        :param passphrase: Passphrase for decrypting private key, if set
+        :param execute: Executes the plan right away if True
+
+        """
+        url = "/api/v1/GitPush"
+        body = {}
+
+        if message is not None:
+            body['Message'] = message
+        if author is not None:
+            body['Author'] = author
+        if email is not None:
+            body['Email'] = email
+        if branch is not None:
+            body['Branch'] = branch
+        if new_branch is not None:
+            body['NewBranch'] = new_branch
+        if force is not None:
+            body['Force'] = force
+        if username is not None:
+            body['Username'] = username
+        if password is not None:
+            body['Password'] = password
+        if public_key is not None:
+            body['PublicKey'] = public_key
+        if private_key is not None:
+            body['PrivateKey'] = private_key
+        if passphrase is not None:
+            body['Passphrase'] = passphrase
+
+        for key, value in kwargs.items():
+            body[key] = value
+
+        body_json = json.dumps(body)
+        response = self._rest.POST(url=url, data=body_json)
+
+        if execute:
+            plan_id = json.loads(response.content).get('ID')
+            self.git_execute_plan(plan_id=plan_id)
+
+        return response
+
+    def git_pull(self, branch: str, force: bool = None, execute: bool = None, username: str = None, password: str = None, 
+                public_key: str = None, private_key: str = None, passphrase: str = None, **kwargs) -> Response:
+        """ Creates a gitpull plan, returns response
+        :param branch: The name of source branch
+        :param force: A flag passed in for evaluating preconditions
+        :param execute: Executes the plan right away if True
+        :param username: GIT username
+        :param password: GIT password
+        :param public_key: SSH public key, available from PAA V2.0.9.4
+        :param private_key: SSH private key, available from PAA V2.0.9.4
+        :param passphrase: Passphrase for decrypting private key, if set
+        """
+        url = "/api/v1/GitPull"
+        body = {}
+
+        if branch is not None:
+            body['Branch'] = branch
+        if force is not None:
+            body['Force'] = force
+        if username is not None:
+            body['Username'] = username
+        if password is not None:
+            body['Password'] = password
+        if public_key is not None:
+            body['PublicKey'] = public_key
+        if private_key is not None:
+            body['PrivateKey'] = private_key
+        if passphrase is not None:
+            body['Passphrase'] = passphrase
+
+        for key, value in kwargs.items():
+            body[key] = value
+
+        body_json = json.dumps(body)
+        response = self._rest.POST(url=url, data=body_json)
+
+        if execute:
+            plan_id = json.loads(response.content).get('ID')
+            self.git_execute_plan(plan_id=plan_id)
+
+        return response
+
+    def git_execute_plan(self, plan_id) -> Response:
+        """ Executes a plan based on the planid
+        :param planid: GitPlan id
+        """
+        url = format_url("/api/v1/GitPlans('{}')/tm1.Execute",plan_id)
+        return self._rest.POST(url=url)
+
+    def git_get_plans(self, **kwargs) -> List[GitPlan]:
+        """ Gets a list of currently available GIT plans
+        """
+        url = "/api/v1/GitPlans"
+        plans = []
+        response_dict = json.loads(self._rest.GET(url=url, body=kwargs).content)
+        # Every individual plan is wrapped in a "value" parent, iterate through those to get the actual plans
+        for plan in response_dict.get('value'):
+            plan_id = plan.get('ID')
+            # Check if plan has an ID, sometimes there's a null in the mix that we don't want
+            if plan_id is None:
+                continue
+            plan_branch = plan.get('Branch')
+            plan_force = plan.get('Force')
+
+            # A git plan can either be a PushPlan or a PullPlan, these have slightly different variables, so we need to handle those differently
+            if plan.get('@odata.type') == '#ibm.tm1.api.v1.GitPushPlan':
+                plan_new_branch = plan.get('NewBranch')
+                plan_source_files = plan.get('SourceFiles')
+
+                new_commit = GitCommit(
+                            commit_id=plan.get('NewCommit').get('ID'),
+                            summary=plan.get('NewCommit').get('Summary'),
+                            author=plan.get('NewCommit').get('Author'))
+
+                parent_commit = GitCommit(
+                            commit_id=plan.get('ParentCommit').get('ID'),
+                            summary=plan.get('ParentCommit').get('Summary'),
+                            author=plan.get('ParentCommit').get('Author'))
+
+                current_plan = GitPushPlan(
+                            plan_id=plan_id, branch=plan_branch, force=plan_force,
+                            new_branch=plan_new_branch, new_commit=new_commit,
+                            parent_commit=parent_commit, source_files=plan_source_files)
+
+            elif plan.get('@odata.type') == '#ibm.tm1.api.v1.GitPullPlan':
+
+                plan_commit = GitCommit(
+                                commit_id=plan.get('Commit').get('ID'), 
+                                summary=plan.get('Commit').get('Summary'), 
+                                author=plan.get('Commit').get('Author'))
+
+                plan_operations = plan.get('Operations')
+                current_plan = GitPullPlan(plan_id=plan_id, branch=plan_branch, force=plan_force, commit=plan_commit, operations=plan_operations)
+
+            else:
+                raise ValueError("Invalid plan detected")
+            
+            plans.append(current_plan)
+            return plans

--- a/TM1py/Services/GitService.py
+++ b/TM1py/Services/GitService.py
@@ -72,11 +72,9 @@ class GitService(ObjectService):
         if config is not None:
             body['Config'] = config
         
-        for key, value in kwargs.items():
-            body[key] = value
-
         body_json = json.dumps(body)
-        response = self._rest.POST(url=url, data=body_json)
+        response = self._rest.POST(url=url, data=body_json, **kwargs)
+
         return self.from_json(response.json())
 
     def git_uninit(self, force=False):
@@ -110,11 +108,8 @@ class GitService(ObjectService):
         if passphrase is not None:
             body['Passphrase'] = passphrase
         
-        for key, value in kwargs.items():
-            body[key] = value
-
         body_json = json.dumps(body)
-        response = self._rest.POST(url=url, data=body_json)
+        response = self._rest.POST(url=url, data=body_json, **kwargs)
 
         return self.from_json(response.json())
 
@@ -162,11 +157,8 @@ class GitService(ObjectService):
         if passphrase is not None:
             body['Passphrase'] = passphrase
 
-        for key, value in kwargs.items():
-            body[key] = value
-
         body_json = json.dumps(body)
-        response = self._rest.POST(url=url, data=body_json)
+        response = self._rest.POST(url=url, data=body_json, **kwargs)
 
         if execute:
             plan_id = json.loads(response.content).get('ID')
@@ -204,11 +196,8 @@ class GitService(ObjectService):
         if passphrase is not None:
             body['Passphrase'] = passphrase
 
-        for key, value in kwargs.items():
-            body[key] = value
-
         body_json = json.dumps(body)
-        response = self._rest.POST(url=url, data=body_json)
+        response = self._rest.POST(url=url, data=body_json, **kwargs)
 
         if execute:
             plan_id = json.loads(response.content).get('ID')

--- a/TM1py/Services/TM1Service.py
+++ b/TM1py/Services/TM1Service.py
@@ -2,7 +2,7 @@ import pickle
 
 from TM1py.Services import HierarchyService, SecurityService, ApplicationService, SubsetService, ServerService, \
     MonitoringService, ProcessService, PowerBiService, AnnotationService, ViewService, RestService, CellService, \
-    ChoreService, DimensionService, CubeService, ElementService, SandboxService
+    ChoreService, DimensionService, CubeService, ElementService, SandboxService, GitService
 
 
 class TM1Service:
@@ -31,6 +31,8 @@ class TM1Service:
         self.applications = ApplicationService(self._tm1_rest)
         self.views = ViewService(self._tm1_rest)
         self.sandboxes = SandboxService(self._tm1_rest)
+        self.git = GitService(self._tm1_rest)
+
 
     def logout(self, **kwargs):
         self._tm1_rest.logout(**kwargs)

--- a/TM1py/Services/__init__.py
+++ b/TM1py/Services/__init__.py
@@ -15,4 +15,5 @@ from TM1py.Services.SecurityService import SecurityService
 from TM1py.Services.ServerService import ServerService
 from TM1py.Services.SubsetService import SubsetService
 from TM1py.Services.ViewService import ViewService
+from TM1py.Services.GitService import GitService
 from TM1py.Services.TM1Service import TM1Service

--- a/TM1py/__init__.py
+++ b/TM1py/__init__.py
@@ -16,6 +16,7 @@ Usage:
 
 # __init__ can hoist attributes from submodules into higher namespaces for convenience
 
+from TM1py.Services.GitService import GitService
 from TM1py.Services.ObjectService import ObjectService
 from TM1py.Services.RestService import RestService
 from TM1py.Services.TM1Service import TM1Service


### PR DESCRIPTION
This set of commits adds basic support for Git by adding a GitService and objects for Git, GitCommit, GitPlan and GitRemote. The code is based on a postman collection set I created to experiment with GIT and TM1 and has been working in my rather limited internal testing. 

I've tried to adhere to what I perceive to be the current software design patterns of tm1py. Feedback is welcomed, and please inform me if you want me to squash the commits or do other things to improve the merge. 

Fixes #156 