### PR TITLE
ProcessDebugBreakpoint: Initial commit

### DIFF
--- a/TM1py/Objects/ProcessDebugBreakpoint.py
+++ b/TM1py/Objects/ProcessDebugBreakpoint.py
@@ -1,0 +1,186 @@
+# -*- coding: utf-8 -*-
+import json
+import re
+from typing import Optional, Iterable, Dict, List, Union
+
+from TM1py.Objects.TM1Object import TM1Object
+
+
+class ProcessDebugBreakpoint(TM1Object):
+    """ Abstraction of a TM1 Process Debug Breakpoing.
+
+    """
+
+
+    def __init__(self,
+               breakpoint_type: str = '',
+               breakpoint_id: int = 1,
+               enabled: bool = True,
+               hitmode: str = '',
+               hitcount: int = 0,
+               expression: str = '',
+               variable_name: str = '',
+               process_name: str = '',
+               procedure: str = '',
+               line_number: int = 0,
+               object_name: str = '',
+               object_type: str = '',
+               lock_mode: str = ''
+    ):
+
+        self._type = breakpoint_type
+        self._id = breakpoint_id
+        self._enabled = enabled
+        self._hitmode = hitmode
+        self._hitcount = hitcount
+        self._expression = expression
+        self._variable_name = variable_name
+        self._process_name = process_name
+        self._procedure = procedure
+        self._line_number = line_number
+        self._object_name = object_name
+        self._object_type = object_type
+        self._lock_mode = lock_mode
+
+
+    @classmethod
+    def from_dict(cls, breakpoint_as_dict, **kwargs) -> 'ProcessDebugBreakpoint':
+        """
+        :param breakpoing
+        :return: an instance of this class
+        """
+        breakpoint_type = breakpoint_as_dict['@odata.type'][16:]
+        return cls(
+            breakpoint_type=breakpoint_type,
+            breakpoint_id=breakpoint_as_dict['ID'],
+            enabled=breakpoint_as_dict['Enabled'],
+            hitmode=breakpoint_as_dict['HitMode'],
+            hitcount=breakpoint_as_dict['HitCount'],
+            expression=breakpoint_as_dict['Expression'],
+            variable_name=breakpoint_as_dict['VariableName'] if breakpoint_type == "ProcessDebugContextDataBreakpoint" else "",
+            process_name=breakpoint_as_dict['ProcessName'] if breakpoint_type == "ProcessDebugContextLineBreakpoint" else "",
+            procedure=breakpoint_as_dict['Procedure'] if breakpoint_type == "ProcessDebugContextLineBreakpoint" else "",
+            line_number=breakpoint_as_dict['LineNumber'] if breakpoint_type == "ProcessDebugContextLineBreakpoint" else "",
+            object_name=breakpoint_as_dict['ObjectName'] if breakpoint_type == "ProcessDebugContextLockBreakpoint" else "",
+            object_type=breakpoint_as_dict['ObjectType'] if breakpoint_type == "ProcessDebugContextLockBreakpoint" else "",
+            lock_mode=breakpoint_as_dict['LockMode'] if breakpoint_type == "ProcessDebugContextLockBreakpoint" else ""
+        )
+
+    @property
+    def breakpoint_type(self) -> str:
+        return self._type
+
+    @property
+    def breakpoint_id(self) -> int:
+        return self._id
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+        
+    @property
+    def hitmode(self) -> str:
+        return self._hitmode
+        
+    @property
+    def hitcount(self) -> int:
+        return self._hitcount
+        
+    @property
+    def expression(self) -> str:
+        return self._expression
+        
+    @property
+    def variable_name(self) -> str:
+        return self._variable_name
+        
+    @property
+    def process_name(self) -> str:
+        return self._process_name
+        
+    @property
+    def procedure(self) -> str:
+        return self._procedure
+        
+    @property
+    def line_number(self) -> int:
+        return self._line_number
+        
+    @property
+    def object_name(self) -> str:
+        return self._object_name
+        
+    @property
+    def object_type(self) -> str:
+        return self._object_type
+        
+    @property
+    def lock_mode(self) -> str:
+        return self._lock_mode
+
+    @property
+    def body(self) -> str:
+        return self._construct_body()
+
+    @enabled.setter
+    def enabled(self, value: bool):
+        self._enabled = value
+
+    @hitmode.setter
+    def hitmode(self, value: str):
+        self._hitmode = value
+
+    @expression.setter
+    def expression(self, value: str):
+        self._expression = value
+
+    @variable_name.setter
+    def variable_name(self, value: str):
+        self._variable_name = value
+
+    @process_name.setter
+    def process_name(self, value: str):
+        self._process_name = value
+
+    @procedure.setter
+    def procedure(self, value: str):
+        self._procedure = value
+
+    @line_number.setter
+    def line_number(self, value: str):
+        self._line_number = value
+
+    @object_name.setter
+    def object_name(self, value: str):
+        self._object_name = value
+
+    @object_type.setter
+    def object_type(self, value: str):
+        self._object_type = value
+
+    @lock_mode.setter
+    def lock_mode(self, value: str):
+        self._lock_mode = value
+
+
+    def _construct_body(self, **kwargs) -> str:
+        body_as_dict = {
+            '@odata.type': "#ibm.tm1.api.v1." + self._type,
+            'ID': self._id,
+            'Enabled': self._enabled,
+            'HitMode': self._hitmode,
+            'Expression': self._expression
+        }
+
+        if self._type == 'ProcessDebugContextDataBreakpoint':
+            body_as_dict['VariableName'] = self._variable_name
+        elif self._type == 'ProcessDebugContextLineBreakpoint':
+            body_as_dict['ProcessName'] = self._process_name
+            body_as_dict['Procedure'] = self._procedure
+            body_as_dict['LineNumber'] = self._line_number
+        elif self._type == 'ProcessDebugContextLockBreakpoint':
+            body_as_dict['ObjectName'] = self._object_name
+            body_as_dict['ObjectType'] = self._object_type
+            body_as_dict['LockMode'] = self._lock_mode
+
+        return json.dumps(body_as_dict, ensure_ascii=False)

