### PR TITLE
Raise ValueError if csv is not df compatible

### DIFF
--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -369,9 +369,11 @@ def build_csv_from_cellset_dict(
 
     column_axis, row_axis, _ = extract_axes_from_cellset(raw_cellset_as_dict=raw_cellset_as_dict)
 
+    num_headers = 0
     if include_headers:
         headers = _build_headers_for_csv(row_axis, column_axis, row_dimensions, column_dimensions, include_attributes)
         csv_writer.writerow(headers)
+        num_headers = len(headers)
 
     for ordinal, cell in enumerate(cells[:top or len(cells)]):
         # if skip is used in execution we must use the original ordinal from the cell, if not we can simply enumerate
@@ -401,7 +403,9 @@ def build_csv_from_cellset_dict(
             line.extend(line_items)
 
         line.append(str(cell["Value"] or ""))
-
+        if include_attributes and include_headers and not len(line) == num_headers:
+            raise ValueError("Invalid response. With 'include_attributes' as True,"
+                             " Attributes must be requested explicitly as PROPERTIES in the MDX")
         csv_writer.writerow(line)
 
     return csv_content.getvalue().strip()

--- a/Tests/CellService_test.py
+++ b/Tests/CellService_test.py
@@ -99,6 +99,7 @@ class TestCellService(unittest.TestCase):
                 attribute_values[(element.name, "Attr2")] = "2"
                 attribute_values[(element.name, "Attr3")] = "3"
                 attribute_values[(element.name, "NA")] = "4"
+
             cls.tm1.cubes.cells.write_values(attribute_cube, attribute_values)
 
         # Build Cube


### PR DESCRIPTION
It is a bad practice to use the `execute_mdx_dataframe` function with `include_attributes` as True, while omitting the PROPERTIES in the MDX query.

It is bad because the response JSON is arbitrary and depending on what
attributes exist and don't exist in the TM1 model.

Instead of attempting to work with this flawed response JSON,
TM1py must raise an error demanding that the user
requests attributes properly by the use of PROPERTIES in the MDX query.

Solves #507 and #718