### PR TITLE
Support TM1 12 in IBM cloud

### DIFF
--- a/TM1py/Services/RestService.py
+++ b/TM1py/Services/RestService.py
@@ -10,6 +10,7 @@ from typing import Union, Dict, Tuple, Optional
 
 import requests
 import urllib3
+from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
 from requests import Timeout, Response, ConnectionError
 from requests.adapters import HTTPAdapter
 
@@ -131,6 +132,7 @@ class RestService:
         :param namespace String - optional CAM namespace
         :param ssl: boolean -  as specified in the tm1s.cfg
         :param cam_passport: String - the cam passport
+        :param paw_api_key: Use in combination with base_url to authenticate with TM1 12 in IBM cloud
         :param session_id: String - TM1SessionId e.g. q7O6e1w49AixeuLVxJ1GZg
         :param session_context: String - Name of the Application. Controls "Context" column in Arc / TM1top.
         If None, use default: TM1py
@@ -195,7 +197,8 @@ class RestService:
         self.disable_http_warnings()
         # re-use or create tm1 http session
         self._s = requests.session()
-        if "session_id" in kwargs:
+
+        if 'session_id' in kwargs:
             self._s.cookies.set("TM1SessionId", kwargs["session_id"])
         else:
             self._start_session(
@@ -204,6 +207,7 @@ class RestService:
                 namespace=kwargs.get("namespace", None),
                 gateway=kwargs.get("gateway", None),
                 cam_passport=kwargs.get("cam_passport", None),
+                paw_api_key=kwargs.get("paw_api_key", None),
                 decode_b64=self.translate_to_boolean(kwargs.get("decode_b64", False)),
                 integrated_login=self.translate_to_boolean(kwargs.get("integrated_login", False)),
                 integrated_login_domain=kwargs.get("integrated_login_domain"),
@@ -334,12 +338,13 @@ class RestService:
             self._s.close()
 
     def _start_session(self, user: str, password: str, decode_b64: bool = False, namespace: str = None,
-                       gateway: str = None, cam_passport: str = None, integrated_login: bool = None,
-                       integrated_login_domain: str = None, integrated_login_service: str = None,
-                       integrated_login_host: str = None, integrated_login_delegate: bool = None,
-                       impersonate: str = None):
+                       gateway: str = None, cam_passport: str = None, paw_api_key: str = None,
+                       integrated_login: bool = None, integrated_login_domain: str = None,
+                       integrated_login_service: str = None, integrated_login_host: str = None,
+                       integrated_login_delegate: bool = None, impersonate: str = None):
         """ perform a simple GET request (Ask for the TM1 Version) to start a session
         """
+
         # Authorization with integrated_login
         if integrated_login:
             self._s.auth = HttpNegotiateAuth(
@@ -356,6 +361,7 @@ class RestService:
                 namespace,
                 gateway,
                 cam_passport,
+                paw_api_key,
                 self._verify)
             self.add_http_header('Authorization', token)
 
@@ -463,15 +469,23 @@ class RestService:
 
     @staticmethod
     def _build_authorization_token(user: str, password: str, namespace: str = None, gateway: str = None,
-                                   cam_passport: str = None, verify: bool = False) -> str:
-        """ Build the Authorization Header for CAM and Native Security
+                                   cam_passport: str = None, paw_api_key: str = None, verify: bool = False) -> str:
+        """ Build the required Authorization Header for each authentication type
+
         """
         if cam_passport:
             return 'CAMPassport ' + cam_passport
+        elif paw_api_key:
+            return 'Bearer ' + RestService._build_authorization_token_ibm_cloud_iam(paw_api_key)
         elif namespace:
             return RestService._build_authorization_token_cam(user, password, namespace, gateway, verify)
         else:
             return RestService._build_authorization_token_basic(user, password)
+
+    @staticmethod
+    def _build_authorization_token_ibm_cloud_iam(paw_api_key: str = None):
+        authenticator = IAMAuthenticator(paw_api_key)
+        return authenticator.token_manager.get_token()
 
     @staticmethod
     def _build_authorization_token_cam(user: str = None, password: str = None, namespace: str = None,

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -12,6 +12,7 @@ from io import StringIO
 from typing import Any, Dict, List, Tuple, Iterable, Optional, Generator, Union
 
 import requests
+from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
 from mdxpy import MdxBuilder, Member
 
 from TM1py.Exceptions.Exceptions import TM1pyVersionException, TM1pyNotAdminException
@@ -1128,3 +1129,16 @@ def build_mdx_and_values_from_cellset(cells: Dict, cube_name: str, dimensions: I
         values.append(value)
     mdx = query.to_mdx()
     return mdx, values
+
+
+def get_servers_from_ibm_cloud(base_url: str, paw_api_key: str) -> List[Dict]:
+    """
+    :param base_url: e.g., https://eu-de.planning-analytics.cloud.ibm.com/api/P7NG815TNO4P/v0/tm1/
+    :param paw_api_key: PAW API Key from IBM Cloud
+    """
+    authenticator = IAMAuthenticator(paw_api_key)
+    auth_token = "Bearer " + authenticator.token_manager.get_token()
+    url = base_url.rstrip('/') + "/Servers"
+    response = requests.get(url, headers={"Authorization": auth_token})
+
+    return response.json()['value']

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-SCHEDULE_VERSION = '1.9.0'
+SCHEDULE_VERSION = '2.0.0'
 SCHEDULE_DOWNLOAD_URL = (
         'https://github.com/Cubewise-code/TM1py/tarball/' + SCHEDULE_VERSION
 )
@@ -38,7 +38,8 @@ setup(
         'requests',
         'pytz',
         'requests_negotiate_sspi;platform_system=="Windows"',
-        'mdxpy'],
+        'mdxpy',
+        'ibm-cloud-sdk-core'],
     extras_require={
         "pandas": ["pandas"]
     },


### PR DESCRIPTION
new arg for `TM1Service`, `RestService`: `paw_api_key`.
`paw_api_key` and `base_url` allow connection to TM1 12 in IBM cloud

``` python
with TM1Service(
        base_url="https://eu-de.planning-analytics.cloud.ibm.com/api/Q9NT819TNO2C/v0/tm1/24Retail",
        paw_api_key=PAW_API_KEY) as tm1:

    cube_names = tm1.cubes.get_all_names()
    print(cube_names[0])
```