### PR TITLE
Introduce `Tm1LogHandler` class 

### DIFF
--- a/TM1py/Services/ServerService.py
+++ b/TM1py/Services/ServerService.py
@@ -172,7 +172,7 @@ class ServerService(ObjectService):
 
         from TM1py.Services import ProcessService
         process_service = ProcessService(self._rest)
-        process = Process(name="", prolog_procedure="LogOutput('{}', '{}');".format(level, message))
+        process = Process(name="", prolog_procedure="LogOutput('{}', '{}');".format(level, message.replace("'", "''")))
         success, status, _ = process_service.execute_process_with_return(process, **kwargs)
 
         if not success:


### PR DESCRIPTION
Allow easy logging to TM1 Message Log with the standard python logging framework.

Sample:

``` python
import logging
import sys
from pathlib import Path

from TM1py import TM1Service
from TM1py.Utils import Tm1LogHandler


def configure_logging():
    log_file = Path(__file__).parent.joinpath(Path("simple_script.log"))

    logging.basicConfig(
        filename=str(log_file),
        format="%(asctime)s - %(levelname)s - %(message)s",
        level=logging.INFO,
    )
    # also log to stdout
    logging.getLogger().addHandler(logging.StreamHandler(sys.stdout))


def add_tm1_logger(tm1: TM1Service):
    tm1_handler = Tm1LogHandler(tm1)

    tm1_handler.setLevel(logging.INFO)

    logging.getLogger().addHandler(tm1_handler)


if __name__ == "__main__":
    configure_logging()
    logging.info(f"Starting script: {__file__}")

    with TM1Service(base_url="https://localhost:12354", user="admin", password="apple") as tm1:
        add_tm1_logger(tm1)

        logging.info(f"Successfully connected to '{tm1.server.get_server_name()}' running version '{tm1.version}'")

```

