### PR TITLE
Breakpoint refactor & new functions

### DIFF
--- a/TM1py/Objects/ProcessDebugBreakpoint.py
+++ b/TM1py/Objects/ProcessDebugBreakpoint.py
@@ -163,6 +163,10 @@ class ProcessDebugBreakpoint(TM1Object):
 
     @property
     def body(self) -> str:
+        return json.dumps(self._construct_body())
+
+    @property
+    def body_as_dict(self) -> Dict:
         return self._construct_body()
 
     @enabled.setter
@@ -227,4 +231,4 @@ class ProcessDebugBreakpoint(TM1Object):
             body_as_dict['ObjectType'] = self._object_type
             body_as_dict['LockMode'] = self._lock_mode
 
-        return json.dumps(body_as_dict, ensure_ascii=False)
+        return body_as_dict

--- a/TM1py/Services/ProcessService.py
+++ b/TM1py/Services/ProcessService.py
@@ -411,9 +411,28 @@ class ProcessService(ObjectService):
     def debug_step_over(self, debug_id: str, **kwargs) -> Dict:
         """ 
         Runs a single statement in the process
-        If ExecuteProcess is next function, will NOT debug child process        
+        If ExecuteProcess is next function, will NOT debug child process
         """
         url = format_url("/api/v1/ProcessDebugContexts('{}')/tm1.StepOver", debug_id)
+        self._rest.POST(url, **kwargs)
+
+        # digest time  necessary for TM1 <= 11.8
+        # ToDo: remove in later versions of TM1 once issue in TM1 server is resolved
+        time.sleep(0.1)
+
+        raw_url = "/api/v1/ProcessDebugContexts('{}')?$expand=Breakpoints," \
+                  "Thread,CallStack($expand=Variables,Process($select=Name))"
+        url = format_url(raw_url, debug_id)
+        response = self._rest.GET(url, **kwargs)
+
+        return response.json()
+
+    def debug_step_in(self, debug_id: str, **kwargs) -> Dict:
+        """ 
+        Runs a single statement in the process
+        If ExecuteProcess is next function, will pause at first statement inside child process
+        """
+        url = format_url("/api/v1/ProcessDebugContexts('{}')/tm1.StepIn", debug_id)
         self._rest.POST(url, **kwargs)
 
         # digest time  necessary for TM1 <= 11.8

--- a/TM1py/Services/ProcessService.py
+++ b/TM1py/Services/ProcessService.py
@@ -506,6 +506,14 @@ class ProcessService(ObjectService):
         except:
             raise ValueError(f"'{variable_name}' not found in collection")
 
