### PR TITLE
Add `skip_non_updateable` arg to write function

### DIFF
--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -607,6 +607,14 @@ class CellService(ObjectService):
                 skip_non_updateable=skip_non_updateable,
                 **kwargs)
 
+        return self.write_through_cellset(cube_name, cellset_as_dict, dimensions, increment, deactivate_transaction_log,
+                                          reactivate_transaction_log, sandbox_name, use_changeset, skip_non_updateable,
+                                          **kwargs)
+
+    def write_through_cellset(self, cube_name: str, cellset_as_dict: Dict, dimensions: Iterable[str] = None,
+                              increment: bool = False, deactivate_transaction_log: bool = False,
+                              reactivate_transaction_log: bool = False, sandbox_name: str = None,
+                              use_changeset: bool = False, skip_non_updateable: bool = False, **kwargs) -> str:
         if not dimensions:
             dimensions = self.get_dimension_names_for_writing(cube_name=cube_name, **kwargs)
 
@@ -704,12 +712,11 @@ class CellService(ObjectService):
 
             comma_separated_elements = ",".join("'" + element.replace("'", "''") + "'" for element in coordinates)
 
+            cell_is_updateable_pre = ""
+            cell_is_updateable_post = ";"
             if skip_non_updateable:
                 cell_is_updateable_pre = f"IF(CellIsUpdateable('{cube_name}', {comma_separated_elements})=1,"
                 cell_is_updateable_post = ",0);"
-            else:
-                cell_is_updateable_pre = ""
-                cell_is_updateable_post = ";"
 
             statement = "".join([
                 cell_is_updateable_pre,

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -10,6 +10,7 @@ from enum import Enum, unique
 from typing import Any, Dict, List, Tuple, Iterable, Optional, Generator, Union
 
 import requests
+from mdxpy import MdxBuilder, Member
 
 from TM1py.Exceptions.Exceptions import TM1pyVersionException, TM1pyNotAdminException
 
@@ -1084,3 +1085,23 @@ def cell_is_updateable(cell: dict) -> bool:
     bit = extract_cell_updateable_property(cell["Updateable"], CellUpdateableProperty.CELL_IS_NOT_UPDATEABLE)
     updateable = not bit
     return updateable
+
+
+def build_mdx_from_cellset(cells: Dict, cube_name: str, dimensions: Iterable[str]) -> str:
+    query = MdxBuilder.from_cube(cube_name)
+    for coordinates in cells:
+        members = (Member.of(dimension, element) for dimension, element in zip(dimensions, coordinates))
+        query.add_member_tuple_to_columns(*members)
+    mdx = query.to_mdx()
+    return mdx
+
+
+def build_mdx_and_values_from_cellset(cells: Dict, cube_name: str, dimensions: Iterable[str]) -> Tuple[str, List]:
+    values = []
+    query = MdxBuilder.from_cube(cube_name)
+    for coordinates, value in cells.items():
+        members = (Member.of(dimension, element) for dimension, element in zip(dimensions, coordinates))
+        query.add_member_tuple_to_columns(*members)
+        values.append(value)
+    mdx = query.to_mdx()
+    return mdx, values


### PR DESCRIPTION
Handy new argument to skip cells that are not updateable.

Fixes #651