### PR TITLE
Additional features - CubeSaveData and DeleteAllPersistentFeeders

### DIFF
--- a/TM1py/Services/CubeService.py
+++ b/TM1py/Services/CubeService.py
@@ -346,6 +346,18 @@ class CubeService(ObjectService):
         url = format_url("/api/v1/Cubes('{}')/tm1.Unlock", cube_name)
         return self._rest.POST(url=url, **kwargs)
 
+    @require_admin
+    def cube_save_data(self, cube_name: str, **kwargs) -> Response:
+        """ Serializes a cube by saving data updates
+
+        :param cube_name:
+        :return: Response
+        """
+        from TM1py.Services import ProcessService
+        ti = "CubeSaveData('{0}');".format(cube_name)
+        process_service = ProcessService(self._rest)
+        return process_service.execute_ti_code(ti, **kwargs)
+
     def get_random_intersection(self, cube_name: str, unique_names: bool = False) -> List[str]:
         """ Get a random Intersection in a cube
         used mostly for regression testing.

--- a/TM1py/Services/ServerService.py
+++ b/TM1py/Services/ServerService.py
@@ -351,6 +351,13 @@ class ServerService(ObjectService):
         return process_service.execute_ti_code(ti, **kwargs)
 
     @require_admin
+    def delete_persistent_feeders(self, **kwargs) -> Response:
+        from TM1py.Services import ProcessService
+        ti = "DeleteAllPersistentFeeders;"
+        process_service = ProcessService(self._rest)
+        return process_service.execute_ti_code(ti, **kwargs)
+
+    @require_admin
     def start_performance_monitor(self):
         config = {
             "Administration": {"PerformanceMonitorOn": True}


### PR DESCRIPTION
This branch has two new updates in terms of additional features. 

i) A new function **cube_save_data** is added in CubeService.py to serialize a cube using TM1Py. This requires cube name as a parameter and returns the response code.
ii) A new function **delete_persistent_feeders** is added in ServerService.py to delete all persistent feeders using TM1Py. This does not require any parameter and returns the response code.

Both these functions executes a temporary ti process to execute CubeSaveData and DeleteAllPersistentFeeders functions respectively.