--- a/TM1py/Services/ProcessService.py
+++ b/TM1py/Services/ProcessService.py
@@ -459,3 +459,9 @@ class ProcessService(ObjectService):
 
         response = self._rest.POST(url, breakpoint.body, **kwargs)
         return response
+
+    def debug_remove_breakpoint(self, debug_id: str, breakpoint_id: int, **kwargs) -> Response:
+        url = format_url("/api/v1/ProcessDebugContexts('{}')/Breakpoints('{}')", debug_id, breakpoint_id)
+
+        response = self._rest.DELETE(url, **kwargs)
+        return response

--- a/TM1py/Services/ProcessService.py
+++ b/TM1py/Services/ProcessService.py
@@ -433,3 +433,17 @@ class ProcessService(ObjectService):
 
         return response.json()
     
+    def debug_continue(self, debug_id: str, **kwargs) -> Dict:
+        url = format_url("/api/v1/ProcessDebugContexts('{}')/tm1.Continue", debug_id)
+        self._rest.POST(url, **kwargs)
+
+        # digest time  necessary for TM1 <= 11.8
+        # ToDo: remove in later versions of TM1 once issue in TM1 server is resolved
+        time.sleep(0.1)
+
+        raw_url = "/api/v1/ProcessDebugContexts('{}')?$expand=Breakpoints," \
+                  "Thread,CallStack($expand=Variables,Process($select=Name))"
+        url = format_url(raw_url, debug_id)
+        response = self._rest.GET(url, **kwargs)
+
+        return response.json()

--- a/TM1py/Services/ProcessService.py
+++ b/TM1py/Services/ProcessService.py
@@ -465,3 +465,9 @@ class ProcessService(ObjectService):
 
         response = self._rest.DELETE(url, **kwargs)
         return response
