### PR TITLE
Fix mismatch df header

### DIFF
--- a/TM1py/Services/PowerBiService.py
+++ b/TM1py/Services/PowerBiService.py
@@ -129,6 +129,9 @@ class PowerBiService:
 
         df_data = self.execute_mdx(mdx)
 
+        # override hierarchy name
+        df_data.rename(columns={0:dimension_name})
+        
         # shift levels to right hand side
         if not skip_parents:
             # skip max level (= leaves)

--- a/TM1py/Services/PowerBiService.py
+++ b/TM1py/Services/PowerBiService.py
@@ -130,7 +130,7 @@ class PowerBiService:
         df_data = self.execute_mdx(mdx)
 
         # override hierarchy name
-        df_data.rename(columns={0:dimension_name})
+        df_data.rename(columns={hierarchy_name:dimension_name},inplace=True)
         
         # shift levels to right hand side
         if not skip_parents:


### PR DESCRIPTION
Overriding default row header in dataframe returned by MDX to match the dimension name used in the drop duplicate operation. 