### PR TITLE
Add arguments to execute_mdx, execute_view

### DIFF
--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -689,8 +689,8 @@ class CellService(ObjectService):
 
     def execute_mdx(self, mdx: str, cell_properties: List[str] = None, top: int = None, skip_contexts: bool = False,
                     skip: int = None, skip_zeros: bool = False, skip_consolidated_cells: bool = False,
-                    skip_rule_derived_cells: bool = False, sandbox_name: str = None,
-                    **kwargs) -> CaseAndSpaceInsensitiveTuplesDict:
+                    skip_rule_derived_cells: bool = False, sandbox_name: str = None, element_unique_names: bool = True,
+                    values_only: bool = False, **kwargs) -> CaseAndSpaceInsensitiveTuplesDict:
         """ Execute MDX and return the cells with their properties
 
         :param mdx: MDX Query, as string
@@ -702,6 +702,8 @@ class CellService(ObjectService):
         :param skip_consolidated_cells: skip consolidated cells in cellset
         :param skip_rule_derived_cells: skip rule derived cells in cellset
         :param sandbox_name: str
+        :param element_unique_names: '[d1].[h1].[e1]' or 'e1'
+        :param values_only: cell values in result dictionary, instead of cell_properties dictionary
         :return: content in sweet concise structure.
         """
         cellset_id = self.create_cellset(mdx=mdx, sandbox_name=sandbox_name, **kwargs)
@@ -716,12 +718,14 @@ class CellService(ObjectService):
             skip_rule_derived_cells=skip_rule_derived_cells,
             delete_cellset=True,
             sandbox_name=sandbox_name,
+            element_unique_names=element_unique_names,
+            values_only=values_only,
             **kwargs)
 
     def execute_view(self, cube_name: str, view_name: str, private: bool = False, cell_properties: Iterable[str] = None,
                      top: int = None, skip_contexts: bool = False, skip: int = None, skip_zeros: bool = False,
                      skip_consolidated_cells: bool = False, skip_rule_derived_cells: bool = False,
-                     sandbox_name: str = None,
+                     sandbox_name: str = None, element_unique_names: bool = True, values_only: bool = False,
                      **kwargs) -> CaseAndSpaceInsensitiveTuplesDict:
         """ get view content as dictionary with sweet and concise structure.
             Works on NativeView and MDXView !
@@ -737,8 +741,9 @@ class CellService(ObjectService):
         :param skip_zeros: skip zeros in cellset (irrespective of zero suppression in MDX / view)
         :param skip_consolidated_cells: skip consolidated cells in cellset
         :param skip_rule_derived_cells: skip rule derived cells in cellset
+        :param element_unique_names: '[d1].[h1].[e1]' or 'e1'
         :param sandbox_name: str
-
+        :param values_only: cell values in result dictionary, instead of cell_properties dictionary
         :return: Dictionary : {([dim1].[elem1], [dim2][elem6]): {'Value':3127.312, 'Ordinal':12}   ....  }
         """
         cellset_id = self.create_cellset_from_view(cube_name=cube_name, view_name=view_name, private=private,
@@ -754,6 +759,8 @@ class CellService(ObjectService):
             skip_rule_derived_cells=skip_rule_derived_cells,
             delete_cellset=True,
             sandbox_name=sandbox_name,
+            element_unique_names=element_unique_names,
+            values_only=values_only,
             **kwargs)
 
     def execute_mdx_raw(
@@ -1830,6 +1837,8 @@ class CellService(ObjectService):
             skip_consolidated_cells: bool = False,
             skip_rule_derived_cells: bool = False,
             sandbox_name: str = None,
+            element_unique_names: bool = True,
+            values_only: bool = False,
             **kwargs) -> CaseAndSpaceInsensitiveTuplesDict:
         """ Execute cellset and return the cells with their properties
 
@@ -1843,7 +1852,9 @@ class CellService(ObjectService):
         :param skip_consolidated_cells: skip consolidated cells in cellset
         :param skip_rule_derived_cells: skip rule derived cells in cellset
         :param sandbox_name: str
-        :return: Content in sweet consice strcuture.
+        :param element_unique_names: '[d1].[h1].[e1]' or 'e1'
+        :param values_only: cell values in result dictionary, instead of cell_properties dictionary
+        :return: Content in sweet concise strcuture.
         """
         if not cell_properties:
             cell_properties = ['Value']
@@ -1861,11 +1872,14 @@ class CellService(ObjectService):
             skip_consolidated_cells=skip_consolidated_cells,
             skip_rule_derived_cells=skip_rule_derived_cells,
             sandbox_name=sandbox_name,
+            include_hierarchies=False,
             **kwargs)
 
         return Utils.build_content_from_cellset_dict(
             raw_cellset_as_dict=raw_cellset,
-            top=top)
+            top=top,
+            element_unique_names=element_unique_names,
+            values_only=values_only)
 
     def create_cellset(self, mdx: str, sandbox_name: str = None, **kwargs) -> str:
         """ Execute MDX in order to create cellset at server. return the cellset-id

--- a/Tests/CellService.py
+++ b/Tests/CellService.py
@@ -981,6 +981,30 @@ class TestCellService(unittest.TestCase):
                 Utils.dimension_name_from_element_unique_name(coordinates[2]),
                 self.dimension_names[2])
 
+    def test_execute_mdx_unique_element_names_false(self):
+        mdx = MdxBuilder.from_cube(self.cube_name) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.members([Member.of(self.dimension_names[0], "Element 1")])) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(self.dimension_names[1], "Element2"))) \
+            .add_member_to_where("[" + self.dimension_names[2] + "].[Element3]").to_mdx()
+
+        data = self.tm1.cubes.cells.execute_mdx(mdx, element_unique_names=False)
+
+        self.assertEqual(len(data), 1)
+        for coordinates, cell in data.items():
+            self.assertEqual(coordinates, ("Element 1", "Element 2", "Element 3"))
+
+    def test_execute_mdx_values_only_true(self):
+        mdx = MdxBuilder.from_cube(self.cube_name) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.members([Member.of(self.dimension_names[0], "Element 1")])) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(self.dimension_names[1], "Element1"))) \
+            .add_member_to_where("[" + self.dimension_names[2] + "].[Element1]").to_mdx()
+
+        data = self.tm1.cubes.cells.execute_mdx(mdx, values_only=True)
+
+        self.assertEqual(len(data), 1)
+        for coordinates, value in data.items():
+            self.assertEqual(1, value)
+
     def test_execute_mdx_raw_skip_contexts(self):
         mdx = MdxBuilder.from_cube(self.cube_name) \
             .add_hierarchy_set_to_row_axis(MdxHierarchySet.member(Member.of(self.dimension_names[0], "Element1"))) \
@@ -1530,7 +1554,6 @@ class TestCellService(unittest.TestCase):
             'Attr1': {0: 'TM1py'},
             'Value': {0: 1.0}}
         self.assertEqual(expected, df.to_dict())
-
 
     @skip_if_no_pandas
     def test_execute_mdx_dataframe_pivot(self):


### PR DESCRIPTION
to control the structure of the result dictionary
- `values_only`
- `element_unique_names`

Through these optional arguments `execute_mdx` can return shape:
```
{('e1', 'e2'): 2}
```

instead of:
```
{('[d1].[e1]', '[d2].[e2]'): {'Value': 2}}
```