### PR TITLE
Allow iterative_json_parsing in conjunction with include_attributes

### DIFF
--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -2208,7 +2208,7 @@ class CellService(ObjectService):
             attributes_by_dimension = self._get_attributes_by_dimension(cube)
             for _, attributes in attributes_by_dimension.items():
                 for attribute in attributes:
-                    prefix = f'Axes.item.Tuples.item.Members.item.Attributes.{attribute.replace(" ", "")}'
+                    prefix = f'Axes.item.Tuples.item.Members.item.Attributes.{attribute}'
                     prefixes_of_interest.append(prefix)
                     attributes_prefixes.add(prefix)
 

--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -11,7 +11,7 @@ from io import StringIO
 from typing import List, Union, Dict, Iterable, Tuple, Optional
 
 import ijson
-from mdxpy import MdxHierarchySet, MdxBuilder, Member
+from mdxpy import MdxHierarchySet, MdxBuilder
 from requests import Response
 
 from TM1py.Exceptions.Exceptions import TM1pyException, TM1pyWritePartialFailureException, TM1pyWriteFailureException, \
@@ -25,10 +25,10 @@ from TM1py.Services.ViewService import ViewService
 from TM1py.Utils import Utils, CaseAndSpaceInsensitiveSet, format_url, add_url_parameters
 from TM1py.Utils.Utils import build_pandas_dataframe_from_cellset, dimension_name_from_element_unique_name, \
     CaseAndSpaceInsensitiveDict, wrap_in_curly_braces, CaseAndSpaceInsensitiveTuplesDict, \
-    abbreviate_mdx, \
-    build_csv_from_cellset_dict, require_version, require_pandas, build_cellset_from_pandas_dataframe, \
+    abbreviate_mdx, build_csv_from_cellset_dict, require_version, require_pandas, build_cellset_from_pandas_dataframe, \
     case_and_space_insensitive_equals, get_cube, resembles_mdx, require_admin, extract_compact_json_cellset, \
-    cell_is_updateable, build_mdx_from_cellset, build_mdx_and_values_from_cellset, dimension_names_from_element_unique_names
+    cell_is_updateable, build_mdx_from_cellset, build_mdx_and_values_from_cellset, \
+    dimension_names_from_element_unique_names
 
 try:
     import pandas as pd
@@ -2187,9 +2187,10 @@ class CellService(ObjectService):
             member_properties=['Name', 'Attributes'] if include_attributes else ['Name'],
             **kwargs)
 
-        # start parsing of JSON directly into CSV
         row_headers = list(dimension_names_from_element_unique_names(rows))
         column_headers = list(dimension_names_from_element_unique_names(columns))
+
+        # start parsing of JSON directly into CSV
         axes0_list = []
         axes1_list = []
         current_axes = 0

--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -28,7 +28,7 @@ from TM1py.Utils.Utils import build_pandas_dataframe_from_cellset, dimension_nam
     abbreviate_mdx, \
     build_csv_from_cellset_dict, require_version, require_pandas, build_cellset_from_pandas_dataframe, \
     case_and_space_insensitive_equals, get_cube, resembles_mdx, require_admin, extract_compact_json_cellset, \
-    cell_is_updateable, build_mdx_from_cellset, build_mdx_and_values_from_cellset
+    cell_is_updateable, build_mdx_from_cellset, build_mdx_and_values_from_cellset, dimension_names_from_element_unique_names
 
 try:
     import pandas as pd
@@ -119,7 +119,7 @@ def manage_changeset(func):
 
 def odata_compact_json(return_as_dict: bool):
     """ Higher order function to manage header and response when using compact JSON
-        
+
         Applies when decorated function has `use_compact_json` argument set to True
 
         Currently only supports responses with only cell properties and where they are explicitly specified:
@@ -1180,14 +1180,12 @@ class CellService(ObjectService):
         """
         cellset_id = self.create_cellset(mdx, sandbox_name=sandbox_name, **kwargs)
 
