### PR TITLE
Cube Rule search function and new skip_control parameters

### DIFF
--- a/TM1py/Services/CubeService.py
+++ b/TM1py/Services/CubeService.py
@@ -84,11 +84,19 @@ class CubeService(ObjectService):
         cubes = [Cube.from_dict(cube_as_dict=cube) for cube in response.json()['value']]
         return cubes
 
-    def get_number_of_cubes(self, **kwargs) -> int:
-        url = format_url(
-            "/api/v1/Cubes/$count")
-        response = self._rest.GET(url, **kwargs)
-        return int(response.text)
+    def get_number_of_cubes(self, skip_control_cubes: bool = False, **kwargs) -> int:
+        """ Ask TM1 Server for count of cubes
+
+        :skip_control_cubes: bool, True will exclude control cubes from count
+        :return: int, count
+        """ 
+        if skip_control_cubes:
+            response = len(self.get_all_names(skip_control_cubes=True, **kwargs))
+        else:
+            response = int(self._rest.GET(url=format_url("/api/v1/Cubes/$count"), **kwargs).text)
+    
+        return response
+
 
     def get_measure_dimension(self, cube_name: str, **kwargs) -> str:
         url = format_url(
@@ -148,30 +156,48 @@ class CubeService(ObjectService):
         url = format_url("/api/v1/Cubes('{}')", cube_name)
         return self._exists(url, **kwargs)
 
-    def get_all_names(self, **kwargs) -> List[str]:
+    def get_all_names(self, skip_control_cubes: bool = False, **kwargs) -> List[str]:
         """ Ask TM1 Server for list of all cube names
-
+        
+        :skip_control_cubes: bool, True will exclude control cubes from list
         :return: List of Strings
         """
-        response = self._rest.GET(url='/api/v1/Cubes?$select=Name', **kwargs)
+        url = format_url(
+                "/api/v1/{}?$select=Name",
+                'ModelCubes()' if skip_control_cubes else 'Cubes'
+        )
+
+        response = self._rest.GET(url, **kwargs)
         cubes = list(entry['Name'] for entry in response.json()['value'])
         return cubes
 
-    def get_all_names_with_rules(self, **kwargs) -> List[str]:
+    def get_all_names_with_rules(self, skip_control_cubes: bool = False, **kwargs) -> List[str]:
         """ Ask TM1 Server for list of all cube names that have rules
-
+        
+        :skip_control_cubes: bool, True will exclude control cubes from list
         :return: List of Strings
         """
-        response = self._rest.GET(url="/api/v1/Cubes?$select=Name,Rules&$filter=Rules ne null", **kwargs)
+        url = format_url(
+                "/api/v1/{}?$select=Name,Rules&$filter=Rules ne null",
+                'ModelCubes()' if skip_control_cubes else 'Cubes'
+        )
+
+        response = self._rest.GET(url, **kwargs)
         cubes = list(cube['Name'] for cube in response.json()['value'])
         return cubes
 
-    def get_all_names_without_rules(self, **kwargs) -> List[str]:
+    def get_all_names_without_rules(self, skip_control_cubes: bool = False, **kwargs) -> List[str]:
         """ Ask TM1 Server for list of all cube names that do not have rules
-
+        :skip_control_cubes: bool, True will exclude control cubes from list
         :return: List of Strings
         """
-        response = self._rest.GET(url="/api/v1/Cubes?$select=Name,Rules&$filter=Rules eq null", **kwargs)
+
+        url = format_url(
+                "/api/v1/{}?$select=Name,Rules&$filter=Rules eq null",
+                'ModelCubes()' if skip_control_cubes else 'Cubes'
+        )
+
+        response = self._rest.GET(url, **kwargs)
         cubes = list(cube['Name'] for cube in response.json()['value'])
         return cubes
 

--- a/TM1py/Services/CubeService.py
+++ b/TM1py/Services/CubeService.py
@@ -91,7 +91,7 @@ class CubeService(ObjectService):
         :return: int, count
         """ 
         if skip_control_cubes:
-            response = len(self.get_all_names(skip_control_cubes=True, **kwargs))
+            response = int(self._rest.GET(url=format_url("/api/v1/ModelCubes()?$select=Name&$count"), **kwargs).json()['@odata.count'])
         else:
             response = int(self._rest.GET(url=format_url("/api/v1/Cubes/$count"), **kwargs).text)
     

--- a/TM1py/Services/CubeService.py
+++ b/TM1py/Services/CubeService.py
@@ -224,6 +224,19 @@ class CubeService(ObjectService):
         response = self._rest.GET(url, **kwargs)
         cube_dict = {entry['Name']: [dim['Name'] for dim in entry['Dimensions']] for entry in response.json()['value']}
         return cube_dict
+    
+    def search_for_rule_substring(self, rule_contains: str, skip_control_cubes: bool = False, **kwargs) -> List[Cube]:
+        """ get all cubes from TM1 Server as TM1py.Cube instances where rules for given cube contain specified substring
+
+        :return: List of TM1py.Cube instances
+        """
+        url = format_url(
+            "/api/v1/{}?$filter=Rules ne null and contains(toupper(Rules),toupper('{}'))&$expand=Dimensions($select=Name)",
+            'ModelCubes()' if skip_control_cubes else 'Cubes', rule_contains
+        )
+        response = self._rest.GET(url, **kwargs)
+        cubes = [Cube.from_dict(cube_as_dict=cube) for cube in response.json()['value']]
+        return cubes    
 
     @require_version(version="11.4")
     def get_storage_dimension_order(self, cube_name: str, **kwargs) -> List[str]:

--- a/TM1py/Services/CubeService.py
+++ b/TM1py/Services/CubeService.py
@@ -225,18 +225,20 @@ class CubeService(ObjectService):
         cube_dict = {entry['Name']: [dim['Name'] for dim in entry['Dimensions']] for entry in response.json()['value']}
         return cube_dict
     
-    def search_for_rule_substring(self, rule_contains: str, skip_control_cubes: bool = False, **kwargs) -> List[Cube]:
+    def search_for_rule_substring(self, substring: str, skip_control_cubes: bool = False, **kwargs) -> List[Cube]:
         """ get all cubes from TM1 Server as TM1py.Cube instances where rules for given cube contain specified substring
 
+        :param substring: string to search for in rules
+        :param skip_control_cubes: bool, True will exclude control cubes from result
         :return: List of TM1py.Cube instances
         """
         url = format_url(
             "/api/v1/{}?$filter=Rules ne null and contains(toupper(Rules),toupper('{}'))&$expand=Dimensions($select=Name)",
-            'ModelCubes()' if skip_control_cubes else 'Cubes', rule_contains
+            'ModelCubes()' if skip_control_cubes else 'Cubes', substring
         )
         response = self._rest.GET(url, **kwargs)
         cubes = [Cube.from_dict(cube_as_dict=cube) for cube in response.json()['value']]
-        return cubes    
+        return cubes   
 
     @require_version(version="11.4")
     def get_storage_dimension_order(self, cube_name: str, **kwargs) -> List[str]:

--- a/TM1py/Services/DimensionService.py
+++ b/TM1py/Services/DimensionService.py
@@ -153,7 +153,7 @@ class DimensionService(ObjectService):
         """
 
         if skip_control_dims:
-            response = len(self.get_all_names(skip_control_dims=True, **kwargs))
+            response = int(self._rest.GET("/api/v1/ModelDimensions()?$select=Name&$count", **kwargs).json()['@odata.count'])
         else:
             response = int(self._rest.GET("/api/v1/Dimensions/$count", **kwargs).text)
         

--- a/TM1py/Services/ProcessService.py
+++ b/TM1py/Services/ProcessService.py
@@ -104,7 +104,8 @@ class ProcessService(ObjectService):
                          "or contains(toupper(DataProcedure),toupper('{}')) " \
                          "or contains(toupper(EpilogProcedure),toupper('{}'))",
                          search_string, search_string, search_string, search_string
-            ) + "{}".format(model_process_filter if skip_control_processes else "")
+            )
+        url += "{}".format(model_process_filter if skip_control_processes else "")
         response = self._rest.GET(url, **kwargs)
         processes = list(process['Name'] for process in response.json()['value'])
         return processes

