### PR TITLE
Search cube rules function

### DIFF
--- a/TM1py/Services/CubeService.py
+++ b/TM1py/Services/CubeService.py
@@ -224,6 +224,19 @@ class CubeService(ObjectService):
         response = self._rest.GET(url, **kwargs)
         cube_dict = {entry['Name']: [dim['Name'] for dim in entry['Dimensions']] for entry in response.json()['value']}
         return cube_dict
+    
+    def search_for_rule_substring(self, rule_contains: str, skip_control_cubes: bool = False, **kwargs) -> List[Cube]:
+        """ get all cubes from TM1 Server as TM1py.Cube instances where rules for given cube contain specified substring
+
+        :return: List of TM1py.Cube instances
+        """
+        url = format_url(
+            "/api/v1/{}?$filter=Rules ne null and contains(toupper(Rules),toupper('{}'))&$expand=Dimensions($select=Name)",
+            'ModelCubes()' if skip_control_cubes else 'Cubes', rule_contains
+        )
+        response = self._rest.GET(url, **kwargs)
+        cubes = [Cube.from_dict(cube_as_dict=cube) for cube in response.json()['value']]
+        return cubes    
 
     @require_version(version="11.4")
     def get_storage_dimension_order(self, cube_name: str, **kwargs) -> List[str]:

--- a/TM1py/Services/CubeService.py
+++ b/TM1py/Services/CubeService.py
@@ -225,18 +225,20 @@ class CubeService(ObjectService):
         cube_dict = {entry['Name']: [dim['Name'] for dim in entry['Dimensions']] for entry in response.json()['value']}
         return cube_dict
     
-    def search_for_rule_substring(self, rule_contains: str, skip_control_cubes: bool = False, **kwargs) -> List[Cube]:
+    def search_for_rule_substring(self, substring: str, skip_control_cubes: bool = False, **kwargs) -> List[Cube]:
         """ get all cubes from TM1 Server as TM1py.Cube instances where rules for given cube contain specified substring
 
+        :param substring: string to search for in rules
+        :param skip_control_cubes: bool, True will exclude control cubes from result
         :return: List of TM1py.Cube instances
         """
         url = format_url(
             "/api/v1/{}?$filter=Rules ne null and contains(toupper(Rules),toupper('{}'))&$expand=Dimensions($select=Name)",
-            'ModelCubes()' if skip_control_cubes else 'Cubes', rule_contains
+            'ModelCubes()' if skip_control_cubes else 'Cubes', substring
         )
         response = self._rest.GET(url, **kwargs)
         cubes = [Cube.from_dict(cube_as_dict=cube) for cube in response.json()['value']]
-        return cubes    
+        return cubes   
 
     @require_version(version="11.4")
     def get_storage_dimension_order(self, cube_name: str, **kwargs) -> List[str]:

--- a/Tests/CubeService_test.py
+++ b/Tests/CubeService_test.py
@@ -224,6 +224,34 @@ class TestCubeService(unittest.TestCase):
 
         errors = self.tm1.cubes.check_rules(cube_name=self.cube_name)
         self.assertEqual(1, len(errors))
+        
+    def test_search_for_rule_substring_no_match(self):
+        cubes = self.tm1.cubes.search_for_rule_substring(substring:"find_nothing")
+        self.assertEqual(0, len(cubes))
+
+    def test_search_for_rule_substring_happy_case(self):
+        cube = self.tm1.cubes.get(cube_name=self.cube_name)
+        cube.rules = "#find_me_comment"
+        self.tm1.cubes.update(cube)
+
+        cubes = self.tm1.cubes.search_for_rule_substring(substring:"find_me_comment")
+        self.assertEqual(cube_name, cubes[0].name)
+
+    def test_search_for_rule_substring_skip_control_cubes_false(self):
+        cube = self.tm1.cubes.get_control_cubes()[0]
+        cube.rules = "#find_control_comment"
+        self.tm1.cubes.update(cube)
+
+        cubes = self.tm1.cubes.search_for_rule_substring(substring:"find_control_comment", skip_control_cubes=False)
+        self.assertEqual(cube_name, cubes[0].name)
+
+    def test_search_for_rule_substring_skip_control_cubes_true(self):
+        cube = self.tm1.cubes.get_control_cubes()[0]
+        cube.rules = "#find_control_comment"
+        self.tm1.cubes.update(cube)
+
+        cubes = self.tm1.cubes.search_for_rule_substring(substring:"find_control_comment", skip_control_cubes=True)
+        self.assertEqual(0, len(cubes))        
 
     def test_get_measure_dimension(self):
         measure_dimension = self.tm1.cubes.get_measure_dimension(self.cube_name)


### PR DESCRIPTION
Adding function to search rules of cube for substring. Similar to prior work searching TI process for substring or searching cubes with dim or dim substring. The function will return list of Cube objects, including full rules file. I debated only returning matching rule lines, but thought that might be dangerous if someone were to inadvertently update a cubes rules with only the matched lines. The function includes the parameter "skip_control_cubes" similar to the other search functions.

