### PR TITLE
Add get_active_threads

### DIFF
--- a/TM1py/Services/MonitoringService.py
+++ b/TM1py/Services/MonitoringService.py
@@ -28,11 +28,11 @@ class MonitoringService(ObjectService):
         return response.json()['value']
 
     def get_active_threads(self, **kwargs):
-        '''Return a list of non-idle threads from the TM1 Server
+        """Return a list of non-idle threads from the TM1 Server
 
             :return:
                 list: TM1 threads as dict
-        '''
+        """
         url = "/api/v1/Threads?$filter=Function ne 'GET /api/v1/Threads' and State ne 'Idle'"
         response = self._rest.GET(url, **kwargs)
         return response.json()['value']

--- a/TM1py/Services/MonitoringService.py
+++ b/TM1py/Services/MonitoringService.py
@@ -27,6 +27,16 @@ class MonitoringService(ObjectService):
         response = self._rest.GET(url, **kwargs)
         return response.json()['value']
 
+    def get_active_threads(self, **kwargs):
+        '''Return a list of non-idle threads from the TM1 Server
+
+            :return:
+                list: TM1 threads as dict
+        '''
+        url = "/api/v1/Threads?$filter=Function ne 'GET /api/v1/Threads' and State ne 'Idle'"
+        response = self._rest.GET(url, **kwargs)
+        return response.json()['value']
+
     def cancel_thread(self, thread_id: int, **kwargs) -> Response:
         """ Kill a running thread
         


### PR DESCRIPTION
Add get_active_threads function to filter TM1 threads which are non-idle directly via REST end-point.