### PR TITLE
Raise Exception when session creation fails

### DIFF
--- a/TM1py/Services/RestService.py
+++ b/TM1py/Services/RestService.py
@@ -365,6 +365,10 @@ class RestService:
                 additional_headers["TM1-Impersonate"] = impersonate
 
             response = self.GET(url=url, headers=additional_headers)
+            if response is None:
+                raise ValueError(f"No response returned from URL: '{self._base_url + url}'. "
+                                 f"Please double check your address and port number in the URL.")
+                
             self._version = response.text
         finally:
             # After we have session cookie, drop the Authorization Header


### PR DESCRIPTION
Raise exception when session creation fails
Hitting`/api/v1/Configuration/ProductVersion/$value` with incorrect address or port does not raise an `Exception`, rather it tries to get the **product version** from the `response` and fails with an `AttributeError` as `response` will be `None`.
Added a `ValueError` to avoid this case.