### PR TITLE
Element functions

### DIFF
--- a/TM1py/Services/ElementService.py
+++ b/TM1py/Services/ElementService.py
@@ -112,6 +112,21 @@ class ElementService(ObjectService):
         response = self._rest.GET(url, **kwargs)
         return [e["Name"] for e in response.json()['value']]
 
+    def get_numeric_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[Element]:
+        url = format_url(
+            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type eq 1",
+            dimension_name,
+            hierarchy_name)
+        response = self._rest.GET(url, **kwargs)
+        return [Element.from_dict(element) for element in response.json()["value"]] 
+
+    def get_numeric_element_names(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[str]:
+        url = format_url("/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type eq 1",
+                         dimension_name,
+                         hierarchy_name)
+        response = self._rest.GET(url, **kwargs)
+        return [e["Name"] for e in response.json()['value']]
+
     def get_element_names(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[str]:
         """ Get all element names
 

--- a/TM1py/Services/ElementService.py
+++ b/TM1py/Services/ElementService.py
@@ -180,6 +180,22 @@ class ElementService(ObjectService):
         response = self._rest.GET(url, **kwargs)
         return int(response.text)
 
+    def get_number_of_numeric_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> int:
+        url = format_url(
+            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements/$count?$filter=Type eq 1",
+            dimension_name,
+            hierarchy_name)
+        response = self._rest.GET(url, **kwargs)
+        return int(response.text)
+
+    def get_number_of_string_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> int:
+        url = format_url(
+            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements/$count?$filter=Type eq 2",
+            dimension_name,
+            hierarchy_name)
+        response = self._rest.GET(url, **kwargs)
+        return int(response.text)
+
     def get_all_leaf_element_identifiers(self, dimension_name: str, hierarchy_name: str,
                                          **kwargs) -> CaseAndSpaceInsensitiveSet:
         """ Get all element names and alias values for leaf elements in a hierarchy

--- a/TM1py/Services/ElementService.py
+++ b/TM1py/Services/ElementService.py
@@ -652,6 +652,15 @@ class ElementService(ObjectService):
 
         return [record["Name"] for record in response.json()["value"]]
 
+    def get_parents_all_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[str]:
+        url = format_url(
+            f"/api/v1/Dimensions('{dimension_name}')/Hierarchies('{hierarchy_name}')/Elements?$select=Name"
+            f"&$expand=Parents($select=Name)",
+        )
+        response = self._rest.GET(url=url, **kwargs)
+
+        return {child["Name"]: [parent["Name"] for parent in child["Parents"]] for child in response.json()["value"]}
+
     def get_element_principal_name(self, dimension_name: str, hierarchy_name: str, element_name: str, **kwargs) -> str:
         element = self.get(dimension_name, hierarchy_name, element_name, **kwargs)
         return element.name

--- a/TM1py/Services/ElementService.py
+++ b/TM1py/Services/ElementService.py
@@ -713,7 +713,7 @@ class ElementService(ObjectService):
 
         return [record["Name"] for record in response.json()["value"]]
 
-    def get_parents_all_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[str]:
+    def get_parents_of_all_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> Dict[str, List[str]]:
         url = format_url(
             f"/api/v1/Dimensions('{dimension_name}')/Hierarchies('{hierarchy_name}')/Elements?$select=Name"
             f"&$expand=Parents($select=Name)",

--- a/TM1py/Services/ElementService.py
+++ b/TM1py/Services/ElementService.py
@@ -97,6 +97,21 @@ class ElementService(ObjectService):
         response = self._rest.GET(url, **kwargs)
         return [e["Name"] for e in response.json()['value']]
 
+    def get_consolidated_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[Element]:
+        url = format_url(
+            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type eq 3",
+            dimension_name,
+            hierarchy_name)
+        response = self._rest.GET(url, **kwargs)
+        return [Element.from_dict(element) for element in response.json()["value"]] 
+
+    def get_consolidated_element_names(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[str]:
+        url = format_url("/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type eq 3",
+                         dimension_name,
+                         hierarchy_name)
+        response = self._rest.GET(url, **kwargs)
+        return [e["Name"] for e in response.json()['value']]
+
     def get_element_names(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[str]:
         """ Get all element names
 

--- a/TM1py/Services/ElementService.py
+++ b/TM1py/Services/ElementService.py
@@ -127,6 +127,21 @@ class ElementService(ObjectService):
         response = self._rest.GET(url, **kwargs)
         return [e["Name"] for e in response.json()['value']]
 
+    def get_string_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[Element]:
+        url = format_url(
+            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type eq 2",
+            dimension_name,
+            hierarchy_name)
+        response = self._rest.GET(url, **kwargs)
+        return [Element.from_dict(element) for element in response.json()["value"]] 
+
+    def get_string_element_names(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[str]:
+        url = format_url("/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type eq 2",
+                         dimension_name,
+                         hierarchy_name)
+        response = self._rest.GET(url, **kwargs)
+        return [e["Name"] for e in response.json()['value']]
+
     def get_element_names(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[str]:
         """ Get all element names
 

--- a/Tests/ElementService_test.py
+++ b/Tests/ElementService_test.py
@@ -698,8 +698,8 @@ class TestElementService(unittest.TestCase):
                 hierarchy_name=self.hierarchy_name,
                 element_name="Not Existing Element")
 
-    def test_get_parents_all_elements_happy_case(self):
-        parents = self.tm1.elements.get_parents_all_elements(
+    def test_get_parents_of_all_elements_happy_case(self):
+        parents = self.tm1.elements.get_parents_of_all_elements(
             dimension_name=self.dimension_name,
             hierarchy_name=self.hierarchy_name
             )

--- a/Tests/ElementService_test.py
+++ b/Tests/ElementService_test.py
@@ -229,6 +229,23 @@ class TestElementService(unittest.TestCase):
         self.assertNotIn(self.extra_year, leaf_element_names)
         self.assertNotIn("Total Years", leaf_element_names)
 
+    def test_get_consolidated_element_names(self):
+        consol_element_names = self.tm1.dimensions.hierarchies.elements.get_consolidated_element_names(
+            self.dimension_name,
+            self.hierarchy_name)
+        for consol in consol_element_names:
+            self.assertNotIn(consol, self.years)
+        self.assertIn("Total Years", consol_element_names)
+
+    def test_get_numeric_element_names(self):
+        numeric_element_names = self.tm1.dimensions.hierarchies.elements.get_numeric_element_names(
+            self.dimension_name,
+            self.hierarchy_name)
+        for elem in numeric_element_names:
+            self.assertIn(elem, self.years)
+        self.assertNotIn(self.extra_year, numeric_element_names)
+        self.assertNotIn("Total Years", numeric_element_names)
+
     def test_get_leaf_elements(self):
         leaf_elements = self.tm1.dimensions.hierarchies.elements.get_leaf_elements(
             self.dimension_name,
@@ -239,6 +256,27 @@ class TestElementService(unittest.TestCase):
         leaf_element_names = [element.name for element in leaf_elements]
         self.assertNotIn(self.extra_year, leaf_element_names)
         self.assertNotIn("Total Year", leaf_element_names)
+
+    def test_get_numeric_elements(self):
+        numeric_elements = self.tm1.dimensions.hierarchies.elements.get_numeric_elements(
+            self.dimension_name,
+            self.hierarchy_name)
+        for elem in numeric_elements:
+            self.assertIn(elem.name, self.years)
+            self.assertNotEqual(elem.element_type, "Consolidated")
+        numeric_element_names = [element.name for element in numeric_elements]
+        self.assertNotIn(self.extra_year, numeric_element_names)
+        self.assertNotIn("Total Year", numeric_element_names)
+
+    def test_get_consolidated_elements(self):
+        consol_elements = self.tm1.dimensions.hierarchies.elements.get_consolidated_elements(
+            self.dimension_name,
+            self.hierarchy_name)
+        for consol in consol_elements:
+            self.assertNotIn(consol.name, self.years)
+            self.assertNotEqual(consol.element_type, "Numeric")
+        consol_element_names = [element.name for element in consol_elements]
+        self.assertIn("Total Year", consol_element_names)
 
     def test_element_exists(self):
         for year in self.years:
@@ -364,6 +402,50 @@ class TestElementService(unittest.TestCase):
             self.dimension_name, self.hierarchy_name)
 
         self.assertEqual(number_of_elements, 2)
+
+    def test_get_number_of_numeric_elements(self):
+        number_of_elements = self.tm1.dimensions.hierarchies.elements.get_number_of_numeric_elements(
+            self.dimension_name, self.hierarchy_name)
+
+        self.assertEqual(number_of_elements, 5)
+
+    def test_string_element_functions(self):
+        string_elem = 'string_element'
+        element = Element(string_elem, "String")
+        self.tm1.dimensions.hierarchies.elements.create(
+            self.dimension_name,
+            self.hierarchy_name,
+            element)
+        
+        number_of_elements = self.tm1.dimensions.hierarchies.elements.get_number_of_string_elements(
+            self.dimension_name, self.hierarchy_name)
+        self.assertEqual(number_of_elements, 1)
+
+        string_element_names = self.tm1.dimensions.hierarchies.elements.get_string_element_names(
+            self.dimension_name,
+            self.hierarchy_name)
+        for elem in string_element_names:
+            self.assertIn(elem, [string_elem])
+        self.assertNotIn('Total Years', string_element_names)
+        self.assertNotIn("1989", string_element_names)
+
+        string_elements = self.tm1.dimensions.hierarchies.elements.get_string_elements(
+            self.dimension_name,
+            self.hierarchy_name)
+        for elem in string_elements:
+            self.assertIn(elem.name, [string_elem])
+            self.assertNotEqual(elem.element_type, "Consolidated")
+            self.assertNotEqual(elem.element_type, "Numeric")
+        string_element_names = [element.name for element in string_elements]
+        self.assertNotIn('1989', string_element_names)
+        self.assertNotIn("Total Year", string_element_names)
+
+        self.tm1.dimensions.hierarchies.elements.delete(
+            self.dimension_name,
+            self.hierarchy_name,
+            element.name)
+
+
 
     def test_create_element_attribute(self):
         element_attribute = ElementAttribute("NewAttribute", "String")
@@ -615,6 +697,14 @@ class TestElementService(unittest.TestCase):
                 dimension_name=self.dimension_name,
                 hierarchy_name=self.hierarchy_name,
                 element_name="Not Existing Element")
+
+    def test_get_parents_all_elements_happy_case(self):
+        parents = self.tm1.elements.get_parents_all_elements(
+            dimension_name=self.dimension_name,
+            hierarchy_name=self.hierarchy_name
+            )
+
+        self.assertEqual(len(parents), 7)
 
     def test_element_is_parent_dim_not_exist(self):
         with self.assertRaises(TM1pyRestException):


### PR DESCRIPTION
I've added new functions to element service for string and numeric elements. I've also added a `get_parents_all_elements` function which is similar to `get_parents` but instead of taking an element argument, will return parents for all elements in dim.

I've taken a stab at the tests for these new functions. I wrapped all of the string element testing in one function because I add a string function to test and then immediately delete. This seemed better than adding it when the class is created, seemed like it could mess up some other tests.