### PR TITLE
Feature/odata compact json

### DIFF
--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -874,7 +874,7 @@ class CellService(ObjectService):
     def execute_mdx(self, mdx: str, cell_properties: List[str] = None, top: int = None, skip_contexts: bool = False,
                     skip: int = None, skip_zeros: bool = False, skip_consolidated_cells: bool = False,
                     skip_rule_derived_cells: bool = False, sandbox_name: str = None, element_unique_names: bool = True,
-                    skip_cell_properties: bool = False, **kwargs) -> CaseAndSpaceInsensitiveTuplesDict:
+                    skip_cell_properties: bool = False, use_compact_json: bool = False, **kwargs) -> CaseAndSpaceInsensitiveTuplesDict:
         """ Execute MDX and return the cells with their properties
 
         :param mdx: MDX Query, as string
@@ -888,6 +888,7 @@ class CellService(ObjectService):
         :param sandbox_name: str
         :param element_unique_names: '[d1].[h1].[e1]' or 'e1'
         :param skip_cell_properties: cell values in result dictionary, instead of cell_properties dictionary
+        :param use_compact_json: bool
         :return: content in sweet concise structure.
         """
         cellset_id = self.create_cellset(mdx=mdx, sandbox_name=sandbox_name, **kwargs)
@@ -904,13 +905,14 @@ class CellService(ObjectService):
             sandbox_name=sandbox_name,
             element_unique_names=element_unique_names,
             skip_cell_properties=skip_cell_properties,
+            use_compact_json=use_compact_json,
             **kwargs)
 
     def execute_view(self, cube_name: str, view_name: str, private: bool = False, cell_properties: Iterable[str] = None,
                      top: int = None, skip_contexts: bool = False, skip: int = None, skip_zeros: bool = False,
                      skip_consolidated_cells: bool = False, skip_rule_derived_cells: bool = False,
                      sandbox_name: str = None, element_unique_names: bool = True, skip_cell_properties: bool = False,
-                     **kwargs) -> CaseAndSpaceInsensitiveTuplesDict:
+                     use_compact_json: bool = False, **kwargs) -> CaseAndSpaceInsensitiveTuplesDict:
         """ get view content as dictionary with sweet and concise structure.
             Works on NativeView and MDXView !
 
@@ -928,6 +930,7 @@ class CellService(ObjectService):
         :param element_unique_names: '[d1].[h1].[e1]' or 'e1'
         :param sandbox_name: str
         :param skip_cell_properties: cell values in result dictionary, instead of cell_properties dictionary
+        :param use_compact_json: bool
         :return: Dictionary : {([dim1].[elem1], [dim2][elem6]): {'Value':3127.312, 'Ordinal':12}   ....  }
         """
         cellset_id = self.create_cellset_from_view(cube_name=cube_name, view_name=view_name, private=private,
@@ -945,6 +948,7 @@ class CellService(ObjectService):
             sandbox_name=sandbox_name,
             element_unique_names=element_unique_names,
             skip_cell_properties=skip_cell_properties,
+            use_compact_json=use_compact_json,
             **kwargs)
 
     def execute_mdx_raw(
@@ -961,6 +965,7 @@ class CellService(ObjectService):
             skip_rule_derived_cells: bool = False,
             sandbox_name: str = None,
             include_hierarchies: bool = False,
+            use_compact_json: bool = False,
             **kwargs) -> Dict:
         """ Execute MDX and return the raw data from TM1
 
@@ -976,6 +981,7 @@ class CellService(ObjectService):
         :param skip_rule_derived_cells: skip rule derived cells in cellset
         :param sandbox_name: str
         :param include_hierarchies: retrieve Hierarchies property on Axes
+        :param use_compact_json: bool
         :return: Raw format from TM1.
         """
         cellset_id = self.create_cellset(mdx=mdx, sandbox_name=sandbox_name, **kwargs)
@@ -993,6 +999,7 @@ class CellService(ObjectService):
             skip_rule_derived_cells=skip_rule_derived_cells,
             sandbox_name=sandbox_name,
             include_hierarchies=include_hierarchies,