--- a/TM1py/Services/ProcessService.py
+++ b/TM1py/Services/ProcessService.py
@@ -90,19 +90,21 @@ class ProcessService(ObjectService):
         processes = list(process['Name'] for process in response.json()['value'])
         return processes
 
-    def search_string_in_code(self, search_string: str, **kwargs) -> List[str]:
+    def search_string_in_code(self, search_string: str, skip_control_processes: bool=False, **kwargs) -> List[str]:
         """ Ask TM1 Server for list of process names that contain string anywhere in code tabs: Prolog,Metadata,Data,Epilog
         will not search DataSource, Parameters, Variables, or Attributes
 
-        :param search_string: case insensitive string to search for
+        :param skip_control_processes: bool, True to exclude processes that begin with "}" or "{"
+        :param skip_control_processe
         """
+        model_process_filter = "&$filter=startswith(Name,'}') eq false and startswith(Name,'{') eq false"
         url = format_url("/api/v1/Processes?$select=Name&$filter=" \
                          "contains(toupper(PrologProcedure),toupper('{}')) " \
                          "or contains(toupper(MetadataProcedure),toupper('{}')) " \
                          "or contains(toupper(DataProcedure),toupper('{}')) " \
                          "or contains(toupper(EpilogProcedure),toupper('{}'))",
                          search_string, search_string, search_string, search_string
-            )
+            ) + "{}".format(model_process_filter if skip_control_processes else "")
         response = self._rest.GET(url, **kwargs)
         processes = list(process['Name'] for process in response.json()['value'])
         return processes