-        if use_iterative_json and include_attributes:
-            raise ValueError("Iterative JSON parsing must not be used together with include_attributes")
-
         if use_iterative_json:
             return self.extract_cellset_csv_iter_json(
                 cellset_id=cellset_id, top=top, skip=skip, skip_zeros=skip_zeros,
                 skip_rule_derived_cells=skip_rule_derived_cells, skip_consolidated_cells=skip_consolidated_cells,
-                line_separator=line_separator, value_separator=value_separator, sandbox_name=sandbox_name, **kwargs)
+                line_separator=line_separator, value_separator=value_separator, sandbox_name=sandbox_name,
+                include_attributes=include_attributes, **kwargs)
 
         return self.extract_cellset_csv(
             cellset_id=cellset_id, top=top, skip=skip, skip_zeros=skip_zeros,
@@ -2157,6 +2155,7 @@ class CellService(ObjectService):
             line_separator: str = "\r\n",
             value_separator: str = ",",
             sandbox_name: str = None,
+            include_attributes: bool = False,
             **kwargs) -> str:
         """ Execute cellset and return only the 'Content', in csv format
 
@@ -2169,9 +2168,10 @@ class CellService(ObjectService):
         :param line_separator:
         :param value_separator
         :param sandbox_name: str
+        :param include_attributes: boolean
         :return: Raw format from TM1.
         """
