### PR TITLE
Cleanup cellservice writeback changesets

### DIFF
--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -83,6 +83,26 @@ def manage_transaction_log(func):
 
     return wrapper
 
+def manage_changeset(func):
+    """ Control the start and end of change sets which goups write events together in the TM1 transaction log.
+
+    Decorated function working with all non-TI based writing methods
+    """
+
+    @functools.wraps(func)
+    def wrapper(self, *args, **kwargs):
+        if not kwargs.get("use_changeset", False):
+            try:
+                changeset = self.begin_changeset()
+                kwargs["changeset"]=changeset
+                return func(self, *args, **kwargs)
+            finally:
+                self.end_changeset(changeset)
+        else:
+            return func(self, *args, **kwargs)
+
+    return wrapper
+
 
 class CellService(ObjectService):
     """ Service to handle Read and Write operations to TM1 cubes
@@ -312,9 +332,11 @@ class CellService(ObjectService):
         dimensions = cube_service.get_dimension_names(cube_name, True, **kwargs)
         return dimensions
 
+
     @require_pandas
     def write_dataframe(self, cube_name: str, data: 'pd.DataFrame', dimensions: Iterable[str] = None,
                         sandbox_name: str = None,
+                        use_changeset: bool = True,
                         **kwargs) -> Response:
         """
         Function expects same shape as `execute_mdx_dataframe` returns.
@@ -340,7 +362,7 @@ class CellService(ObjectService):
         cells = build_cellset_from_pandas_dataframe(data)
 
         return self.write_values(cube_name=cube_name, cellset_as_dict=cells, dimensions=dimensions,
-                                 sandbox_name=sandbox_name, **kwargs)
+                                 sandbox_name=sandbox_name, use_changeset=use_changeset, **kwargs)
 
     def write_value(self, value: Union[str, float], cube_name: str, element_tuple: Iterable,
                     dimensions: Iterable[str] = None, sandbox_name: str = None, **kwargs) -> Response:
@@ -367,9 +389,10 @@ class CellService(ObjectService):
         data = json.dumps(body_as_dict, ensure_ascii=False)
         return self._rest.POST(url=url, data=data, **kwargs)
 
+
     def write(self, cube_name: str, cellset_as_dict: Dict, dimensions: Iterable[str] = None, increment: bool = False,
               deactivate_transaction_log: bool = False, reactivate_transaction_log: bool = False,
-              sandbox_name: str = None, use_ti=False, **kwargs):
+              sandbox_name: str = None, use_ti=False, use_changeset: bool=True, **kwargs):
         """ Write values to a cube
 
         Same signature as `write_values` method, but faster since it uses `write_values_through_cellset`
@@ -416,6 +439,7 @@ class CellService(ObjectService):
             deactivate_transaction_log=deactivate_transaction_log,
             reactivate_transaction_log=reactivate_transaction_log,
             sandbox_name=sandbox_name,
+            use_changeset=True,
             **kwargs)
 
     @require_admin
@@ -507,9 +531,10 @@ class CellService(ObjectService):
 
         return process_service.execute_process_with_return(process, **kwargs)
 
+    @manage_changeset
     @manage_transaction_log
     def write_values(self, cube_name: str, cellset_as_dict: Dict, dimensions: Iterable[str] = None,
-                     sandbox_name: str = None, **kwargs) -> Response:
+                     sandbox_name: str = None, use_changeset:bool = True, **kwargs) -> Response:
         """ Write values to a cube
 
         For cellsets with > 1000 cells look into `write` or `write_values_through_cellset`
@@ -525,6 +550,7 @@ class CellService(ObjectService):
             dimensions = self.get_dimension_names_for_writing(cube_name=cube_name, **kwargs)
         url = format_url("/api/v1/Cubes('{}')/tm1.Update", cube_name)
         url = add_url_parameters(url, **{"!sandbox": sandbox_name})
+        url = add_url_parameters(url, **{"!ChangeSet":kwargs.get('changeset')})
 
         updates = []
         for element_tuple, value in cellset_as_dict.items():
@@ -541,9 +567,10 @@ class CellService(ObjectService):
         updates = '[' + ','.join(updates) + ']'
         return self._rest.POST(url=url, data=updates, **kwargs)
 
+
     @manage_transaction_log
     def write_values_through_cellset(self, mdx: str, values: Iterable, increment: bool = False,
-                                     sandbox_name: str = None, **kwargs) -> Response:
+                                     sandbox_name: str = None, use_changeset: bool = True, **kwargs) -> Response:
         """ Significantly faster than write_values function
 
         Cellset gets created according to MDX Expression. For instance:
@@ -578,10 +605,11 @@ class CellService(ObjectService):
             current_values = self.extract_cellset_values(cellset_id, delete_cellset=False, **kwargs)
             values = (x + (y or None) for x, y in zip(values, current_values))
 
-        return self.update_cellset(cellset_id=cellset_id, values=values, sandbox_name=sandbox_name, **kwargs)
+        return self.update_cellset(cellset_id=cellset_id, values=values, sandbox_name=sandbox_name, use_changeset=use_changeset, **kwargs)
 
+    @manage_changeset
     @tidy_cellset
-    def update_cellset(self, cellset_id: str, values: Iterable, sandbox_name: str = None, **kwargs) -> Response:
+    def update_cellset(self, cellset_id: str, values: Iterable, sandbox_name: str = None, use_changeset: bool = True, **kwargs) -> Response:
         """ Write values into cellset
 
         Number of values must match the number of cells in the cellset
