### PR TITLE
Rename `values_only` argument

### DIFF
--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -736,7 +736,7 @@ class CellService(ObjectService):
     def execute_mdx(self, mdx: str, cell_properties: List[str] = None, top: int = None, skip_contexts: bool = False,
                     skip: int = None, skip_zeros: bool = False, skip_consolidated_cells: bool = False,
                     skip_rule_derived_cells: bool = False, sandbox_name: str = None, element_unique_names: bool = True,
-                    values_only: bool = False, **kwargs) -> CaseAndSpaceInsensitiveTuplesDict:
+                    skip_cell_properties: bool = False, **kwargs) -> CaseAndSpaceInsensitiveTuplesDict:
         """ Execute MDX and return the cells with their properties
 
         :param mdx: MDX Query, as string
@@ -749,7 +749,7 @@ class CellService(ObjectService):
         :param skip_rule_derived_cells: skip rule derived cells in cellset
         :param sandbox_name: str
         :param element_unique_names: '[d1].[h1].[e1]' or 'e1'
-        :param values_only: cell values in result dictionary, instead of cell_properties dictionary
+        :param skip_cell_properties: cell values in result dictionary, instead of cell_properties dictionary
         :return: content in sweet concise structure.
         """
         cellset_id = self.create_cellset(mdx=mdx, sandbox_name=sandbox_name, **kwargs)
@@ -765,13 +765,13 @@ class CellService(ObjectService):
             delete_cellset=True,
             sandbox_name=sandbox_name,
             element_unique_names=element_unique_names,
-            values_only=values_only,
+            skip_cell_properties=skip_cell_properties,
             **kwargs)
 
     def execute_view(self, cube_name: str, view_name: str, private: bool = False, cell_properties: Iterable[str] = None,
                      top: int = None, skip_contexts: bool = False, skip: int = None, skip_zeros: bool = False,
                      skip_consolidated_cells: bool = False, skip_rule_derived_cells: bool = False,
-                     sandbox_name: str = None, element_unique_names: bool = True, values_only: bool = False,
+                     sandbox_name: str = None, element_unique_names: bool = True, skip_cell_properties: bool = False,
                      **kwargs) -> CaseAndSpaceInsensitiveTuplesDict:
         """ get view content as dictionary with sweet and concise structure.
             Works on NativeView and MDXView !
@@ -789,7 +789,7 @@ class CellService(ObjectService):
         :param skip_rule_derived_cells: skip rule derived cells in cellset
         :param element_unique_names: '[d1].[h1].[e1]' or 'e1'
         :param sandbox_name: str
-        :param values_only: cell values in result dictionary, instead of cell_properties dictionary
+        :param skip_cell_properties: cell values in result dictionary, instead of cell_properties dictionary
         :return: Dictionary : {([dim1].[elem1], [dim2][elem6]): {'Value':3127.312, 'Ordinal':12}   ....  }
         """
         cellset_id = self.create_cellset_from_view(cube_name=cube_name, view_name=view_name, private=private,
@@ -806,7 +806,7 @@ class CellService(ObjectService):
             delete_cellset=True,
             sandbox_name=sandbox_name,
             element_unique_names=element_unique_names,
-            values_only=values_only,
+            skip_cell_properties=skip_cell_properties,
             **kwargs)
 
     def execute_mdx_raw(
@@ -1884,7 +1884,7 @@ class CellService(ObjectService):
             skip_rule_derived_cells: bool = False,
             sandbox_name: str = None,
             element_unique_names: bool = True,
-            values_only: bool = False,
+            skip_cell_properties: bool = False,
             **kwargs) -> CaseAndSpaceInsensitiveTuplesDict:
         """ Execute cellset and return the cells with their properties
 
@@ -1899,7 +1899,7 @@ class CellService(ObjectService):
         :param skip_rule_derived_cells: skip rule derived cells in cellset
         :param sandbox_name: str
         :param element_unique_names: '[d1].[h1].[e1]' or 'e1'
-        :param values_only: cell values in result dictionary, instead of cell_properties dictionary
+        :param skip_cell_properties: cell values in result dictionary, instead of cell_properties dictionary
         :return: Content in sweet concise strcuture.
         """
         if not cell_properties:
@@ -1925,7 +1925,7 @@ class CellService(ObjectService):
             raw_cellset_as_dict=raw_cellset,
             top=top,
             element_unique_names=element_unique_names,
-            values_only=values_only)
+            skip_cell_properties=skip_cell_properties)
 
     def create_cellset(self, mdx: str, sandbox_name: str = None, **kwargs) -> str:
         """ Execute MDX in order to create cellset at server. return the cellset-id

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -181,12 +181,12 @@ def build_content_from_cellset_dict(
         raw_cellset_as_dict: Dict,
         top: Optional[int] = None,
         element_unique_names: bool = True,
-        values_only: bool = False) -> 'CaseAndSpaceInsensitiveTuplesDict':
+        skip_cell_properties: bool = False) -> 'CaseAndSpaceInsensitiveTuplesDict':
     """ transform raw cellset data into concise dictionary
     :param raw_cellset_as_dict:
     :param top: Int, number of cells to return (counting from top)
     :param element_unique_names: '[d1].[h1].[e1]' or 'e1'
-    :param values_only: cell values in result dictionary, instead of cell_properties dictionary
+    :param skip_cell_properties: cell values in result dictionary, instead of cell_properties dictionary
     :return:
     """
     cube_dimensions = [dim['Name'] for dim in raw_cellset_as_dict['Cube']['Dimensions']]
@@ -215,7 +215,7 @@ def build_content_from_cellset_dict(
             coordinates.extend(coordinate)
 
         coordinates = sort_coordinates(cube_dimensions, coordinates, element_unique_names=element_unique_names)
-        content_as_dict[coordinates] = cell['Value'] if values_only else cell
+        content_as_dict[coordinates] = cell['Value'] if skip_cell_properties else cell
     return content_as_dict
 
 

--- a/Tests/CellService.py
+++ b/Tests/CellService.py
@@ -1024,13 +1024,13 @@ class TestCellService(unittest.TestCase):
         for coordinates, cell in data.items():
             self.assertEqual(coordinates, ("Element 1", "Element 2", "Element 3"))
 
-    def test_execute_mdx_values_only_true(self):
+    def test_execute_mdx_skip_cell_properties_true(self):
         mdx = MdxBuilder.from_cube(self.cube_name) \
             .add_hierarchy_set_to_row_axis(MdxHierarchySet.members([Member.of(self.dimension_names[0], "Element 1")])) \
             .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(self.dimension_names[1], "Element1"))) \
             .add_member_to_where("[" + self.dimension_names[2] + "].[Element1]").to_mdx()
 
-        data = self.tm1.cubes.cells.execute_mdx(mdx, values_only=True)
+        data = self.tm1.cubes.cells.execute_mdx(mdx, skip_cell_properties=True)
 
         self.assertEqual(len(data), 1)
         for coordinates, value in data.items():


### PR DESCRIPTION
in `execute_view`, `execute_mdx `function rename `values_only` arg to
`skip_cell_properties` for sake of readability and clarity