### PR TITLE
Create new server on adminhost

### DIFF
--- a/TM1py/Objects/Server.py
+++ b/TM1py/Objects/Server.py
@@ -22,6 +22,7 @@ class Server:
         self.host = server_as_dict['Host'] 
         self.is_local = server_as_dict['IsLocal'] 
         self.ssl_certificate_id = server_as_dict['SSLCertificateID'] 
+        self.ssl_certificate_authority = server_as_dict['SSLCertificateAuthority'] 
         self.ssl_certificate_revocation_list = server_as_dict['SSLCertificateRevocationList'] 
         self.client_export_ssl_server_keyid = server_as_dict['ClientExportSSLSvrKeyID'] 
         self.client_export_ssl_server_cert = server_as_dict['ClientExportSSLSvrCert'] 

--- a/TM1py/Objects/Server.py
+++ b/TM1py/Objects/Server.py
@@ -18,4 +18,11 @@ class Server:
         self.http_port_number = server_as_dict['HTTPPortNumber']
         self.using_ssl = server_as_dict['UsingSSL']
         self.accepting_clients = server_as_dict['AcceptingClients']
-
+        self.self_registered = server_as_dict['SelfRegistered'] 
+        self.host = server_as_dict['Host'] 
+        self.is_local = server_as_dict['IsLocal'] 
+        self.ssl_certificate_id = server_as_dict['SSLCertificateID'] 
+        self.ssl_certificate_revocation_list = server_as_dict['SSLCertificateRevocationList'] 
+        self.client_export_ssl_server_keyid = server_as_dict['ClientExportSSLSvrKeyID'] 
+        self.client_export_ssl_server_cert = server_as_dict['ClientExportSSLSvrCert'] 
+        self.last_updated = server_as_dict['LastUpdated']

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -8,7 +8,7 @@ from contextlib import suppress
 from enum import Enum, unique
 from typing import Any, Dict, List, Tuple, Iterable, Optional, Generator
 
-from TM1py.Exceptions.Exceptions import TM1pyVersionException, TM1pyNotAdminException, TM1pyRestException
+from TM1py.Exceptions.Exceptions import TM1pyVersionException, TM1pyNotAdminException
 
 try:
     import pandas as pd
@@ -100,7 +100,7 @@ def create_server_on_adminhost(adminhost='localhost', server_as_dict={}):
     response_as_dict = json.loads(response)
 
     return Server(response_as_dict)
-    
+
 def build_url_friendly_object_name(object_name: str) -> str:
     return object_name.replace("'", "''").replace('%', '%25').replace('#', '%23')
 

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -74,7 +74,7 @@ def get_all_servers_from_adminhost(adminhost='localhost') -> List:
         servers.append(server)
     return servers
 
-def create_server_on_adminhost(adminhost='localhost', server_as_dict={}):
+def create_server_on_adminhost(adminhost='localhost', server_as_dict=None):
     from TM1py.Objects import Server
     """  Create new TM1 instance on Adminhost
     :param adminhost: IP or DNS Alias of the adminhost
@@ -92,7 +92,8 @@ def create_server_on_adminhost(adminhost='localhost', server_as_dict={}):
                 "AcceptingClients":True }
     :return: instance of TM1py.Server
     """
-
+    if server_as_Dict is None: 
+        server_as_dict = {}
     conn = http_client.HTTPConnection(adminhost, 5895)
     request = '/api/v1/Servers'
     conn.request('POST', request, body=json.dumps(server_as_dict), headers={'Content-Type':'application/json'})

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -8,7 +8,7 @@ from contextlib import suppress
 from enum import Enum, unique
 from typing import Any, Dict, List, Tuple, Iterable, Optional, Generator
 
-from TM1py.Exceptions.Exceptions import TM1pyVersionException, TM1pyNotAdminException
+from TM1py.Exceptions.Exceptions import TM1pyVersionException, TM1pyNotAdminException, TM1pyRestException
 
 try:
     import pandas as pd
@@ -74,7 +74,33 @@ def get_all_servers_from_adminhost(adminhost='localhost') -> List:
         servers.append(server)
     return servers
 
+def create_server_on_adminhost(adminhost='localhost', server_as_dict={}):
+    from TM1py.Objects import Server
+    """  Create new TM1 instance on Adminhost
+    :param adminhost: IP or DNS Alias of the adminhost
+    :param server_as_dict: 
+            server_as_dict = {
+                "Name":"MyModel1",
+                "IPAddress":"172.20.10.10",
+                "IPv6Address":None,
+                "PortNumber":12345,
+                "UsingSSL": True,
+                "ClientMessagePortNumber":61098,
+                "HTTPPortNumber":12999,
+                "ClientExportSSLSvrCert":True,
+                "ClientExportSSLSvrKeyID":"whateverExportSSLSvrKeyID",
+                "AcceptingClients":True }
+    :return: instance of TM1py.Server
+    """
 
+    conn = http_client.HTTPConnection(adminhost, 5895)
+    request = '/api/v1/Servers'
+    conn.request('POST', request, body=json.dumps(server_as_dict), headers={'Content-Type':'application/json'})
+    response = conn.getresponse().read().decode('utf-8')
+    response_as_dict = json.loads(response)
+
+    return Server(response_as_dict)
+    
 def build_url_friendly_object_name(object_name: str) -> str:
     return object_name.replace("'", "''").replace('%', '%25').replace('#', '%23')
 


### PR DESCRIPTION
Create a new TM1 instance on the AdminHost via POST method. Requires a valid AdminHost string, and the server configuration. Return instance of TM1py.Server.

Example use:
```python
from TM1py import TM1Service, Utils


with TM1Service(address="", port=12354, ssl=True, user="admin", password="apple") as tm1:
    admin_server = tm1.server.get_admin_host()
    server_as_dict = {
        "Name":"MyModel1",
        "IPAddress":"172.20.10.10",
        "IPv6Address":None,
        "PortNumber":12345,
        "UsingSSL": True,
        "ClientMessagePortNumber":61098,
        "HTTPPortNumber":12999,
        "ClientExportSSLSvrCert":True,
        "ClientExportSSLSvrKeyID":"whateverExportSSLSvrKeyID",
        "AcceptingClients":True
    }

    new_server = Utils.create_server_on_adminhost(
                    adminhost=admin_server,
                    server_as_dict=server_as_dict
                    )
    servers = Utils.get_all_servers_from_adminhost(adminhost=admin_server)
```