+    def debug_get_process_procedure(self, debug_id: str, **kwargs) -> str:
+        raw_url = "/api/v1/ProcessDebugContexts('{}')?$expand=" \
+                  "CallStack($select=Procedure)"
+        url = format_url(raw_url, debug_id)
+
+        response = self._rest.GET(url, **kwargs)
+        return response.json()['CallStack'][0]['Procedure']
+
     @require_admin
     def evaluate_boolean_ti_expression(self, formula: str):
         prolog_procedure = f"""

--- a/TM1py/Services/ProcessService.py
+++ b/TM1py/Services/ProcessService.py
@@ -522,7 +522,7 @@ class ProcessService(ObjectService):
         response = self._rest.GET(url, **kwargs)
         return response.json()['CallStack'][0]['LineNumber']
 
-    def debug_get_process_record_number(self, debug_id: str, **kwargs) -> str:
+    def debug_get_record_number(self, debug_id: str, **kwargs) -> str:
         raw_url = "/api/v1/ProcessDebugContexts('{}')?$expand=" \
                   "CallStack($select=RecordNumber)"
         url = format_url(raw_url, debug_id)

--- a/TM1py/Services/ProcessService.py
+++ b/TM1py/Services/ProcessService.py
@@ -459,10 +459,15 @@ class ProcessService(ObjectService):
         response = self._rest.GET(url, **kwargs)
         return [ProcessDebugBreakpoint.from_dict(b) for b in response.json()['value']]
 
-    def debug_add_breakpoint(self, debug_id: str, break_point: ProcessDebugBreakpoint, **kwargs) -> Response:
+    def debug_add_breakpoint(self, debug_id: str, break_point: Iterable[ProcessDebugBreakpoint] = None, **kwargs) -> Response:
         url = format_url("/api/v1/ProcessDebugContexts('{}')/Breakpoints", debug_id)
 
-        response = self._rest.POST(url, break_point.body, **kwargs)
+        if isinstance(break_point, list):
+            body = json.dumps([breakpoint.body_as_dict for breakpoint in break_point])
+        else:
+            body = json.dumps(break_point.body_as_dict)
+
+        response = self._rest.POST(url, body, **kwargs)
         return response
 
     def debug_remove_breakpoint(self, debug_id: str, breakpoint_id: int, **kwargs) -> Response:

--- a/TM1py/Services/ProcessService.py
+++ b/TM1py/Services/ProcessService.py
@@ -388,6 +388,9 @@ class ProcessService(ObjectService):
             return response.text
 
     def debug_process(self, process_name: str, timeout: float = None, **kwargs) -> Dict:
+        """ 
+        Start debug session for specified process; debug session id is returned in response        
+        """
         raw_url = "/api/v1/Processes('{}')/tm1.Debug?$expand=Breakpoints," \
                   "Thread,CallStack($expand=Variables,Process($select=Name))"
         url = format_url(raw_url, process_name)
@@ -406,6 +409,10 @@ class ProcessService(ObjectService):
         return response.json()
 
     def debug_step_over(self, debug_id: str, **kwargs) -> Dict:
+        """ 
+        Runs a single statement in the process
+        If ExecuteProcess is next function, will NOT debug child process        
+        """
         url = format_url("/api/v1/ProcessDebugContexts('{}')/tm1.StepOver", debug_id)
         self._rest.POST(url, **kwargs)
 
@@ -422,7 +429,7 @@ class ProcessService(ObjectService):
 
     def debug_step_out(self, debug_id: str, **kwargs) -> Dict:
         """
-        Resumes execution and runs until next breakpoint or current process has finished.
+        Resumes execution and runs until current process has finished.
         """
         url = format_url("/api/v1/ProcessDebugContexts('{}')/tm1.StepOut", debug_id)
         self._rest.POST(url, **kwargs)
@@ -439,6 +446,10 @@ class ProcessService(ObjectService):
         return response.json()
 
     def debug_continue(self, debug_id: str, **kwargs) -> Dict:
+        """ 
+        Resumes execution until next breakpoint
+        
+        """
         url = format_url("/api/v1/ProcessDebugContexts('{}')/tm1.Continue", debug_id)
         self._rest.POST(url, **kwargs)
 
@@ -560,7 +571,7 @@ class ProcessService(ObjectService):
         """ This function is same functionality as hitting "Evaluate" within variable formula editor in TI
             Function creates temporary TI and then starts a debug session on that TI
             EnableTIDebugging=T must be present in .cfg file
-            Only suited for Deb and one-off uses, don't incorporate into dataframe lambda function
+            Only suited for DEV and one-off uses, don't incorporate into dataframe lambda function
 
         :param formula: a valid tm1 variable formula (no double quotes, no equals sign, semicolon optional)
             e.g. "8*2;", "CellGetN('c1', 'e1', 'e2);", "ATTRS('Region', 'France', 'Currency')"

--- a/TM1py/Services/ProcessService.py
+++ b/TM1py/Services/ProcessService.py
@@ -453,7 +453,7 @@ class ProcessService(ObjectService):
 
         return response.json()
 
-    def debug_get_breakpoints(self, debug_id: str, **kwargs) -> List:
+    def debug_get_breakpoints(self, debug_id: str, **kwargs) -> List[ProcessDebugBreakpoint]:
         url = format_url("/api/v1/ProcessDebugContexts('{}')/Breakpoints", debug_id)
 
         response = self._rest.GET(url, **kwargs)