--- a/TM1py/Services/ProcessService.py
+++ b/TM1py/Services/ProcessService.py
@@ -48,11 +48,14 @@ class ProcessService(ObjectService):
         response = self._rest.GET(url, **kwargs)
         return Process.from_dict(response.json())
 
-    def get_all(self, **kwargs) -> List[Process]:
+    def get_all(self, skip_control_processes: bool = False, **kwargs) -> List[Process]:
         """ Get a processes from TM1 Server
     
+        :skip_control_processes: bool, True to exclude processes that begin with "}" or "{"
         :return: List, instances of the TM1py.Process
         """
+        model_process_filter = "&$filter=startswith(Name,'}') eq false and startswith(Name,'{') eq false"
+
         url = "/api/v1/Processes?$select=*,UIData,VariablesUIData," \
               "DataSource/dataSourceNameForServer," \
               "DataSource/dataSourceNameForClient," \
@@ -67,7 +70,8 @@ class ProcessService(ObjectService):
               "DataSource/userName," \
               "DataSource/password," \
               "DataSource/usesUnicode," \
-              "DataSource/subset"
+              "DataSource/subset{}".format(model_process_filter if skip_control_processes else "")
+
         response = self._rest.GET(url, **kwargs)
         response_as_dict = response.json()
         return [Process.from_dict(p) for p in response_as_dict['value']]

--- a/TM1py/Services/ProcessService.py
+++ b/TM1py/Services/ProcessService.py
@@ -51,7 +51,7 @@ class ProcessService(ObjectService):
     def get_all(self, skip_control_processes: bool = False, **kwargs) -> List[Process]:
         """ Get a processes from TM1 Server
     
-        :skip_control_processes: bool, True to exclude processes that begin with "}" or "{"
+        :param skip_control_processes: bool, True to exclude processes that begin with "}" or "{"
         :return: List, instances of the TM1py.Process
         """
         model_process_filter = "&$filter=startswith(Name,'}') eq false and startswith(Name,'{') eq false"
