### PR TITLE
Enable TCP keepalive option for executing long-run requests

### DIFF
--- a/TM1py/Services/RestService.py
+++ b/TM1py/Services/RestService.py
@@ -126,6 +126,14 @@ class RestService:
                'Accept': 'application/json;odata.metadata=none,text/plain',
                'TM1-SessionContext': 'TM1py'}
 
+    # You can reset the following TCP socket options based on your own use cases when tcp_keepalive is eanbled
+    # TCP_KEEPIDLE: Time in seconds until the first keepalive is sent
+    # TCP_KEEPINTVL: How often should the keepalive packet be sent
+    # TCP_KEEPCNT: The max number of keepalive packets to send
+    TCP_SOCKET_OPTIONS = {'TCP_KEEPIDLE': 30,
+                          'TCP_KEEPINTVL': 15,
+                          'TCP_KEEPCNT': 60}
+
     def __init__(self, **kwargs):
         """ Create an instance of RESTService
         :param address: String - address of the TM1 instance
@@ -237,15 +245,11 @@ class RestService:
 
     def _manage_http_adapter(self):
         if self._tcp_keepalive:
-            # Set the following socket options
             # SO_KEEPALIVE: set 1 to enable TCP keepalive
-            # TCP_KEEPIDLE: Time in seconds until the first keepalive is sent
-            # TCP_KEEPINTVL: How often should the keepalive packet be sent
-            # TCP_KEEPCNT: The max number of keepalive packets to send
             socket_options = urllib3.connection.HTTPConnection.default_socket_options + [(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
-                                                                                         (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 30),
-                                                                                         (socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 15),
-                                                                                         (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 60)]
+                                                                                         (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, self.TCP_SOCKET_OPTIONS['TCP_KEEPIDLE']),
+                                                                                         (socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, self.TCP_SOCKET_OPTIONS['TCP_KEEPINTVL']),
+                                                                                         (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, self.TCP_SOCKET_OPTIONS['TCP_KEEPCNT'])]
 
             if self._connection_pool_size is not None:
                 adapter = HTTPAdapterWithSocketOptions(pool_connections=int(self._connection_pool_size),

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -13,6 +13,7 @@ from io import StringIO
 from typing import Any, Dict, List, Tuple, Iterable, Optional, Generator, Union
 
 import requests
+from requests.adapters import HTTPAdapter
 from mdxpy import MdxBuilder, Member
 
 from TM1py.Exceptions.Exceptions import TM1pyVersionException, TM1pyNotAdminException
@@ -1164,3 +1165,14 @@ def frame_to_significant_digits(x, digits=15):
         return str(x).replace('e+', 'E')
     digits -= math.ceil(math.log10(abs(x)))
     return str(round(x, digits)).replace('e+', 'E')
+
+
+class HTTPAdapterWithSocketOptions(HTTPAdapter):
+    def __init__(self, *args, **kwargs):
+        self.socket_options = kwargs.pop("socket_options", None)
+        super(HTTPAdapterWithSocketOptions, self).__init__(*args, **kwargs)
+
+    def init_poolmanager(self, *args, **kwargs):
+        if self.socket_options is not None:
+            kwargs["socket_options"] = self.socket_options
+        super(HTTPAdapterWithSocketOptions, self).init_poolmanager(*args, **kwargs)


### PR DESCRIPTION
Hi, @MariusWirtz 
I have tested four methods and they look good to me. 
The usage of this parameter is similar to the async one. If both are specified, then async_requests_mode is used by default.
`with TM1Service(address, port, ssl, user, password, namespace, async_requests_mode=True, tcp_keepalive=True) as tm1:`
As you can see, the TCP keepalive method captures the response a bit faster (<1s) than the async mode and since it is operating at TCP layer level, it would be more efficient (no polling and no more connections) than the async method at HTTP layer level, I suppose. 
![image](https://user-images.githubusercontent.com/3345149/191941892-4b93d456-e498-4e8d-987f-2a5882ef5713.png)
I don't have other cloud environments to test. If someone can confirm it in other environments, it would be good. Thanks.