### PR TITLE
Add option to pass element selection as iterator in get_value function

### DIFF
--- a/Tests/CellService_test.py
+++ b/Tests/CellService_test.py
@@ -358,6 +358,51 @@ class TestCellService(unittest.TestCase):
         self.assertEqual(value, 2)
         self.tm1.cubes.cells.write_value(original_value, self.cube_name, ('element1', 'ELEMENT 2', 'EleMent  3'))
 
+    def test_get_value_iterator(self):
+        original_value = self.tm1.cubes.cells.get_value(self.cube_name, 'Element1, Element2, Element3')
+        response = self.tm1.cubes.cells.write_value(3, self.cube_name, ('element1', 'ELEMENT 2', 'EleMent  3'))
+        self.assertTrue(response.ok)
+        value = self.tm1.cubes.cells.get_value(self.cube_name, (
+            (self.dimension_names[0], 'Element1'), 
+            (self.dimension_names[1], 'EleMent2') ,
+            (self.dimension_names[2], 'ELEMENT  3')
+            ))
+        self.assertEqual(value, 3)
+        self.tm1.cubes.cells.write_value(original_value, self.cube_name, ('element1', 'ELEMENT 2', 'EleMent  3'))
+
+    def test_write_and_get_value_hierarchy(self):
+        original_value = self.tm1.cubes.cells.get_value(self.cube_name, 'Element1,EleMent2,ELEMENT  3')
+        response = self.tm1.cubes.cells.write_value(4, self.cube_name, ('element1', 'ELEMENT 2', 'EleMent  3'))
+        self.assertTrue(response.ok)
+        value = self.tm1.cubes.cells.get_value(self.cube_name, f'{self.dimension_names[0]}::Element1,EleMent2,{self.dimension_names[2]}::ELEMENT  3')
+        self.assertEqual(value, 4)
+        self.tm1.cubes.cells.write_value(original_value, self.cube_name, ('element1', 'ELEMENT 2', 'EleMent  3'))
+
+    def test_get_value_iterator_hierarchy(self):
+        original_value = self.tm1.cubes.cells.get_value(self.cube_name, 'Element1, Element2, Element3')
+        response = self.tm1.cubes.cells.write_value(5, self.cube_name, ('element1', 'ELEMENT 2', 'EleMent  3'))
+        self.assertTrue(response.ok)
+        value = self.tm1.cubes.cells.get_value(self.cube_name, [
+            (self.dimension_names[0], self.dimension_names[0],'Element1'), 
+            (self.dimension_names[1], 'EleMent2'), 
+            Member.of(self.dimension_names[2], self.dimension_names[2], 'ELEMENT  3')
+            ])
+        self.assertEqual(value, 5)
+        self.tm1.cubes.cells.write_value(original_value, self.cube_name, ('element1', 'ELEMENT 2', 'EleMent  3'))
+
+    def test_write_and_get_value_changed_separator(self):
+        original_value = self.tm1.cubes.cells.get_value(self.cube_name, 'Element1,EleMent2,ELEMENT  3')
+        response = self.tm1.cubes.cells.write_value(6, self.cube_name, ('element1', 'ELEMENT 2', 'EleMent  3'))
+        self.assertTrue(response.ok)
+        value = self.tm1.cubes.cells.get_value(
+            self.cube_name, 
+            f'{self.dimension_names[0]}$$Element1;EleMent2;{self.dimension_names[2]}  $$ ELEMENT  3',
+            element_separator=";",
+            hierarchy_element_separator="$$"
+        )
+        self.assertEqual(value, 6)
+        self.tm1.cubes.cells.write_value(original_value, self.cube_name, ('element1', 'ELEMENT 2', 'EleMent  3'))
+
     def test_write_values(self):
         cells = {("Element 2", "Element4", "Element7"): 716}
 

--- a/Tests/CellService_test.py
+++ b/Tests/CellService_test.py
@@ -403,6 +403,15 @@ class TestCellService(unittest.TestCase):
         self.assertEqual(value, 6)
         self.tm1.cubes.cells.write_value(original_value, self.cube_name, ('element1', 'ELEMENT 2', 'EleMent  3'))
 
+    def test_get_value_old_interface(self):
+        """ Tests if the old function interface with parameter element_string is still usable -> for backwards compatibility """
+        original_value = self.tm1.cubes.cells.get_value(self.cube_name, 'Element1,EleMent2,ELEMENT  3')
+        response = self.tm1.cubes.cells.write_value(7, self.cube_name, ('element1', 'ELEMENT 2', 'EleMent  3'))
+        self.assertTrue(response.ok)
+        value = self.tm1.cubes.cells.get_value(self.cube_name, element_string = 'Element1,EleMent2,ELEMENT  3')
+        self.assertEqual(value, 7)
+        self.tm1.cubes.cells.write_value(original_value, self.cube_name, ('element1', 'ELEMENT 2', 'EleMent  3'))
+
     def test_write_values(self):
         cells = {("Element 2", "Element4", "Element7"): 716}
 


### PR DESCRIPTION
Hi together,

@MariusWirtz 
We discussed the option to pass element coordinates as Iterators to the ```get_value()```-function. That would remove the need to specify special separators for the element string.
You also had the idea to use the MDXpy ```Member``` object. I tried that and it worked out really nice! :)

It also simplifies the building of the MDX statement, because it provides the ```unique_name``` directly.
This could be used to create the ```Member``` directly from the splitted strings too. After that the MDX query can be build independently of the input type always from the ```Member``` object.
So I did some little restructuring to use the ```Member``` consistently throughout the function.


The ```get_value``` function is now callable without hierarchies like this:

```python
get_value("CubeName", [(Dimension1, Element1), (Dimension2, Element2), (Dimension3, Element3)])
```

or with hierarchies like this:
```python
get_value("CubeName", [(Dimension1, Hierarchy1, Element1), (Dimension1, Hierarchy2, Element2), (Dimension2, Element3)])
```

or directly with the ```mdxpy.Member``` objects


Unfortunately this has the disadvantage that the user has to always provide the dimension name. If not given it is not distinguishable if the next element belongs to the next dimension or to the same dimension but another hierarchy.
Does anyone see an option to determine that?
