### PR TITLE
Cube and Process Search functions

### DIFF
--- a/TM1py/Services/CubeService.py
+++ b/TM1py/Services/CubeService.py
@@ -196,7 +196,6 @@ class CubeService(ObjectService):
         :param dimension_name: string, valid dimension name (case insensitive)
         :param model_cubes_only: bool, True will filter result to model cubes only
         """
-
         cube_prefix = 'Cubes' if model_cubes_only == False else 'ModelCubes()'
         url = format_url(
             "/api/v1/{}?$select=Name&$filter=Dimensions/any(d: toupper(d/Name) eq toupper('{}'))",
@@ -223,8 +222,7 @@ class CubeService(ObjectService):
         response = self._rest.GET(url, **kwargs)
         cube_dict = {entry['Name']:[dim['Name'] for dim in entry['Dimensions']] for entry in response.json()['value']}
         return cube_dict
-    
-    
+        
     @require_version(version="11.4")
     def get_storage_dimension_order(self, cube_name: str, **kwargs) -> List[str]:
         """ Get the storage dimension order of a cube

--- a/TM1py/Services/CubeService.py
+++ b/TM1py/Services/CubeService.py
@@ -189,14 +189,14 @@ class CubeService(ObjectService):
             return dimension_names[1:]
         return dimension_names
 
-    def get_names_with_dimension(self, dimension_name: str, model_cubes_only: bool = False,
+    def get_names_with_dimension(self, dimension_name: str, skip_control_cubes: bool = False,
                                  **kwargs) -> List[str]:
         """ Ask TM1 Server for list of cube names that contain specific dimension
 
         :param dimension_name: string, valid dimension name (case insensitive)
-        :param model_cubes_only: bool, True will filter result to model cubes only
+        :param skip_control_cubes: bool, True will exclude control cubes from result
         """
-        cube_prefix = 'Cubes' if model_cubes_only == False else 'ModelCubes()'
+        cube_prefix = 'Cubes' if skip_control_cubes == False else 'ModelCubes()'
         url = format_url(
             "/api/v1/{}?$select=Name&$filter=Dimensions/any(d: toupper(d/Name) eq toupper('{}'))",
             cube_prefix, dimension_name
@@ -206,14 +206,14 @@ class CubeService(ObjectService):
         return cubes
 
 
-    def get_names_with_dimension_wildcard(self, wildcard: str, model_cubes_only: bool = False,
+    def get_names_with_dimension_wildcard(self, wildcard: str, skip_control_cubes: bool = False,
                                           **kwargs) -> List[str]:
         """ Ask TM1 Server for list of cube names that contain dimension whose name contains wildcard
 
         :param wildcard: string, wildcard to search for in dim name
-        :param model_cubes_only: bool, True will filter result to model cubes only
+        :param skip_control_cubes: bool, True will exclude control cubes from result
         """
-        cube_prefix = 'Cubes' if model_cubes_only == False else 'ModelCubes()'
+        cube_prefix = 'Cubes' if skip_control_cubes == False else 'ModelCubes()'
         url = format_url(
             "/api/v1/{}?$select=Name&$filter=Dimensions/any(d: contains(toupper(d/Name),toupper('{}')))" \
             "&$expand=Dimensions($select=Name;$filter=contains(toupper(Name),toupper('{}')))",

--- a/TM1py/Services/ProcessService.py
+++ b/TM1py/Services/ProcessService.py
@@ -94,7 +94,6 @@ class ProcessService(ObjectService):
                          "or contains(toupper(EpilogProcedure),toupper('{}'))",
                          search_string, search_string, search_string, search_string
             )
-        
         response = self._rest.GET(url, **kwargs)
         processes = list(process['Name'] for process in response.json()['value'])
         return processes

--- a/TM1py/Services/ProcessService.py
+++ b/TM1py/Services/ProcessService.py
@@ -82,8 +82,9 @@ class ProcessService(ObjectService):
         processes = list(process['Name'] for process in response.json()['value'])
         return processes
 
-    def search_string_in_body(self, search_string: str, **kwargs) -> List[str]:
-        """ Ask TM1 Server for list of process names that contain string anywhere in body
+    def search_string_in_code(self, search_string: str, **kwargs) -> List[str]:
+        """ Ask TM1 Server for list of process names that contain string anywhere in code tabs: Prolog,Metadata,Data,Epilog
+        will not search DataSource, Parameters, Variables, or Attributes
 
         :param search_string: case insensitive string to search for
         """


### PR DESCRIPTION
**Process Search:** added 2 functions to search for string in process body and to search string in process name
_search_string_in_body_ will look for string anywhere in prolog, metadata, data epilog. UseCase: find TI process(es) that imports a csv file with name "x.csv"
_search_string_in_name_ will search for string anywhere in process name; two parameters: name_startswith and name_contains. name_contains can be an iterable list of strings to search with AND operator. UseCase: find TI process(es) that start with "Load" and have string "GL" anywhere in process name.

**Cube Search:** added 2 functions to find list of cubes that contain specified dimension or wildcard search on dimension name
_get_names_with_dimension_ will return list of cubes that contain specified dimension, optional parameter to return model cubes only. UseCase: find all cubes that use dimension "Account" , a dimension I'm planning a major reconstruction of
_get_names_with_dimension_wildcard_ will return dictionary of cubes that contain a dimension whose name contains a wildcard search criteria. The dimensions returned for a given cube in this function are only the dimensions that match the wildcard search criteria. UseCase: find all cubes that use dim that has the word "time" in its name so I can work on harmonizing them.