### PR TITLE
View subset search

### DIFF
--- a/TM1py/Services/CubeService.py
+++ b/TM1py/Services/CubeService.py
@@ -278,34 +278,6 @@ class CubeService(ObjectService):
         cubes = [Cube.from_dict(cube_as_dict=cube) for cube in response.json()['value']]
         return cubes   
 
-    def search_subset_in_view(self, dimension_name: str = None, subset_name: str = None, skip_control_cubes: bool = False,
-                            cube_name: str = None, **kwargs):
-            """ Get all public views that utlize given subset in specified dimension.
-
-            :param dimension_name: string, valid dimension name with subset to query
-            :param subset_name: string, valid subset name to search for in views
-            :param skip_control_cubes: bool, True to only search views within model cubes
-            :param cube_name: str, optionally specify cube to search, otherwise will search all cubes
-            :return: list of view objects that contain specified subset
-            """
-        view_list = []
-
-        for cube in [cube_name if cube_name else
-                    self.get_names_with_dimension(dimension_name=dimension_name,
-                                                skip_control_cubes=skip_control_cubes
-                                                )
-                    ][0]:
-
-            all_views = self.views.get_all(cube_name=cube, include_elements=False)
-
-            for view in all_views[1]:
-                view_list.append(self.views.get(cube_name=view.cube, view_name=view.name)) if any(
-                    sub_item for item in [view.titles, view.rows, view.columns] for sub_item in item
-                    if sub_item.dimension_name == dimension_name and sub_item.subset.name == subset_name
-                ) else None
-
-        return view_list
-
     @require_version(version="11.4")
     def get_storage_dimension_order(self, cube_name: str, **kwargs) -> List[str]:
         """ Get the storage dimension order of a cube

--- a/TM1py/Services/CubeService.py
+++ b/TM1py/Services/CubeService.py
@@ -278,6 +278,34 @@ class CubeService(ObjectService):
         cubes = [Cube.from_dict(cube_as_dict=cube) for cube in response.json()['value']]
         return cubes   
 
+    def search_subset_in_view(self, dimension_name: str = None, subset_name: str = None, skip_control_cubes: bool = False,
+                            cube_name: str = None, **kwargs):
+            """ Get all public views that utlize given subset in specified dimension.
+
+            :param dimension_name: string, valid dimension name with subset to query
+            :param subset_name: string, valid subset name to search for in views
+            :param skip_control_cubes: bool, True to only search views within model cubes
+            :param cube_name: str, optionally specify cube to search, otherwise will search all cubes
+            :return: list of view objects that contain specified subset
+            """
+        view_list = []
+
+        for cube in [cube_name if cube_name else
+                    self.get_names_with_dimension(dimension_name=dimension_name,
+                                                skip_control_cubes=skip_control_cubes
+                                                )
+                    ][0]:
+
+            all_views = self.views.get_all(cube_name=cube, include_elements=False)
+
+            for view in all_views[1]:
+                view_list.append(self.views.get(cube_name=view.cube, view_name=view.name)) if any(
+                    sub_item for item in [view.titles, view.rows, view.columns] for sub_item in item
+                    if sub_item.dimension_name == dimension_name and sub_item.subset.name == subset_name
+                ) else None
+
+        return view_list
+
     @require_version(version="11.4")
     def get_storage_dimension_order(self, cube_name: str, **kwargs) -> List[str]:
         """ Get the storage dimension order of a cube

--- a/TM1py/Services/ViewService.py
+++ b/TM1py/Services/ViewService.py
@@ -235,7 +235,7 @@ class ViewService(ObjectService):
                 "or"
                 "(tm1.NativeView/Titles/any (t: t/Subset/Name eq '{}' and t/Subset/Hierarchy/Dimension/Name eq '{}'))"
                 ");"
-                "tm1.NativeView/Rows/Subset($expand=Hierarchy($select=Name;"
+                "$expand=tm1.NativeView/Rows/Subset($expand=Hierarchy($select=Name;"
                 "$expand=Dimension($select=Name)),Elements($select=Name{});"
                 "$select=Expression,UniqueName,Name, Alias),  "
                 "tm1.NativeView/Columns/Subset($expand=Hierarchy($select=Name;"
