### PR TITLE
Feature element ancestors

### DIFF
--- a/TM1py/Services/ElementService.py
+++ b/TM1py/Services/ElementService.py
@@ -3,7 +3,7 @@ import json
 from typing import List, Union, Iterable, Optional, Dict, Tuple
 
 from requests import Response
-
+from mdxpy import MdxHierarchySet
 from TM1py.Exceptions import TM1pyRestException
 from TM1py.Objects import ElementAttribute, Element
 from TM1py.Services.ObjectService import ObjectService
@@ -648,3 +648,19 @@ class ElementService(ObjectService):
     def get_element_principal_name(self, dimension_name: str, hierarchy_name: str, element_name: str, **kwargs) -> str:
         element = self.get(dimension_name, hierarchy_name, element_name, **kwargs)
         return element.name
+
+    def element_is_descendant_of(self, dimension_name: str, hierarchy_name: str, descendant, ancestor,
+                                   max_depth: int = None):
+        if not self.get(dimension_name, hierarchy_name, ancestor).element_type == Element.Types.CONSOLIDATED:
+            raise ValueError('parent must be a consolidated element.')
+
+        return descendant in self.get_members_under_consolidation(dimension_name, hierarchy_name, ancestor, max_depth)
+
+    def element_is_parent_of(self, dimension_name: str, hierarchy_name: str, parent: str, child: str):
+        return parent in self.get_parents(dimension_name, hierarchy_name, child)
+
+    def element_is_ancestor_of(self, dimension_name: str, hierarchy_name: str, ancestor: str, member: str, mode: str):
+        return member in self.execute_set_mdx(
+            MdxHierarchySet(dimension_name, hierarchy_name).ancestors(member).to_mdx())
+
+    # mdx variant & TI process variant, get parents until root variant, drilldown vs drillup, get_ancestors in REST

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -696,9 +696,10 @@ def build_cellset_from_pandas_dataframe(df: 'pd.DataFrame') -> 'CaseAndSpaceInse
     """
     if isinstance(df.index, pd.MultiIndex):
         df.reset_index(inplace=True)
-    cellset = CaseAndSpaceInsensitiveTuplesDict(
-        dict(zip(df.iloc[:, :-1].itertuples(index=False, name=None), df.iloc[:, -1].values)))
-
+    cellset = CaseAndSpaceInsensitiveTuplesDict()
+    split = df.to_numpy().tolist()
+    for row in split:
+        cellset[tuple(row[0:-1])] = row[-1]
     return cellset
 
 
@@ -799,10 +800,10 @@ def map_cell_properties_to_compact_json_response(properties: List, compact_cells
     properties = [Ordinal, Value, RuleDerived]
     compact_cells_response = [[0, 258, 100], [1, 258, 500]]
     result: {Cells: [
-        { Ordinal: 0, Value: 100, RuleDerived: 258},
+        { Ordinal: 0, Value: 100, RuleDerived: 258}, 
         { Ordinal: 1, Value: 500, RuleDerived: 258}
     ]}
-
+    
 
     :param properties: list of `Cell` properties e.g [Ordinal, Value, Updateable, ...]
     :param compact_cells_response: list of cells returned in compact json format

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -696,10 +696,9 @@ def build_cellset_from_pandas_dataframe(df: 'pd.DataFrame') -> 'CaseAndSpaceInse
     """
     if isinstance(df.index, pd.MultiIndex):
         df.reset_index(inplace=True)
-    cellset = CaseAndSpaceInsensitiveTuplesDict()
-    split = df.to_numpy().tolist()
-    for row in split:
-        cellset[tuple(row[0:-1])] = row[-1]
+    cellset = CaseAndSpaceInsensitiveTuplesDict(
+        dict(zip(df.iloc[:, :-1].itertuples(index=False, name=None), df.iloc[:, -1].values)))
+
     return cellset
 
 
@@ -800,10 +799,10 @@ def map_cell_properties_to_compact_json_response(properties: List, compact_cells
     properties = [Ordinal, Value, RuleDerived]
     compact_cells_response = [[0, 258, 100], [1, 258, 500]]
     result: {Cells: [
-        { Ordinal: 0, Value: 100, RuleDerived: 258}, 
+        { Ordinal: 0, Value: 100, RuleDerived: 258},
         { Ordinal: 1, Value: 500, RuleDerived: 258}
     ]}
-    
+
 
     :param properties: list of `Cell` properties e.g [Ordinal, Value, Updateable, ...]
     :param compact_cells_response: list of cells returned in compact json format


### PR DESCRIPTION
For large/deep dimensions, it could be more efficient to use the descendants-based method. Especially when checking non-leaf level elements for ancestors this method might have performance benefits.

![image](https://user-images.githubusercontent.com/101728567/180194504-445bede6-7e6f-4e7a-bed0-aa05479e91d4.png)