+            use_compact_json=use_compact_json,
             **kwargs)
 
     def execute_view_raw(
@@ -1010,6 +1017,7 @@ class CellService(ObjectService):
             skip_consolidated_cells: bool = False,
             skip_rule_derived_cells: bool = False,
             sandbox_name: str = None,
+            use_compact_json: bool = False,
             **kwargs) -> Dict:
         """ Execute a cube view and return the raw data from TM1
 
@@ -1027,6 +1035,7 @@ class CellService(ObjectService):
         :param skip_consolidated_cells: skip consolidated cells in cellset
         :param skip_rule_derived_cells: skip rule derived cells in cellset
         :param sandbox_name: str
+        :param use_compact_json: bool
         :return: Raw format from TM1.
         """
         cellset_id = self.create_cellset_from_view(cube_name=cube_name, view_name=view_name, private=private,
@@ -1044,33 +1053,36 @@ class CellService(ObjectService):
             skip_consolidated_cells=skip_consolidated_cells,
             delete_cellset=True,
             sandbox_name=sandbox_name,
+            use_compact_json=use_compact_json,
             **kwargs)
 
-    def execute_mdx_values(self, mdx: str, sandbox_name: str = None, **kwargs) -> List[Union[str, float]]:
+    def execute_mdx_values(self, mdx: str, sandbox_name: str = None, use_compact_json: bool = False, **kwargs) -> List[Union[str, float]]:
         """ Optimized for performance. Query only raw cell values.
         Coordinates are omitted !
 
         :param mdx: a valid MDX Query
         :param sandbox_name: str
+        :param use_compact_json: bool
         :return: List of cell values
         """
         cellset_id = self.create_cellset(mdx=mdx, sandbox_name=sandbox_name, **kwargs)
-        return self.extract_cellset_values(cellset_id, delete_cellset=True, sandbox_name=sandbox_name, **kwargs)
+        return self.extract_cellset_values(cellset_id, delete_cellset=True, sandbox_name=sandbox_name, use_compact_json=use_compact_json, **kwargs)
 
     def execute_view_values(self, cube_name: str, view_name: str, private: bool = False, sandbox_name: str = None,
-                            **kwargs) -> List[Union[str, float]]:
+                            use_compact_json: bool = False, **kwargs) -> List[Union[str, float]]:
         """ Execute view and retrieve only the cell values
 
         :param cube_name: String, name of the cube
         :param view_name: String, name of the view
         :param private: True (private) or False (public)
         :param sandbox_name: str
+        :param use_compact_json: bool
         :param kwargs:
         :return:
         """
         cellset_id = self.create_cellset_from_view(cube_name=cube_name, view_name=view_name, private=private,
                                                    sandbox_name=sandbox_name, **kwargs)
-        return self.extract_cellset_values(cellset_id, delete_cellset=True, sandbox_name=sandbox_name, **kwargs)
+        return self.extract_cellset_values(cellset_id, delete_cellset=True, sandbox_name=sandbox_name, use_compact_json=use_compact_json, **kwargs)
 
     def execute_mdx_rows_and_values(self, mdx: str, element_unique_names: bool = True, sandbox_name: str = None,
                                     **kwargs) -> CaseAndSpaceInsensitiveTuplesDict:
@@ -1410,6 +1422,7 @@ class CellService(ObjectService):
             top: int = None,
             skip: int = None,
             sandbox_name: str = None,
+            use_compact_json: bool = False,
             **kwargs) -> Dict:
         """ Execute MDX get dygraph dictionary
         Useful for grids or charting libraries that want an array of cell values per column
@@ -1434,6 +1447,7 @@ class CellService(ObjectService):
         :param member_properties: List of properties to be queried from the members. E.g. ['UniqueName','Attributes']
         :param value_precision: Integer (optional) specifying number of decimal places to return
         :param sandbox_name: str
+        :param use_compact_json: bool
         :return: dict: { titles: [], headers: [axis][], cells: { Page0: [ [column name, column values], [], ... ], ...}}
         """
         cellset_id = self.create_cellset(mdx=mdx, sandbox_name=sandbox_name)
