### PR TITLE
Introduce new cancel_at_timeout argument

### DIFF
--- a/TM1py/Services/MonitoringService.py
+++ b/TM1py/Services/MonitoringService.py
@@ -83,6 +83,14 @@ class MonitoringService(ObjectService):
         response = self._rest.POST(url, **kwargs)
         return response
 
+    def get_active_session_threads(self, exclude_idle: bool = True, **kwargs):
+        url = "/api/v1/ActiveSession/Threads?$filter=Function ne 'GET /api/v1/ActiveSession/Threads'"
+        if exclude_idle:
+            url += " and State ne 'Idle'"
+
+        response = self._rest.GET(url, **kwargs)
+        return response.json()['value']
+
     def get_sessions(self, include_user: bool = True, include_threads: bool = True, **kwargs) -> List:
         url = "/api/v1/Sessions"
         if include_user or include_threads:


### PR DESCRIPTION
`cancel_at_timeout` can be passed to any function in TM1py.
Controls if operation in TM1 is aborted when timeout is reached.

Fixes #489