-        _, _, rows, columns = self.extract_cellset_composition(
+        cube, _, rows, columns = self.extract_cellset_composition(
             cellset_id,
             delete_cellset=False,
             sandbox_name=sandbox_name,
@@ -2184,11 +2184,12 @@ class CellService(ObjectService):
             skip_rule_derived_cells=skip_rule_derived_cells,
             delete_cellset=True,
             sandbox_name=sandbox_name,
-            member_properties=['Name'],
+            member_properties=['Name', 'Attributes'] if include_attributes else ['Name'],
             **kwargs)
 
         # start parsing of JSON directly into CSV
-        dimension_list = []
+        row_headers = list(dimension_names_from_element_unique_names(rows))
+        column_headers = list(dimension_names_from_element_unique_names(columns))
         axes0_list = []
         axes1_list = []
         current_axes = 0
@@ -2200,6 +2201,15 @@ class CellService(ObjectService):
         prefixes_of_interest = ['Cells.item.Value', 'Axes.item.Tuples.item.Members.item.Name',
                                 'Cells.item.Ordinal', 'Axes.item.Tuples.item.Ordinal', 'Cube.Dimensions.item.Name',
                                 'Axes.item.Ordinal']
+
+        attributes_prefixes = set()
+        if include_attributes:
+            attributes_by_dimension = self._get_attributes_by_dimension(cube)
+            for _, attributes in attributes_by_dimension.items():
+                for attribute in attributes:
+                    prefix = f'Axes.item.Tuples.item.Members.item.Attributes.{attribute.replace(" ", "")}'
+                    prefixes_of_interest.append(prefix)
+                    attributes_prefixes.add(prefix)
 
         gen = ((prefix, event, value) for prefix, event, value in parser if prefix in prefixes_of_interest)
         for prefix, event, value in gen:
@@ -2222,6 +2232,28 @@ class CellService(ObjectService):
                 else:
                     axes1_list[current_tuple] += ('' if axes1_list[current_tuple] == '' else value_separator) + value
 
+            if prefix in attributes_prefixes:
+                if event not in ('string', 'number'):
+                    continue
+
+                attribute_name = prefix.split('.')[-1]
+                value = str(value)
+
+                if current_axes == 0:
+                    axes0_list[current_tuple] += ('' if axes0_list[current_tuple] == '' else value_separator) + value
+                else:
+                    axes1_list[current_tuple] += ('' if axes1_list[current_tuple] == '' else value_separator) + value
+
+                # Add header entry for attribute if necessary
+                if current_tuple == 0:
+                    if current_axes == 0:
+                        axis0_elements = axes0_list[current_tuple].split('~')
+                        column_headers.insert(len(axis0_elements) - 1, attribute_name)
+
+                    else:
+                        axis1_elements = axes1_list[current_tuple].split('~')
+                        row_headers.insert(len(axis1_elements) - 1, attribute_name)
+
             elif (prefix, event) == ('Cells.item.Ordinal', 'number'):
                 current_cell_ordinal = value
 
@@ -2232,21 +2264,20 @@ class CellService(ObjectService):
                 else:
                     axes1_list.append('')
 
-            elif (prefix, event) == ('Cube.Dimensions.item.Name', 'string'):
-                dimension_list.append(value)
-
             elif (prefix, event) == ('Axes.item.Ordinal', 'number'):
                 current_axes = value
 
+        # comply with prior implementations: return empty string when cellset is empty
+        if not csv_lines:
+            return ""
+
         # add header
-        dimension_list.append('Value')
-        csv_lines.insert(0, value_separator.join(dimension_list))
+        headers = row_headers + column_headers + ['Value']
+        csv_lines.insert(0, value_separator.join(headers))
 
         csv = line_separator.join(csv_lines)
 
-        # close response
         cellset_response.close()
-
         return csv
 
     @require_pandas
@@ -2279,9 +2310,6 @@ class CellService(ObjectService):
         :param kwargs:
         :return:
         """
-        if use_iterative_json and include_attributes:
-            raise ValueError("Iterative JSON parsing must not be used together with include_attributes")
-
         if use_iterative_json and use_compact_json:
             raise ValueError("Iterative JSON parsing must not be used together with compact JSON")
 
@@ -2289,7 +2317,7 @@ class CellService(ObjectService):
             raw_csv = self.extract_cellset_csv_iter_json(
                 cellset_id=cellset_id, top=top, skip=skip, skip_zeros=skip_zeros,
                 skip_rule_derived_cells=skip_rule_derived_cells, skip_consolidated_cells=skip_consolidated_cells,
-                value_separator='~', sandbox_name=sandbox_name, **kwargs)
+                value_separator='~', sandbox_name=sandbox_name, include_attributes=include_attributes, **kwargs)
         else:
             raw_csv = self.extract_cellset_csv(
                 cellset_id=cellset_id, top=top, skip=skip, skip_zeros=skip_zeros,
@@ -2620,3 +2648,16 @@ class CellService(ObjectService):
     def sandbox_exists(self, sandbox_name) -> bool:
         sandbox_service = SandboxService(self._rest)
         return sandbox_service.exists(sandbox_name)
+
+    def _get_attributes_by_dimension(self, cube: str, **kwargs) -> Dict[str, List[str]]:
+        from TM1py import ElementService
+        element_service = ElementService(self._rest)
+
+        attributes_by_dimension = CaseAndSpaceInsensitiveDict()
+        for dimension_name in self.get_dimension_names_for_writing(cube):
+            attributes_by_dimension[dimension_name] = element_service.get_element_attribute_names(
+                dimension_name,
+                dimension_name,
+                **kwargs)
+
+        return attributes_by_dimension

--- a/TM1py/Services/ElementService.py
+++ b/TM1py/Services/ElementService.py
@@ -340,6 +340,20 @@ class ElementService(ObjectService):
         element_attributes = [ElementAttribute.from_dict(ea) for ea in response.json()['value']]
         return element_attributes
 
+    def get_element_attribute_names(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[str]:
+        """ Get element attributes from hierarchy
+
+        :param dimension_name:
+        :param hierarchy_name:
+        :return:
+        """
+        url = format_url(
+            "/api/v1/Dimensions('{}')/Hierarchies('{}')/ElementAttributes?$select=Name",
+            dimension_name,
+            hierarchy_name)
+        response = self._rest.GET(url, **kwargs)
+        return [ea["Name"] for ea in response.json()['value']]
+
     def get_elements_filtered_by_attribute(self, dimension_name: str, hierarchy_name: str, attribute_name: str,
                                            attribute_value: Union[str, float], **kwargs) -> List[str]:
         """ Get all elements from a hierarchy with given attribute value

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -603,6 +603,16 @@ def element_names_from_element_unique_names(element_unique_names: Iterable[str])
                  in element_unique_names)
 
 