@@ -254,9 +254,9 @@ class ViewService(ObjectService):
                 if cube[view_type]:
                     for view_as_dict in cube[view_type]:
                         if view_as_dict['@odata.type'] == '#ibm.tm1.api.v1.MDXView':
-                            view = MDXView.from_dict(view_as_dict, cube_name)
+                            view = MDXView.from_dict(view_as_dict, cube['Name'])
                         else:
-                            view = NativeView.from_dict(view_as_dict, cube_name)
+                            view = NativeView.from_dict(view_as_dict, cube['Name'])
                         if view_type == "PrivateViews":
                             private_views.append(view)
                         else:

--- a/TM1py/Services/ViewService.py
+++ b/TM1py/Services/ViewService.py
@@ -249,14 +249,18 @@ class ViewService(ObjectService):
                      dimension_name, element_filter, element_filter, element_filter)
 
             response = self._rest.GET(url, **kwargs)
-            response_as_list = response.json()['value']
-            for cube in response_as_list:
-                if cube[view_type]:
+            response_as_list = response.json()[view_type] if cube_name else response.json()['value']
+            if cube_name:
+                for view_as_dict in response_as_list:
+                    view = NativeView.from_dict(view_as_dict, cube_name)
+                    if view_type == "PrivateViews":
+                        private_views.append(view)
+                    else:
+                        public_views.append(view)
+            else:
+                for cube in response_as_list:
                     for view_as_dict in cube[view_type]:
-                        if view_as_dict['@odata.type'] == '#ibm.tm1.api.v1.MDXView':
-                            view = MDXView.from_dict(view_as_dict, cube['Name'])
-                        else:
-                            view = NativeView.from_dict(view_as_dict, cube['Name'])
+                        view = NativeView.from_dict(view_as_dict, cube['Name'])
                         if view_type == "PrivateViews":
                             private_views.append(view)
                         else:

--- a/TM1py/Services/ViewService.py
+++ b/TM1py/Services/ViewService.py
@@ -229,11 +229,14 @@ class ViewService(ObjectService):
                 "/api/v1/Cubes{}?select=Name&$expand={}("
                 "$filter=isof(tm1.NativeView) and"
                 "("
-                "(tm1.NativeView/Rows/any (r: r/Subset/Name eq '{}' and r/Subset/Hierarchy/Dimension/Name eq '{}'))"
+                "(tm1.NativeView/Rows/any (r: replace(tolower(r/Subset/Name), ' ', '') eq '{}' "
+                "and replace(tolower(r/Subset/Hierarchy/Dimension/Name), ' ', '') eq '{}'))"
                 "or"
-                "(tm1.NativeView/Columns/any (c: c/Subset/Name eq '{}' and c/Subset/Hierarchy/Dimension/Name eq '{}')) "
+                "(tm1.NativeView/Columns/any (c: replace(tolower(c/Subset/Name), ' ', '') eq '{}' "
+                "and replace(tolower(c/Subset/Hierarchy/Dimension/Name), ' ', '') eq '{}')) "
                 "or"
-                "(tm1.NativeView/Titles/any (t: t/Subset/Name eq '{}' and t/Subset/Hierarchy/Dimension/Name eq '{}'))"
+                "(tm1.NativeView/Titles/any (t: replace(tolower(t/Subset/Name), ' ', '') eq '{}' "
+                "and replace(tolower(t/Subset/Hierarchy/Dimension/Name), ' ', '') eq '{}'))"
                 ");"
                 "$expand=tm1.NativeView/Rows/Subset($expand=Hierarchy($select=Name;"
                 "$expand=Dimension($select=Name)),Elements($select=Name{});"
@@ -245,8 +248,12 @@ class ViewService(ObjectService):
                 "$expand=Dimension($select=Name)),Elements($select=Name{});"
                 "$select=Expression,UniqueName,Name,Alias), "
                 "tm1.NativeView/Titles/Selected($select=Name))"