+
+    def debug_update_breakpoint(self, debug_id: str, breakpoint: ProcessDebugBreakpoint, **kwargs) -> Response:
+        url = format_url("/api/v1/ProcessDebugContexts('{}')/Breakpoints('{}')", debug_id, breakpoint.breakpoint_id)
+
+        response = self._rest.PATCH(url, breakpoint.body, **kwargs)
+        return response

--- a/TM1py/Services/ProcessService.py
+++ b/TM1py/Services/ProcessService.py
@@ -453,3 +453,9 @@ class ProcessService(ObjectService):
 
         response = self._rest.GET(url, **kwargs)
         return [ProcessDebugBreakpoint.from_dict(b) for b in response.json()['value']]
+
+    def debug_add_breakpoint(self, debug_id: str, breakpoint: ProcessDebugBreakpoint, **kwargs) -> Response:
+        url = format_url("/api/v1/ProcessDebugContexts('{}')/Breakpoints", debug_id)
+
+        response = self._rest.POST(url, breakpoint.body, **kwargs)
+        return response

--- a/TM1py/Services/ProcessService.py
+++ b/TM1py/Services/ProcessService.py
@@ -473,6 +473,14 @@ class ProcessService(ObjectService):
         response = self._rest.PATCH(url, breakpoint.body, **kwargs)
         return response
 
+    def debug_get_variable_values(self, debug_id: str, **kwargs) -> Dict:
+        raw_url = "/api/v1/ProcessDebugContexts('{}')?$expand=" \
+                  "CallStack($expand=Variables)"
+        url = format_url(raw_url, debug_id)
+
+        response = self._rest.GET(url, **kwargs)
+        return response.json()['CallStack'][0]['Variables'] if response.json()['CallStack'] else response.json()['CallStack']
+
     @require_admin
     def ti_formula(self, formula: str, **kwargs) -> str:
         """ This function is same funcitonality as hitting "Evaluate" within variable formula editor in TI

--- a/TM1py/Services/ProcessService.py
+++ b/TM1py/Services/ProcessService.py
@@ -447,3 +447,9 @@ class ProcessService(ObjectService):
         response = self._rest.GET(url, **kwargs)
 
         return response.json()
+
+    def debug_get_breakpoints(self, debug_id: str, **kwargs) -> Dict:
+        url = format_url("/api/v1/ProcessDebugContexts('{}')/Breakpoints", debug_id)
+
+        response = self._rest.GET(url, **kwargs)
+        return [ProcessDebugBreakpoint.from_dict(b) for b in response.json()['value']]


### PR DESCRIPTION
Initial commit with ProcessDebugBreakpoint object and additional debug actions in ProcessService from the existing StepOver and StepOut.

I've also added a function `ti_formula()` to replicate the evaluate option of the TI variable editor in architect/perspectives. It's not a light-weight operation as it involves creating a temporary TI in the same fashion as the `execute_ti_code()` function. It then starts a debug session, sets a breakpoint, and runs until the breakpoint is hit, returning the variable value at that breakpoint before cleaning up the temp TI. The idea for this came from a colleague asking me how to evaluate a variable formula in the PAW TI editor like they frequently do in architect. I wasn't aware of similar functionality in PAW TI editor so created this as a stop-gap until IBM builds something in natively.

I'm expecting to be out on parental leave any day, so won't have time to focus on this for a bit. Below are some initial cleanup ideas/questions that I'd like help with.

1. The object ProcessDebugBreakpoint is a mouthful. If the word "breakpoint" is unique to a process debug context, we could rename the object to simply Breakpoint or DebugBreakpoint
2. Current debug session actions (ie continue, step_out, step_over) return the fully expanded response of the request URL. Does this fit with how we imagine people will use the methods?
3. New functions need docstrings
4. The breakpoint_type parameter takes the full string used for the url e.g. ProcessDebugDataBreakpoint, when this could be refactored to simply be Data, Line, Lock and add the necessary prefix/suffix when building the URL.
5. Validation of breakpoint_type parameter values needed
6. HitMode, LockMode, and LockScope are enumerated types. I don't know exactly how they should be considered differently or any validations that may be needed around their use.
 