### PR TITLE
AuditLog Queries capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ TM1py offers handy features to interact with TM1 from Python, such as
 - Execute loose statements of TI
 - CRUD features for TM1 objects (cubes, dimensions, subsets, etc.)
 - Query and kill threads
-- Query MessageLog and TransactionLog
+- Query MessageLog, TransactionLog and AuditLog
 - Generate MDX Queries from existing cube views
 
 Requirements

--- a/TM1py/Services/ServerService.py
+++ b/TM1py/Services/ServerService.py
@@ -12,7 +12,7 @@ from requests import Response
 from TM1py.Services.ObjectService import ObjectService
 from TM1py.Services.RestService import RestService
 from TM1py.Utils import format_url
-from TM1py.Utils.Utils import CaseAndSpaceInsensitiveDict, require_admin
+from TM1py.Utils.Utils import CaseAndSpaceInsensitiveDict, require_admin, require_version
 
 
 def odata_track_changes_header(func):
@@ -202,6 +202,7 @@ class ServerService(ObjectService):
         return response.json()['value']
     
     @require_admin
+    @require_version(version="11.6")
     def get_audit_log_entries(self, user: str = None, object_type: str = None, object_name: str = None,
                                     since: datetime = None, until: datetime = None, top: int = None, **kwargs) -> Dict:
         """

--- a/TM1py/Services/ServerService.py
+++ b/TM1py/Services/ServerService.py
@@ -205,7 +205,6 @@ class ServerService(ObjectService):
     def get_audit_log_entries(self, user: str = None, object_type: str = None, object_name: str = None,
                                     since: datetime = None, until: datetime = None, top: int = None, **kwargs) -> Dict:
         """
-        :param reverse: Boolean
         :param user: UserName
         :param object_type: ObjectType
         :param object_name: ObjectName


### PR DESCRIPTION
#### Feature:
Include Query AuditLog Capability (#469)

#### Description of changes:
Based on [this tutorial from ibm ](https://www.ibm.com/support/knowledgecenter/en/SSD29G_2.0.0/com.ibm.swg.ba.cognos.tm1_inst.2.0.0.doc/pa_nf_tm1_audit_logging.html), it was included `get_audit_log_entries` method. It follows the same structure pattern of `get_transaction_log_entries`.

#### Requirements

Planning Analytics 2.0.8 or higher - (July 17, 2019)

#### Exemple

This method can be called:

```
with TM1Service(address='localhost', port='xxxx', user="xxxx", password="xxxx", 
            namespace=None,ssl=True) as tm1:
```
    x = tm1.server.get_audit_log_entries(ObjectName='SYSTEM',
                                         object_type='Server',
                                         user='Admin', 
                                         since=datetime.datetime.strptime('2020-12-01', "%Y-%m-%d") )
    
    df = pd.DataFrame(x)

 ```
	    ID 	    TimeStamp 	    UserName 	    Description 	ObjectType 	ObjectName
0 	507 	2021-01-22T17:39:24Z 	Admin 	O usuário 'Admin' efetuou login com êxito a pa... 	Server 	SYSTEM
1 	508 	2021-01-22T18:00:04Z 	Admin 	O usuário 'Admin' efetuou login com êxito a pa... 	Server 	SYSTEM
2 	509 	2021-01-22T18:04:31Z 	Admin 	O usuário 'Admin' efetuou login com êxito a pa... 	Server 	SYSTEM
```

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._