### PR TITLE
Remove linebreaks in values when writing with ti

### DIFF
--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 
+import asyncio
 import functools
 import json
 import uuid
 import warnings
-import asyncio
 from collections import OrderedDict
+from concurrent.futures.thread import ThreadPoolExecutor
 from io import StringIO
 from typing import List, Union, Dict, Iterable, Tuple, Optional
-from concurrent.futures.thread import ThreadPoolExecutor
 
 from mdxpy import MdxHierarchySet, MdxBuilder, Member
 from requests import Response
@@ -411,7 +411,7 @@ class CellService(ObjectService):
                     outcomes.append(await future)
 
             return outcomes
-            
+
         return asyncio.run(write_async(self, data))
 
     def write_value(self, value: Union[str, float], cube_name: str, element_tuple: Iterable,
@@ -531,7 +531,7 @@ class CellService(ObjectService):
 
             if element_type == 'String':
                 function_str = 'CellPutS('
-                value_str = str(value).replace("'", "''")
+                value_str = str(value).replace("'", "''").replace('\r', '').replace('\n', '')
                 value_str = f"'{value_str}'"
 
             # by default assume numeric, to trigger minor errors on write operations to C elements

--- a/Tests/CellService_test.py
+++ b/Tests/CellService_test.py
@@ -487,6 +487,20 @@ class TestCellService(unittest.TestCase):
 
         self.assertEqual(self.tm1.cells.execute_mdx_values(mdx=query.to_mdx()), [8])
 
+    def test_write_through_unbound_process_line_break_hashmark_combo(self):
+        cells = dict()
+        cells["d1e1", "d2e4", "d3e3"] = 'TM1py \r\n#Test'
+
+        self.tm1.cubes.cells.write_through_unbound_process(self.string_cube_name, cells)
+
+        query = MdxBuilder.from_cube(self.string_cube_name)
+        query.add_member_tuple_to_columns(
+            f"[{self.string_dimension_names[0]}].[d1e1]",
+            f"[{self.string_dimension_names[1]}].[d2e4]",
+            f"[{self.string_dimension_names[2]}].[d3e3]")
+
+        self.assertEqual(self.tm1.cells.execute_mdx_values(mdx=query.to_mdx()), ['TM1py #Test'])
+
     def test_undo_cellset_write(self):
         cells = dict()
         cells["Element 12", "Element 13", "Element 15"] = 3.3


### PR DESCRIPTION
currently, linebreaks followed by the hashmark (`#`) break the
`write_through_unbound_process` function.

since turbo integrator doesn't write linebreaks to cells anyways, we may as
well remove them from the string.

Fixes #568