@@ -1445,6 +1459,7 @@ class CellService(ObjectService):
                                         skip=skip,
                                         delete_cellset=True,
                                         sandbox_name=sandbox_name,
+                                        use_compact_json=use_compact_json,
                                         **kwargs)
         return Utils.build_ui_dygraph_arrays_from_cellset(raw_cellset_as_dict=data, value_precision=value_precision)
 
@@ -1459,6 +1474,7 @@ class CellService(ObjectService):
             top: int = None,
             skip: int = None,
             sandbox_name: str = None,
+            use_compact_json: bool = False,
             **kwargs):
         """
         Useful for grids or charting libraries that want an array of cell values per row.
@@ -1495,6 +1511,7 @@ class CellService(ObjectService):
         :param member_properties: List of properties to be queried from the members. E.g. ['UniqueName','Attributes']
         :param value_precision: Integer (optional) specifying number of decimal places to return
         :param sandbox_name: str
+        :param use_compact_json: bool
         :return:
         """
         cellset_id = self.create_cellset_from_view(cube_name=cube_name, view_name=view_name, private=private,
@@ -1507,6 +1524,7 @@ class CellService(ObjectService):
                                         skip=skip,
                                         delete_cellset=True,
                                         sandbox_name=sandbox_name,
+                                        use_compact_json=use_compact_json,
                                         **kwargs)
         return Utils.build_ui_dygraph_arrays_from_cellset(raw_cellset_as_dict=data, value_precision=value_precision)
 
@@ -1519,6 +1537,7 @@ class CellService(ObjectService):
             top: int = None,
             skip: int = None,
             sandbox_name: str = None,
+            use_compact_json: bool = False,
             **kwargs):
         """
         Useful for grids or charting libraries that want an array of cell values per row.
@@ -1553,6 +1572,7 @@ class CellService(ObjectService):
         :param member_properties: List of properties to be queried from the members. E.g. ['UniqueName','Attributes']
         :param value_precision: Integer (optional) specifying number of decimal places to return
         :param sandbox_name: str
+        :param use_compact_json: bool
         :return: dict :{ titles: [], headers: [axis][], cells:{ Page0:{ Row0:{ [row values], Row1: [], ...}, ...}, ...}}
         """
         cellset_id = self.create_cellset(mdx=mdx, sandbox_name=sandbox_name, **kwargs)
@@ -1564,6 +1584,7 @@ class CellService(ObjectService):
                                         skip=skip,
                                         delete_cellset=True,
                                         sandbox_name=sandbox_name,
+                                        use_compact_json=use_compact_json,
                                         **kwargs)
         return Utils.build_ui_arrays_from_cellset(raw_cellset_as_dict=data, value_precision=value_precision)
 
@@ -1578,6 +1599,7 @@ class CellService(ObjectService):
             top: int = None,
             skip: int = None,
             sandbox_name: str = None,
+            use_compact_json: bool = False,
             **kwargs):
         """
         Useful for grids or charting libraries that want an array of cell values per row.
@@ -1614,6 +1636,7 @@ class CellService(ObjectService):
         :param member_properties: List properties to be queried from the member. E.g. ['Name', 'UniqueName']
         :param value_precision: Integer (optional) specifying number of decimal places to return
         :param sandbox_name: str
+        :param use_compact_json: bool
         :return: dict :{ titles: [], headers: [axis][], cells:{ Page0:{ Row0: {[row values], Row1: [], ...}, ...}, ...}}
         """
         cellset_id = self.create_cellset_from_view(cube_name=cube_name, view_name=view_name, private=private,
@@ -1626,6 +1649,7 @@ class CellService(ObjectService):
                                         skip=skip,
                                         delete_cellset=True,
                                         sandbox_name=sandbox_name,
+                                        use_compact_json=use_compact_json,
                                         **kwargs)
         return Utils.build_ui_arrays_from_cellset(raw_cellset_as_dict=data, value_precision=value_precision)
 
@@ -1908,6 +1932,7 @@ class CellService(ObjectService):
             value_separator: str = ",",
             sandbox_name: str = None,
             include_attributes: bool = False,