+def dimension_names_from_element_unique_names(element_unique_names: Iterable[str]) -> Tuple[str]:
+    """ Get tuple of simple element names from the full element unique names
+    :param element_unique_names: tuple of element unique names ([dim1].[hier1].[elem1], ... )
+    :return: tuple of element names: (elem1, elem2, ... )
+    """
+    return tuple(dimension_name_from_element_unique_name(unique_name)
+                 for unique_name
+                 in element_unique_names)
+
+
 def build_element_unique_names(
         dimension_names: Iterable[str],
         element_names: Iterable[str],

--- a/Tests/CellService_test.py
+++ b/Tests/CellService_test.py
@@ -1892,12 +1892,81 @@ class TestCellService(unittest.TestCase):
         df = self.tm1.cubes.cells.execute_mdx_dataframe(mdx, include_attributes=True)
 
         expected = {
+            'TM1py_Tests_Cell_Dimension1': {0: 'Element 1'},
+            'Attr1': {0: 'TM1py'},
+            'TM1py_Tests_Cell_Dimension2': {0: 'Element 1'},
+            'Attr2': {0: '2'},
+            'TM1py_Tests_Cell_Dimension3': {0: 'Element 1'},
+            'Attr3': {0: '3'},
+            'Value': {0: 1.0}}
+        self.assertEqual(expected, df.to_dict())
+
+    @skip_if_no_pandas
+    def test_execute_mdx_dataframe_include_attributes_iter_json(self):
+        mdx = """SELECT
+        NON EMPTY 
+        {[TM1PY_TESTS_CELL_DIMENSION1].[TM1PY_TESTS_CELL_DIMENSION1].[Element1]} 
+        PROPERTIES [TM1PY_TESTS_CELL_DIMENSION1].[ATTR1]  ON 0,
+        NON EMPTY
+        {[TM1PY_TESTS_CELL_DIMENSION3].[TM1PY_TESTS_CELL_DIMENSION3].[Element1]} * 
+        {[TM1PY_TESTS_CELL_DIMENSION2].[TM1PY_TESTS_CELL_DIMENSION2].[Element1]} 
+        PROPERTIES [TM1PY_TESTS_CELL_DIMENSION2].[ATTR2], [TM1PY_TESTS_CELL_DIMENSION3].[ATTR3] ON 1
+        FROM [TM1PY_TESTS_CELL_CUBE]
+        """
+
+        df = self.tm1.cubes.cells.execute_mdx_dataframe(mdx, include_attributes=True, iterative_json_parsing=True)
+
+        expected = {
             'TM1py_Tests_Cell_Dimension3': {0: 'Element 1'},
             'Attr3': {0: '3'},
             'TM1py_Tests_Cell_Dimension2': {0: 'Element 1'},
             'Attr2': {0: '2'},
             'TM1py_Tests_Cell_Dimension1': {0: 'Element 1'},
             'Attr1': {0: 'TM1py'},
+            'Value': {0: 1.0}}
+        self.assertEqual(expected, df.to_dict())
+
+    @skip_if_no_pandas
+    def test_execute_mdx_dataframe_include_attributes_iter_json_all_columns(self):
+        mdx = """SELECT
+        NON EMPTY 
+        {[TM1PY_TESTS_CELL_DIMENSION1].[TM1PY_TESTS_CELL_DIMENSION1].[Element1]} *
+        {[TM1PY_TESTS_CELL_DIMENSION2].[TM1PY_TESTS_CELL_DIMENSION2].[Element1]} *
+        {[TM1PY_TESTS_CELL_DIMENSION3].[TM1PY_TESTS_CELL_DIMENSION3].[Element1]}
+        PROPERTIES [TM1PY_TESTS_CELL_DIMENSION1].[ATTR1], [TM1PY_TESTS_CELL_DIMENSION2].[ATTR2],
+        [TM1PY_TESTS_CELL_DIMENSION3].[ATTR3]  ON 0
+        FROM [TM1PY_TESTS_CELL_CUBE]
+        """
+
+        df = self.tm1.cubes.cells.execute_mdx_dataframe(mdx, include_attributes=True, iterative_json_parsing=True)
+
+        expected = {
+            'TM1py_Tests_Cell_Dimension1': {0: 'Element 1'},
+            'Attr1': {0: 'TM1py'},
+            'TM1py_Tests_Cell_Dimension2': {0: 'Element 1'},
+            'Attr2': {0: '2'},
+            'TM1py_Tests_Cell_Dimension3': {0: 'Element 1'},
+            'Attr3': {0: '3'},
+            'Value': {0: 1.0}}
+        self.assertEqual(expected, df.to_dict())
+
+    @skip_if_no_pandas
+    def test_execute_mdx_dataframe_include_attributes_iter_json_no_attributes(self):
+        mdx = """SELECT
+        {[TM1PY_TESTS_CELL_DIMENSION1].[TM1PY_TESTS_CELL_DIMENSION1].[Element2]} *
+        {[TM1PY_TESTS_CELL_DIMENSION2].[TM1PY_TESTS_CELL_DIMENSION2].[Element2]} *
+        {[TM1PY_TESTS_CELL_DIMENSION3].[TM1PY_TESTS_CELL_DIMENSION3].[Element2]} 
+         PROPERTIES MEMBER_NAME
+        ON 0
+        FROM [TM1PY_TESTS_CELL_CUBE]
+        """
+
+        df = self.tm1.cubes.cells.execute_mdx_dataframe(mdx, include_attributes=True, iterative_json_parsing=True)
+
+        expected = {
+            'TM1py_Tests_Cell_Dimension1': {0: 'Element 2'},
+            'TM1py_Tests_Cell_Dimension2': {0: 'Element 2'},
+            'TM1py_Tests_Cell_Dimension3': {0: 'Element 2'},
             'Value': {0: 1.0}}
         self.assertEqual(expected, df.to_dict())
 

--- a/Tests/CellService_test.py
+++ b/Tests/CellService_test.py
@@ -1892,12 +1892,12 @@ class TestCellService(unittest.TestCase):
         df = self.tm1.cubes.cells.execute_mdx_dataframe(mdx, include_attributes=True)
 
         expected = {
-            'TM1py_Tests_Cell_Dimension1': {0: 'Element 1'},
-            'Attr1': {0: 'TM1py'},
-            'TM1py_Tests_Cell_Dimension2': {0: 'Element 1'},
-            'Attr2': {0: '2'},
             'TM1py_Tests_Cell_Dimension3': {0: 'Element 1'},
             'Attr3': {0: '3'},
+            'TM1py_Tests_Cell_Dimension2': {0: 'Element 1'},
+            'Attr2': {0: '2'},
+            'TM1py_Tests_Cell_Dimension1': {0: 'Element 1'},
+            'Attr1': {0: 'TM1py'},
             'Value': {0: 1.0}}
         self.assertEqual(expected, df.to_dict())
 
@@ -1914,7 +1914,7 @@ class TestCellService(unittest.TestCase):
         FROM [TM1PY_TESTS_CELL_CUBE]
         """
 
-        df = self.tm1.cubes.cells.execute_mdx_dataframe(mdx, include_attributes=True, iterative_json_parsing=True)
+        df = self.tm1.cubes.cells.execute_mdx_dataframe(mdx, include_attributes=True, use_iterative_json=True)
 
         expected = {
             'TM1py_Tests_Cell_Dimension3': {0: 'Element 1'},
@@ -1938,7 +1938,7 @@ class TestCellService(unittest.TestCase):
         FROM [TM1PY_TESTS_CELL_CUBE]
         """
 
-        df = self.tm1.cubes.cells.execute_mdx_dataframe(mdx, include_attributes=True, iterative_json_parsing=True)
+        df = self.tm1.cubes.cells.execute_mdx_dataframe(mdx, include_attributes=True, use_iterative_json=True)
 
         expected = {
             'TM1py_Tests_Cell_Dimension1': {0: 'Element 1'},
@@ -1961,7 +1961,7 @@ class TestCellService(unittest.TestCase):
         FROM [TM1PY_TESTS_CELL_CUBE]
         """
 
-        df = self.tm1.cubes.cells.execute_mdx_dataframe(mdx, include_attributes=True, iterative_json_parsing=True)
+        df = self.tm1.cubes.cells.execute_mdx_dataframe(mdx, include_attributes=True, use_iterative_json=True)
 
         expected = {
             'TM1py_Tests_Cell_Dimension1': {0: 'Element 2'},


### PR DESCRIPTION
related to https://github.com/cubewise-code/tm1py/issues/604

This draft pull request attempts to resolve the current limitation of the `iterative_json_parsing` argument, that it can't be used in conjunction with `include_attributes` on the `execute_mdx_dataframe` function.