-            ).format(cube_filter, view_type, subset_name, dimension_name, subset_name, dimension_name, subset_name, 
-                     dimension_name, element_filter, element_filter, element_filter)
+            ).format(cube_filter, view_type,
+                     subset_name.lower().replace(' ', ''), dimension_name.lower().replace(' ', ''), 
+                     subset_name.lower().replace(' ', ''), dimension_name.lower().replace(' ', ''), 
+                     subset_name.lower().replace(' ', ''), dimension_name.lower().replace(' ', ''), 
+                     element_filter, element_filter, element_filter
+                     )
 
             response = self._rest.GET(url, **kwargs)
             response_as_list = response.json()[view_type] if cube_name else response.json()['value']

--- a/TM1py/Services/ViewService.py
+++ b/TM1py/Services/ViewService.py
@@ -209,9 +209,9 @@ class ViewService(ObjectService):
         response = self._rest.DELETE(url, **kwargs)
         return response
 
-    def search_subset_in_view(self, dimension_name: str = None, subset_name: str = None, cube_name: str = None, 
+    def search_subset_in_native_view(self, dimension_name: str = None, subset_name: str = None, cube_name: str = None, 
                               include_elements: bool = True, **kwargs) -> Tuple[List[View], List[View]]:
-        """ Get all public and private views that utilize specified dimension subset
+        """ Get all public and private native views that utilize specified dimension subset
 
         :param dimension_name: string, valid dimension name with subset to query
         :param subset_name: string, valid subset name to search for in views

--- a/TM1py/Services/ViewService.py
+++ b/TM1py/Services/ViewService.py
@@ -226,7 +226,7 @@ class ViewService(ObjectService):
         private_views, public_views = [], []
         for view_type in ('PrivateViews', 'Views'):
             url = format_url(
-                "/api/v1/Cubes{}?$expand={}("
+                "/api/v1/Cubes{}?select=Name&$expand={}("
                 "$filter=isof(tm1.NativeView) and"
                 "("
                 "(tm1.NativeView/Rows/any (r: r/Subset/Name eq '{}' and r/Subset/Hierarchy/Dimension/Name eq '{}'))"

--- a/TM1py/Services/ViewService.py
+++ b/TM1py/Services/ViewService.py
@@ -225,7 +225,7 @@ class ViewService(ObjectService):
         
         private_views, public_views = [], []
         for view_type in ('PrivateViews', 'Views'):
-            url = format_url(
+            url = (
                 "/api/v1/Cubes{}?select=Name&$expand={}("
                 "$filter=isof(tm1.NativeView) and"
                 "("
@@ -244,9 +244,9 @@ class ViewService(ObjectService):
                 "tm1.NativeView/Titles/Subset($expand=Hierarchy($select=Name;"
                 "$expand=Dimension($select=Name)),Elements($select=Name{});"
                 "$select=Expression,UniqueName,Name,Alias), "
-                "tm1.NativeView/Titles/Selected($select=Name))",
-                cube_filter, view_type, subset_name, dimension_name, subset_name, dimension_name, subset_name, dimension_name, 
-                element_filter, element_filter, element_filter)
+                "tm1.NativeView/Titles/Selected($select=Name))"
+            ).format(cube_filter, view_type, subset_name, dimension_name, subset_name, dimension_name, subset_name, 
+                     dimension_name, element_filter, element_filter, element_filter)
 
             response = self._rest.GET(url, **kwargs)
             response_as_list = response.json()['value']


### PR DESCRIPTION
Method for finding views that contain specified dim/subset as requested in this issue: https://github.com/cubewise-code/tm1py/issues/738#issue-1263244896

I included an enhancement to the get_all function in View Service to specify whether or not the returned list of views should include elements. By excluding the element list, the get_all function leveraged by this new search method runs 10x faster.

I put the subset search function in the cube service as I needed to leverage the get_names_with_dimension function and didn't want to mess with the dependencies.

Ideally, there would be a good odata query to do all of this right in the URL, but that's proving somewhat complex.