### PR TITLE
get_last_message_from_processerrorlog should return text

### DIFF
--- a/TM1py/Services/ProcessService.py
+++ b/TM1py/Services/ProcessService.py
@@ -304,8 +304,8 @@ class ProcessService(ObjectService):
         """ Get the latest ProcessErrorLog from a process entity
 
             :param process_name: name of the process
-            :return: String - the errorlog, e.g.: "Fehler: Prolog Prozedurzeile (9): Zeichenfolge "US772131
-            kann nicht in eine reelle Zahl umgewandelt werden."
+            :return: String - the errorlog, e.g.:  "Error: Data procedure line (9): Invalid key:
+            Dimension Name: "Product", Element Name (Key): "ProductA""
         """
         logs_as_list = self.get_processerrorlogs(process_name, **kwargs)
         if len(logs_as_list) > 0:
@@ -313,7 +313,7 @@ class ProcessService(ObjectService):
             url = format_url("/api/v1/Processes('{}')/ErrorLogs('{}')/Content", process_name, timestamp)
             # response is plain text - due to entity type Edm.Stream
             response = self._rest.GET(url=url, **kwargs)
-            return response
+            return response.text
 
     def debug_process(self, process_name: str, timeout: float = None, **kwargs) -> Dict:
         raw_url = "/api/v1/Processes('{}')/tm1.Debug?$expand=Breakpoints," \

--- a/Tests/ProcessService_test.py
+++ b/Tests/ProcessService_test.py
@@ -350,6 +350,23 @@ class TestProcessService(unittest.TestCase):
 
         self.tm1.processes.delete(process.name)
 
+    def test_get_last_message_from_processerrorlog(self):
+        process = Process(name=str(uuid.uuid4()))
+        process.epilog_procedure = "ItemReject('Not Relevant');"
+
+        if not self.tm1.processes.exists(process.name):
+            self.tm1.processes.create(process)
+        # with parameters
+        success, status, error_log_file = self.tm1.processes.execute_with_return(process_name=process.name)
+        self.assertFalse(success)
+        self.assertEqual(status, "CompletedWithMessages")
+        self.assertIsNotNone(error_log_file)
+
+        content = self.tm1.processes.get_last_message_from_processerrorlog(process_name=process.name)
+        self.assertIn("Not Relevant", content)
+
+        self.tm1.processes.delete(process.name)
+
     def test_delete_process(self):
         process = self.p_bedrock_server_wait
         process.name = str(uuid.uuid4())


### PR DESCRIPTION
`get_last_message_from_processerrorlog` is returning the response code instead of the content in text fomat.
This pull request is to fix that.
Added a test case as well.

fix for #625 