--- a/TM1py/Services/ProcessService.py
+++ b/TM1py/Services/ProcessService.py
@@ -522,6 +522,14 @@ class ProcessService(ObjectService):
         response = self._rest.GET(url, **kwargs)
         return response.json()['CallStack'][0]['LineNumber']
 
+    def debug_get_process_record_number(self, debug_id: str, **kwargs) -> str:
+        raw_url = "/api/v1/ProcessDebugContexts('{}')?$expand=" \
+                  "CallStack($select=RecordNumber)"
+        url = format_url(raw_url, debug_id)
+
+        response = self._rest.GET(url, **kwargs)
+        return response.json()['CallStack'][0]['RecordNumber']
+
     @require_admin
     def evaluate_boolean_ti_expression(self, formula: str):
         prolog_procedure = f"""

--- a/TM1py/Services/ProcessService.py
+++ b/TM1py/Services/ProcessService.py
@@ -514,6 +514,14 @@ class ProcessService(ObjectService):
         response = self._rest.GET(url, **kwargs)
         return response.json()['CallStack'][0]['Procedure']
 
+    def debug_get_process_line_number(self, debug_id: str, **kwargs) -> str:
+        raw_url = "/api/v1/ProcessDebugContexts('{}')?$expand=" \
+                  "CallStack($select=LineNumber)"
+        url = format_url(raw_url, debug_id)
+
+        response = self._rest.GET(url, **kwargs)
+        return response.json()['CallStack'][0]['LineNumber']
+
     @require_admin
     def evaluate_boolean_ti_expression(self, formula: str):
         prolog_procedure = f"""

--- a/TM1py/Services/ProcessService.py
+++ b/TM1py/Services/ProcessService.py
@@ -494,6 +494,18 @@ class ProcessService(ObjectService):
         return response.json()['CallStack'][0]['Variables'] if response.json()['CallStack'] else response.json()[
             'CallStack']
 
+    def debug_get_single_variable_value(self, debug_id: str, variable_name: str, **kwargs) -> str:
+        raw_url = "/api/v1/ProcessDebugContexts('{}')?$expand=" \
+                  "CallStack($expand=Variables($filter=tolower(Name) eq '{}';$select=Value))"
+        url = format_url(raw_url, debug_id, variable_name.lower())
+
+        response = self._rest.GET(url, **kwargs)
+
+        try:
+            return response.json()['CallStack'][0]['Variables'][0]['Value']
+        except:
+            raise ValueError(f"'{variable_name}' not found in collection")
+
     @require_admin
     def evaluate_boolean_ti_expression(self, formula: str):
         prolog_procedure = f"""

--- a/TM1py/Services/ProcessService.py
+++ b/TM1py/Services/ProcessService.py
@@ -530,6 +530,14 @@ class ProcessService(ObjectService):
         response = self._rest.GET(url, **kwargs)
         return response.json()['CallStack'][0]['RecordNumber']
 
+    def debug_get_current_breakpoint(self, debug_id: str, **kwargs) -> ProcessDebugBreakpoint:
+        raw_url = "/api/v1/ProcessDebugContexts('{}')?$expand=CurrentBreakpoint"
+
+        url = format_url(raw_url, debug_id)
+
+        response = self._rest.GET(url=url, **kwargs)
+        return ProcessDebugBreakpoint.from_dict(response.json()["CurrentBreakpoint"])
+
     @require_admin
     def evaluate_boolean_ti_expression(self, formula: str):
         prolog_procedure = f"""


### PR DESCRIPTION
I updated the ProcessDebugBreakpoint object and debug_add_breakpoint function to be able to add multiple breakpoints as requested in issue:https://github.com/cubewise-code/tm1py/issues/764.

I also added some new functions for getting current breakpoint details like procedure and current line number as well as new step_in function to complement the step_over, step_out, and continue functions

I shamefully did **not** update any tests around the breakpoint.