+            use_compact_json: bool = False,
             **kwargs) -> str:
         """ Execute cellset and return only the 'Content', in csv format
 
@@ -1921,6 +1946,7 @@ class CellService(ObjectService):
         :param value_separator
         :param sandbox_name: str
         :param include_attributes: include attribute columns
+        :param use_compact_json: bool
         :return: Raw format from TM1.
         """
         _, _, rows, columns = self.extract_cellset_composition(cellset_id, delete_cellset=False,
@@ -1933,6 +1959,7 @@ class CellService(ObjectService):
                                                 elem_properties=['Name'],
                                                 member_properties=['Name',
                                                                    'Attributes'] if include_attributes else None,
+                                                use_compact_json=use_compact_json,
                                                 **kwargs)
         return build_csv_from_cellset_dict(rows, columns, cellset_dict, line_separator=line_separator,
                                            value_separator=value_separator, top=top,
@@ -2046,7 +2073,7 @@ class CellService(ObjectService):
 
     @require_pandas
     def extract_cellset_dataframe_pivot(self, cellset_id: str, dropna: bool = False, fill_value: bool = False,
-                                        sandbox_name: str = None,
+                                        sandbox_name: str = None, use_compact_json: bool = False,
                                         **kwargs) -> 'pd.DataFrame':
         """ Extract a pivot table (pandas dataframe) from a cellset in TM1
 
@@ -2055,6 +2082,7 @@ class CellService(ObjectService):
         :param fill_value:
         :param kwargs:
         :param sandbox_name: str
+        :param use_compact_json: bool
         :return:
         """
 
@@ -2062,6 +2090,7 @@ class CellService(ObjectService):
             cellset_id=cellset_id,
             delete_cellset=False,
             sandbox_name=sandbox_name,
+            use_compact_json=use_compact_json
             **kwargs)
 
         cube, titles, rows, columns = self.extract_cellset_composition(
@@ -2095,6 +2124,7 @@ class CellService(ObjectService):
             sandbox_name: str = None,
             element_unique_names: bool = True,
             skip_cell_properties: bool = False,
+            use_compact_json: bool = False,
             **kwargs) -> CaseAndSpaceInsensitiveTuplesDict:
         """ Execute cellset and return the cells with their properties
 
@@ -2110,6 +2140,7 @@ class CellService(ObjectService):
         :param sandbox_name: str
         :param element_unique_names: '[d1].[h1].[e1]' or 'e1'
         :param skip_cell_properties: cell values in result dictionary, instead of cell_properties dictionary
+        :param use_compact_json: bool
         :return: Content in sweet concise strcuture.
         """
         if not cell_properties:
@@ -2129,6 +2160,7 @@ class CellService(ObjectService):
             skip_rule_derived_cells=skip_rule_derived_cells,
             sandbox_name=sandbox_name,
             include_hierarchies=False,
