### PR TITLE
Allow multi axes queries in `execute_mdx` function

### DIFF
--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -278,7 +278,6 @@ def build_content_from_cellset_dict(
 
     cells = raw_cellset_as_dict['Cells']
     axes = extract_axes_from_cellset(raw_cellset_as_dict=raw_cellset_as_dict)
-    num_axes = len(axes)
 
     content_as_dict = CaseAndSpaceInsensitiveTuplesDict()
     for cell_ordinal, cell in enumerate(cells[:top or len(cells)]):

--- a/Tests/CellService_test.py
+++ b/Tests/CellService_test.py
@@ -1358,6 +1358,42 @@ class TestCellService(unittest.TestCase):
 
         self.assertEqual(expected_cells, cells)
 
+    def test_execute_mdx_multi_axes_with_where(self):
+        query = MdxBuilder.from_cube(self.cube_with_five_dimensions)
+        query.non_empty(0)
+        query.add_hierarchy_set_to_axis(0, MdxHierarchySet.all_leaves(
+            self.five_dimensions[0],
+            self.five_dimensions[0]))
+
+        query.non_empty(1)
+        query.add_hierarchy_set_to_axis(1, MdxHierarchySet.all_leaves(
+            self.five_dimensions[1],
+            self.five_dimensions[1]))
+
+        query.non_empty(2)
+        query.add_hierarchy_set_to_axis(2, MdxHierarchySet.all_leaves(
+            self.five_dimensions[2],
+            self.five_dimensions[2]))
+
+        query.non_empty(3)
+        query.add_hierarchy_set_to_axis(3, MdxHierarchySet.all_leaves(
+            self.five_dimensions[3],
+            self.five_dimensions[3]))
+
+        query.where(Member(self.five_dimensions[4], self.five_dimensions[4], "e2"))
+
+        cells = self.tm1.cells.execute_mdx(
+            mdx=query.to_mdx(),
+            element_unique_names=False,
+            skip_cell_properties=True,
+            skip_zeros=True)
+
+        expected_cells = {
+            ("e2", "e2", "e2", "e2", "e2"): 2
+        }
+
+        self.assertEqual(expected_cells, cells)
+
     def test_execute_mdx_raw_skip_contexts(self):
         mdx = MdxBuilder.from_cube(self.cube_name) \
             .add_hierarchy_set_to_row_axis(MdxHierarchySet.member(Member.of(self.dimension_names[0], "Element1"))) \


### PR DESCRIPTION
The new change allows this:


``` python
from TM1py import TM1Service

with TM1Service(base_url="https://localhost:12354", user="admin", password="apple") as tm1:
    mdx = """
    SELECT
    NON EMPTY Tm1FilterByLevel({TM1SubsetAll([d1])},0) on 0,
    NON EMPTY Tm1FilterByLevel({TM1SubsetAll([d2])},0) on 1,
    NON EMPTY Tm1FilterByLevel({TM1SubsetAll([d3])},0) on 2,
    NON EMPTY Tm1FilterByLevel({TM1SubsetAll([d4])},0) on 3,
    NON EMPTY Tm1FilterByLevel({TM1SubsetAll([d5])},0) on 4
    FROM [c5]
    """

    cells = tm1.cells.execute_mdx(mdx, element_unique_names=False, skip_cell_properties=True)
    for elements, value in cells.items():
        print(elements, value)

```

```
('e1', 'e1', 'e01', 'e01', 'e01') 4
('e1', 'e1', 'e01', 'e02', 'e01') 1
('e1', 'e1', 'e01', 'e01', 'e02') 2
('e1', 'e1', 'e01', 'e02', 'e02') 3
```