@@ -593,6 +621,7 @@ class CellService(ObjectService):
         """
         url = format_url("/api/v1/Cellsets('{}')/Cells", cellset_id)
         url = add_url_parameters(url, **{"!sandbox": sandbox_name})
+        url = add_url_parameters(url, **{"!ChangeSet": kwargs.get("changeset")})
         data = []
         for o, value in enumerate(values):
             data.append({
@@ -1772,16 +1801,9 @@ class CellService(ObjectService):
         url = add_url_parameters(url, **{"!sandbox": sandbox_name})
         return self._rest.POST(url=url, **kwargs).json()['ID']
 
-    def delete_cellset(self, cellset_id: str, sandbox_name: str = None, **kwargs) -> Response:
-        """ Delete a cellset
 
-        :param cellset_id:
-        :param sandbox_name: str
-        :return:
-        """
-        url = "/api/v1/Cellsets('{}')".format(cellset_id)
-        url = add_url_parameters(url, **{"!sandbox": sandbox_name})
-        return self._rest.DELETE(url, **kwargs)
+
+
 
     def transaction_log_is_active(self, cube_name: str) -> bool:
         mdx = f"""
@@ -1799,7 +1821,9 @@ class CellService(ObjectService):
         updates = {}
         for cube_name in args:
             updates[(cube_name, "Logging")] = "NO"
-        return self.write_values(cube_name="}CubeProperties", cellset_as_dict=updates, **kwargs)
+        return self.write_values(cube_name="}CubeProperties", cellset_as_dict=updates, use_changeset= False, **kwargs)
+
+
 
     def activate_transactionlog(self, *args: str, **kwargs) -> Response:
         """ Activate Transactionlog for one or many cubes
@@ -1810,7 +1834,40 @@ class CellService(ObjectService):
         updates = {}
         for cube_name in args:
             updates[(cube_name, "Logging")] = "YES"
-        return self.write_values(cube_name="}CubeProperties", cellset_as_dict=updates, **kwargs)
+        return self.write_values(cube_name="}CubeProperties", cellset_as_dict=updates, use_changeset= False, **kwargs)
+
+    def begin_changeset(self) -> str:
+        """ begin a change set
+
+        :return: Change set ID
+        """
+
+        url = "/api/v1/BeginChangeSet"
+        return self._rest.POST(url).json()['value']
+        return change_set_id
+
+    def end_changeset(self, change_set: str) -> Response:
+        """end a change set
+
+        :return: Change set ID
+        """
+
+        url = "/api/v1/EndChangeSet"
+        data = {"ChangeSetID":change_set}
+        return self._rest.POST(url, data=json.dumps(data, ensure_ascii=False))
+        return response
+
+    def delete_cellset(self, cellset_id: str, sandbox_name: str = None, **kwargs) -> Response:
+        """ Delete a cellset
+
+        :param cellset_id:
+        :param sandbox_name: str
+        :return:
+        """
+        url = "/api/v1/Cellsets('{}')".format(cellset_id)
+        url = add_url_parameters(url, **{"!sandbox": sandbox_name})
+        return self._rest.DELETE(url, **kwargs)
+
 
     def get_cellset_cells_count(self, mdx: str) -> int:
         """ Execute MDX in order to understand how many cells are in a cellset

--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -18,7 +18,6 @@ from TM1py.Services.ObjectService import ObjectService
 from TM1py.Services.RestService import RestService
 from TM1py.Services.SandboxService import SandboxService
 from TM1py.Services.ViewService import ViewService
-from TM1py.Services.ProcessService import ProcessService
 from TM1py.Utils import Utils, CaseAndSpaceInsensitiveSet, format_url, add_url_parameters
 from TM1py.Utils.Utils import build_pandas_dataframe_from_cellset, dimension_name_from_element_unique_name, \
     CaseAndSpaceInsensitiveDict, wrap_in_curly_braces, CaseAndSpaceInsensitiveTuplesDict, abbreviate_mdx, \


### PR DESCRIPTION
Cell Service Clean Up
1) Added deprecation notice to write values, removed dependency on change set wrapper
2) Update transaction log methods to use write_value instead of write_values
3) Changed write_dataframe to use the new write function to support TI and changesets
4) Added exception when TI and Change sets are used at the same time