### PR TITLE
Improve kwargs delegation through stack

### DIFF
--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -75,13 +75,16 @@ def manage_transaction_log(func):
             else:
                 cube_name = arg
 
+        deactivate_transaction_log = kwargs.pop("deactivate_transaction_log", False)
+        reactivate_transaction_log = kwargs.pop("reactivate_transaction_log", False)
         try:
-            if kwargs.get("deactivate_transaction_log", False):
+
+            if deactivate_transaction_log:
                 self.deactivate_transactionlog(cube_name)
             return func(self, *args, **kwargs)
 
         finally:
-            if kwargs.get("reactivate_transaction_log", False):
+            if reactivate_transaction_log:
                 self.activate_transactionlog(cube_name)
 
     return wrapper


### PR DESCRIPTION
don't foward deactivate_transaction_log and reactivate_transaction_log
needlessly through full stack.

pop them from kwargs after they are consumed in `manage_transaction_log`
decorator.

This way they are not forwarded to execute_process_with_return in use_ti
write mode.