### PR TITLE
Add tests for new search functions

### DIFF
--- a/TM1py/Services/ProcessService.py
+++ b/TM1py/Services/ProcessService.py
@@ -120,15 +120,18 @@ class ProcessService(ObjectService):
         if name_contains:
             if isinstance(name_contains, str):
                 name_filters.append(format_url("contains(toupper(Name),toupper('{}'))", name_contains))
-            else:
+
+            elif isinstance(name_contains, Iterable):
                 name_contains_filters = [format_url("contains(toupper(Name),toupper('{}'))", wildcard)
                                          for wildcard in name_contains]
                 name_filters.append("({})".format(f" {name_contains_operator} ".join(name_contains_filters)))
 
-        url += "&$filter={}".format(" and ".join(name_filters))
+            else:
+                raise ValueError("'name_contains' must be str or iterable")
+
+        url += "&$filter={}".format(f" and ".join(name_filters))
         response = self._rest.GET(url, **kwargs)
-        processes = list(process['Name'] for process in response.json()['value'])
-        return processes
+        return list(process['Name'] for process in response.json()['value'])
     
     def create(self, process: Process, **kwargs) -> Response:
         """ Create a new process on TM1 Server

--- a/Tests/CubeService_test.py
+++ b/Tests/CubeService_test.py
@@ -140,6 +140,46 @@ class TestCubeService(unittest.TestCase):
         dimensions = self.tm1.cubes.get_storage_dimension_order(cube_name=self.cube_name)
         self.assertEqual(dimensions, self.dimension_names)
 
+    def test_search_for_dimension_happy_case(self):
+        cube_names = self.tm1.cubes.search_for_dimension(self.dimension_names[0])
+        self.assertEqual([self.cube_name], cube_names)
+
+    def test_search_for_dimension_no_match(self):
+        cube_names = self.tm1.cubes.search_for_dimension("NotADimensionName")
+        self.assertEqual([], cube_names)
+
+    def test_search_for_dimension_case_insensitive(self):
+        cube_names = self.tm1.cubes.search_for_dimension(self.dimension_names[1].upper())
+        self.assertEqual([self.cube_name], cube_names)
+
+    def test_search_for_dimension_space_insensitive(self):
+        cube_names = self.tm1.cubes.search_for_dimension(" " + self.dimension_names[2] + " ")
+        self.assertEqual([self.cube_name], cube_names)
+
+    def test_search_for_dimension_substring_happy_case(self):
+        cubes = self.tm1.cubes.search_for_dimension_substring(substring=self.dimension_names[0])
+        self.assertEqual({self.cube_name: [self.dimension_names[0]]}, cubes)
+
+    def test_search_for_dimension_substring_case_insensitive(self):
+        cubes = self.tm1.cubes.search_for_dimension_substring(substring=self.dimension_names[1].upper())
+        self.assertEqual({self.cube_name: [self.dimension_names[1]]}, cubes)
+
+    def test_search_for_dimension_substring_space_insensitive(self):
+        cubes = self.tm1.cubes.search_for_dimension_substring(substring=" " + self.dimension_names[2] + " ")
+        self.assertEqual({self.cube_name: [self.dimension_names[2]]}, cubes)
+
+    def test_search_for_dimension_substring_no_match(self):
+        cubes = self.tm1.cubes.search_for_dimension_substring(substring="NotADimensionName")
+        self.assertEqual({}, cubes)
+
+    def test_search_for_dimension_substring_skip_control_cubes_true(self):
+        cubes = self.tm1.cubes.search_for_dimension_substring(substring="}cubes", skip_control_cubes=True)
+        self.assertEqual({}, cubes)
+
+    def test_search_for_dimension_substring_skip_control_cubes_false(self):
+        cubes = self.tm1.cubes.search_for_dimension_substring(substring="}cubes", skip_control_cubes=False)
+        self.assertEqual(cubes['}CubeProperties'], ['}Cubes'])
+
     def test_get_number_of_cubes(self):
         number_of_cubes = self.tm1.cubes.get_number_of_cubes()
         self.assertIsInstance(number_of_cubes, int)

--- a/Tests/ProcessService_test.py
+++ b/Tests/ProcessService_test.py
@@ -374,6 +374,32 @@ class TestProcessService(unittest.TestCase):
             self.tm1.processes.create(process)
         self.tm1.processes.delete(process.name)
 
+    def test_search_string_in_name_no_match_startswith(self):
+        process_names = self.tm1.processes.search_string_in_name(
+            name_startswith="NotAProcessName")
+        self.assertEqual([], process_names)
+
+    def test_search_string_in_name_no_match_contains(self):
+        process_names = self.tm1.processes.search_string_in_name(
+            name_contains="NotAProcessName")
+        self.assertEqual([], process_names)
+
+    def test_search_string_in_name_startswith_happy_case(self):
+        process_names = self.tm1.processes.search_string_in_name(name_startswith=self.p_ascii.name)
+        self.assertEqual([self.p_ascii.name], process_names)
+
+    def test_search_string_in_name_contains_happy_case(self):
+        process_names = self.tm1.processes.search_string_in_name(name_contains=self.p_ascii.name)
+        self.assertEqual([self.p_ascii.name], process_names)
+
+    def test_search_string_in_name_contains_multiple(self):
+        process_names = self.tm1.processes.search_string_in_name(name_contains=self.p_ascii.name.split("_"))
+        self.assertEqual([self.p_ascii.name], process_names)
+
+    def test_search_string_in_code(self):
+        process_names = self.tm1.processes.search_string_in_code("sTestProlog = 'test prolog procedure'")
+        self.assertEqual([self.p_ascii.name], process_names)
+
     @classmethod
     def tearDownClass(cls):
         cls.tm1.dimensions.subsets.delete(


### PR DESCRIPTION
Align search function names. Always prefix with `search_`

Successor of #658