+            use_compact_json=use_compact_json,
             **kwargs)
 
         return Utils.build_content_from_cellset_dict(

--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -115,7 +115,7 @@ def manage_changeset(func):
     return wrapper
 
 
-def odata_compact_json(return_props_with_data: Optional[bool] = True):
+def odata_compact_json(return_props_with_data: bool):
     """ Higher order function to manage header and response when using compact JSON
         
         Applies when decorated function has `use_compact_json` argument set to True
@@ -1700,7 +1700,7 @@ class CellService(ObjectService):
         return response.json()
 
 
-    @odata_compact_json
+    @odata_compact_json(return_props_with_data=True)
     def extract_cellset_cells_raw(
         self, cellset_id: str, 
         cell_properties: Iterable[str] = None, 
@@ -2090,7 +2090,7 @@ class CellService(ObjectService):
             cellset_id=cellset_id,
             delete_cellset=False,
             sandbox_name=sandbox_name,
-            use_compact_json=use_compact_json
+            use_compact_json=use_compact_json,
             **kwargs)
 
         cube, titles, rows, columns = self.extract_cellset_composition(

--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -24,7 +24,7 @@ from TM1py.Services.SandboxService import SandboxService
 from TM1py.Services.ViewService import ViewService
 from TM1py.Utils import Utils, CaseAndSpaceInsensitiveSet, format_url, add_url_parameters
 from TM1py.Utils.Utils import build_pandas_dataframe_from_cellset, dimension_name_from_element_unique_name, \
-    CaseAndSpaceInsensitiveDict, extract_cell_properties_from_odata_context, map_cell_properties_to_data, wrap_in_curly_braces, CaseAndSpaceInsensitiveTuplesDict, abbreviate_mdx, \
+    CaseAndSpaceInsensitiveDict, extract_cell_properties_from_odata_context, map_cell_properties_to_compact_json_response, wrap_in_curly_braces, CaseAndSpaceInsensitiveTuplesDict, abbreviate_mdx, \
     build_csv_from_cellset_dict, require_version, require_pandas, build_cellset_from_pandas_dataframe, \
     case_and_space_insensitive_equals, get_cube, resembles_mdx, require_admin
 
@@ -144,16 +144,16 @@ def odata_compact_json(return_props_with_data: bool):
                     props = extract_cell_properties_from_odata_context(context)
 
                     # First element [0] is the cellset ID, second is the cellset data
-                    data = response['value'][1]
+                    cells_data = response['value'][1]
 
                     # return props with data if required
                     if return_props_with_data:
-                        return map_cell_properties_to_data(props, data)
+                        return map_cell_properties_to_compact_json_response(props, cells_data)
 
                     if len(props) == 1:
-                        return [value[0] for value in data]
+                        return [value[0] for value in cells_data]
 
-                    return data
+                    return cells_data
                 finally:
                     # Restore original header
                     self._rest.add_http_header('Accept', header)

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -737,7 +737,7 @@ def add_url_parameters(url, **kwargs: str) -> str:
 def extract_cell_properties_from_odata_context(context: str) -> Dict:
     """ Takes in an odata_context and returns a dictionary
         with properties as keys and values as indexes
-        { Ordinal: 0, Value: 1, RuleDerived: 258, ... }
+        { Ordinal: 0, Value: 1, ... }
     
     """
     pattern = re.compile('\$metadata#Cellsets\(Cells\(([A-Za-z,]+)\)\)/\$entity')


### PR DESCRIPTION
### Introduces the option to use compact JSON format when querying cellsets. Beneficial when querying large amounts of data and / or remote environments where network latency is typically higher. ###

Implemented through a new `odata_compact_json` decorator which handles the header and maps the data back to the cellset properties based on the odata context. Whether the properties are returned is based on `return_props_with_data` is `True`. The odata context returned in the response is used to parse the response. **Currently only supports requests that query only cell properties (see notes in decorator function).** 

Core low level extract functions have been decorated, namely `extract_cellset_raw` and `extract_cellset_values`. Some refactoring was required, particularly with the former to separate the metadata and cell calls. 

A new parameter `use_compact_json` has been added to all of the relevant functions. Defaults to `False`.

A couple of reservations / thoughts I have on the approach: 
  - Updating the `Accept` header - It's a little tricky because positioning matters and it needs to come after application/json. The default header defined in the RestService is `application/json;odata.metadata=none,text/plain` and in order to use the compact JSON format, it would be `application/json;tm1.compact=v0;odata.metadata=none,text/plain`. I've taken the approach of inserting the header in the right place as opposed to assuming what the default header contains and setting a new one directly. 
  - Using compact JSON for metadata calls - It would be nice to be able to support this as well. However, the odata context only contains properties explicitly asked for on each Entity and doesn't include properties that are returned by default e.g a request to `Cellsets('...')?$expand=Axes` would lead to an odata context of `$metadata#Cellsets(Axes)/$entity` but Ordinal and Cardinality properties would be included in the response by default. In order to parse the response correctly, the odata context would need to be `$metadata#Cellsets(Axes(Ordinal,Cardinality)/$entity`. In order to implement fully, based on what I know so far, besides the parser being very robust to handle all the variations and navigation options, possible workarounds could be to: 

    - Ensure all requests specify properties for each Entity, expand options included.
    -  Hold a lookup to the default properties for each Entity

I'm not a fan of either approach really but the 1st option would appear to be more in our control. That being said, I think this PR is a good start so maybe something we come back to.

Thanks,
George