@@ -79,7 +79,7 @@ class ProcessService(ObjectService):
     def get_all_names(self, skip_control_processes: bool = False, **kwargs) -> List[str]:
         """ Get List with all process names from TM1 Server
         
-        :skip_control_processes: bool, True to exclude processes that begin with "}" or "{"
+        :param skip_control_processes: bool, True to exclude processes that begin with "}" or "{"
         :Returns:
             List of Strings
         """

--- a/TM1py/Services/ProcessService.py
+++ b/TM1py/Services/ProcessService.py
@@ -94,8 +94,10 @@ class ProcessService(ObjectService):
         """ Ask TM1 Server for list of process names that contain string anywhere in code tabs: Prolog,Metadata,Data,Epilog
         will not search DataSource, Parameters, Variables, or Attributes
 
+        :param search_string: case insensitive string to search for
         :param skip_control_processes: bool, True to exclude processes that begin with "}" or "{"
-        :param skip_control_processe
+        :Returns:
+            List of strings
         """
         model_process_filter = "and (startswith(Name,'}') eq false and startswith(Name,'{') eq false)"
         url = format_url("/api/v1/Processes?$select=Name&$filter=" \

--- a/TM1py/Services/ProcessService.py
+++ b/TM1py/Services/ProcessService.py
@@ -72,13 +72,17 @@ class ProcessService(ObjectService):
         response_as_dict = response.json()
         return [Process.from_dict(p) for p in response_as_dict['value']]
 
-    def get_all_names(self, **kwargs) -> List[str]:
+    def get_all_names(self, skip_control_processes: bool = False, **kwargs) -> List[str]:
         """ Get List with all process names from TM1 Server
-
+        
+        :skip_control_processes: bool, True to exclude processes that begin with "}" or "{"
         :Returns:
             List of Strings
         """
-        response = self._rest.GET('/api/v1/Processes?$select=Name', **kwargs)
+        model_process_filter = "&$filter=startswith(Name,'}') eq false and startswith(Name,'{') eq false"
+        url = "/api/v1/Processes?$select=Name{}".format(model_process_filter if skip_control_processes else "")
+        
+        response = self._rest.GET(url, **kwargs)
         processes = list(process['Name'] for process in response.json()['value'])
         return processes
 

--- a/TM1py/Services/ProcessService.py
+++ b/TM1py/Services/ProcessService.py
@@ -97,7 +97,7 @@ class ProcessService(ObjectService):
         :param skip_control_processes: bool, True to exclude processes that begin with "}" or "{"
         :param skip_control_processe
         """
-        model_process_filter = "&$filter=startswith(Name,'}') eq false and startswith(Name,'{') eq false"
+        model_process_filter = "and (startswith(Name,'}') eq false and startswith(Name,'{') eq false)"
         url = format_url("/api/v1/Processes?$select=Name&$filter=" \
                          "contains(toupper(PrologProcedure),toupper('{}')) " \
                          "or contains(toupper(MetadataProcedure),toupper('{}')) " \
@@ -430,3 +430,4 @@ class ProcessService(ObjectService):
         response = self._rest.GET(url, **kwargs)
 
         return response.json()
+    

--- a/Tests/CubeService_test.py
+++ b/Tests/CubeService_test.py
@@ -15,6 +15,7 @@ class TestCubeService(unittest.TestCase):
     prefix = "TM1py_Tests_Cube_"
 
     cube_name = prefix + "some_name"
+    control_cube_name = '}' + prefix + 'some_control_cube_name'
     dimension_names = [
         prefix + "dimension1",
         prefix + "dimension2",
@@ -42,6 +43,15 @@ class TestCubeService(unittest.TestCase):
         if not cls.tm1.cubes.exists(cls.cube_name):
             cls.tm1.cubes.create(cube)
         c = Cube(cls.cube_name, dimensions=cls.dimension_names, rules=Rules(''))
+        if cls.tm1.cubes.exists(c.name):
+            cls.tm1.cubes.delete(c.name)
+        cls.tm1.cubes.create(c)
+
+        # Build Control Cube
+        control_cube = Cube(cls.control_cube_name, cls.dimension_names)
+        if not cls.tm1.cubes.exists(cls.control_cube_name):
+            cls.tm1.cubes.create(control_cube)
+        c = Cube(cls.control_cube_name, dimensions=cls.dimension_names, rules=Rules(''))
         if cls.tm1.cubes.exists(c.name):
             cls.tm1.cubes.delete(c.name)
         cls.tm1.cubes.create(c)
@@ -137,7 +147,7 @@ class TestCubeService(unittest.TestCase):
 
         self.tm1.cubes.delete(cube_name)
 
-        cube = self.tm1.cubes.get_control_cubes()[0]
+        cube = self.tm1.cubes.get(self.control_cube_name)
         cube.rules = "#find_control_comment"
         self.tm1.cubes.update(cube)
         self.assertNotEqual(self.tm1.cubes.get_all_names_with_rules(), self.tm1.cubes.get_all_names_with_rules(skip_control_cubes=True))
@@ -246,7 +256,7 @@ class TestCubeService(unittest.TestCase):
         self.assertEqual(cube_name, cubes[0].name)
 
     def test_search_for_rule_substring_skip_control_cubes_false(self):
-        cube = self.tm1.cubes.get_control_cubes()[0]
+        cube = self.tm1.cubes.get(self.control_cube_name)
         cube.rules = "#find_control_comment"
         self.tm1.cubes.update(cube)
 
@@ -254,7 +264,7 @@ class TestCubeService(unittest.TestCase):
         self.assertEqual(cube_name, cubes[0].name)
 
     def test_search_for_rule_substring_skip_control_cubes_true(self):
-        cube = self.tm1.cubes.get_control_cubes()[0]
+        cube = self.tm1.cubes.get(self.control_cube_name)
         cube.rules = "#find_control_comment"
         self.tm1.cubes.update(cube)
 

--- a/Tests/CubeService_test.py
+++ b/Tests/CubeService_test.py
@@ -121,6 +121,8 @@ class TestCubeService(unittest.TestCase):
 
         self.assertEqual(len(all_cubes_before), len(cubes_with_rules) + len(cubes_without_rules))
 
+        self.assertNotEqual(len(self.tm1.cubes.get_all_names()), len(self.tm1.cubes.get_all_names(skip_control_cubes=True)))
+
         cube_name = self.prefix + "Some_Other_Name"
         dimension_names = self.tm1.dimensions.get_all_names()[1:3]
         cube = Cube(cube_name, dimension_names)
@@ -134,6 +136,12 @@ class TestCubeService(unittest.TestCase):
         self.assertEqual(len(cubes_without_rules), len(self.tm1.cubes.get_all_names_without_rules()))
 
         self.tm1.cubes.delete(cube_name)
+
+        cube = self.tm1.cubes.get_control_cubes()[0]
+        cube.rules = "#find_control_comment"
+        self.tm1.cubes.update(cube)
+        self.assertNotEqual(self.tm1.cubes.get_all_names_with_rules(), self.tm1.cubes.get_all_names_with_rules(skip_control_cubes=True))
+        self.assertNotEqual(self.tm1.cubes.get_all_names_without_rules(), self.tm1.cubes.get_all_names_without_rules(skip_control_cubes=True))
 
     @skip_if_insufficient_version(version="11.4")
     def test_get_storage_dimension_order(self):

--- a/Tests/CubeService_test.py
+++ b/Tests/CubeService_test.py
@@ -224,6 +224,34 @@ class TestCubeService(unittest.TestCase):
 
         errors = self.tm1.cubes.check_rules(cube_name=self.cube_name)
         self.assertEqual(1, len(errors))
+        
+    def test_search_for_rule_substring_no_match(self):
+        cubes = self.tm1.cubes.search_for_rule_substring(substring:"find_nothing")
+        self.assertEqual(0, len(cubes))
+
+    def test_search_for_rule_substring_happy_case(self):
+        cube = self.tm1.cubes.get(cube_name=self.cube_name)
+        cube.rules = "#find_me_comment"
+        self.tm1.cubes.update(cube)
+
+        cubes = self.tm1.cubes.search_for_rule_substring(substring:"find_me_comment")
+        self.assertEqual(cube_name, cubes[0].name)
+
+    def test_search_for_rule_substring_skip_control_cubes_false(self):
+        cube = self.tm1.cubes.get_control_cubes()[0]
+        cube.rules = "#find_control_comment"
+        self.tm1.cubes.update(cube)
+
+        cubes = self.tm1.cubes.search_for_rule_substring(substring:"find_control_comment", skip_control_cubes=False)
+        self.assertEqual(cube_name, cubes[0].name)
+
+    def test_search_for_rule_substring_skip_control_cubes_true(self):
+        cube = self.tm1.cubes.get_control_cubes()[0]
+        cube.rules = "#find_control_comment"
+        self.tm1.cubes.update(cube)
+
+        cubes = self.tm1.cubes.search_for_rule_substring(substring:"find_control_comment", skip_control_cubes=True)
+        self.assertEqual(0, len(cubes))        
 
     def test_get_measure_dimension(self):
         measure_dimension = self.tm1.cubes.get_measure_dimension(self.cube_name)

--- a/Tests/DimensionService_test.py
+++ b/Tests/DimensionService_test.py
@@ -172,10 +172,12 @@ class TestDimensionService(unittest.TestCase):
 
     def test_get_all_names(self):
         self.assertIn(self.dimension_name, self.tm1.dimensions.get_all_names())
-
+        self.assertNotEqual(self.tm1.dimensions.get_all_names(), self.tm1.dimensions.get_all_names(skip_control_dims=True))
+        
     def test_get_number_of_dimensions(self):
         number_of_dimensions = self.tm1.dimensions.get_number_of_dimensions()
         self.assertIsInstance(number_of_dimensions, int)
+        self.assertNotEqual(self.tm1.dimensions.get_number_of_dimensions(), self.tm1.dimensions.get_number_of_dimensions(skip_control_dims=True))
 
     def test_execute_mdx(self):
         mdx = "{TM1SubsetAll(" + self.dimension_name + ")}"

--- a/Tests/ProcessService_test.py
+++ b/Tests/ProcessService_test.py
@@ -400,6 +400,13 @@ class TestProcessService(unittest.TestCase):
         process_names = self.tm1.processes.search_string_in_code("sTestProlog = 'test prolog procedure'")
         self.assertEqual([self.p_ascii.name], process_names)
 
+    def test_get_all_names(self):
+        self.assertNotEqual(self.tm1.processes.get_all_names(), self.tm1.processes.get_all_names(skip_control_processes=True))
+        self.assertNotEqual('}', self.tm1.processes.get_all_names(skip_control_processes=True)[-1][0][0])
+        self.assertEqual('}', self.tm1.processes.get_all_names()[-1][0][0])
+        self.assertNotEQual(self.tm1.processes.get_all(), self.tm1.processes.get_all(skip_control_processes=True))
+
+
     @classmethod
     def tearDownClass(cls):
         cls.tm1.dimensions.subsets.delete(


### PR DESCRIPTION
Sorry for the multiple pull requests that were subsequently closed. I was working on separated, nested branches and created a pull request for each individually before simply merging them all into one here.

1. new function search_for_rule_substring will return all cubes with substring in rules
2. added skip_control_cubes parameter to multiple CubeService functions e.g. get_all_names, get_number_of_cubes
3. added skip_control_dims parameter to DimensionService functions get_all_names and get_number_of_dimensions
4. attempted update to test cases