### PR TITLE
Raise Exception when session creation fails with incorrect address or port

### DIFF
--- a/TM1py/Services/RestService.py
+++ b/TM1py/Services/RestService.py
@@ -366,7 +366,9 @@ class RestService:
 
             response = self.GET(url=url, headers=additional_headers)
             if response is None:
-                raise ValueError("Address or Port number could be invalid in URL: " + self._base_url + url)
+                raise ValueError(
+                    f"No response returned from URL: '{self._base_url + url}'. "
+                    f"Please double check your address and port number in the URL.")
             self._version = response.text
         finally:
             # After we have session cookie, drop the Authorization Header


### PR DESCRIPTION
Hitting`/api/v1/Configuration/ProductVersion/$value` with incorrect address or port does not raise an `Exception`, rather it tries to get the **product version** from the `response` and fails with an `AttributeError` as `response` will be `None`.
Added a `ValueError` to avoid this case.