### PR TITLE
Make custom set easier to use

### DIFF
--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -884,7 +884,13 @@ class CaseAndSpaceInsensitiveSet(collections.abc.MutableSet):
     def __init__(self, *values):
         self._store = {}
         for v in values:
-            self.add(v)
+            if isinstance(v, str):
+                self.add(v)
+            elif isinstance(v, Iterable):
+                for item in v:
+                    self.add(item)
+            else:
+                self.add(v)
 
     def __contains__(self, value):
         return value.lower().replace(" ", "") in self._store


### PR DESCRIPTION
Allow simpler initiation of `CaseAndSpaceInsensitiveSet`:

```
from TM1py.Utils import CaseAndSpaceInsensitiveSet

items = CaseAndSpaceInsensitiveSet(["value1", "value2", "value3"])
```

As opposed to:
```
from TM1py.Utils import CaseAndSpaceInsensitiveSet

items = CaseAndSpaceInsensitiveSet()

for value in ["value1", "value2", "value3"]
    items.add(value)

```

Or:
```
from TM1py.Utils import CaseAndSpaceInsensitiveSet

values = ["value1", "value2", "value3"]
items = CaseAndSpaceInsensitiveSet(*values)

```