### PR TITLE
Update CellService.py

### DIFF
--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -1662,7 +1662,7 @@ class CellService(ObjectService):
         reader = csv.reader(StringIO(lines), delimiter=element_separator)
 
         # skip header
-        next(reader)
+        next(reader, None)
 
         elements_value_dict = CaseAndSpaceInsensitiveDict()
         for row in reader:


### PR DESCRIPTION
updated the skip header code for execute_mdx_elements_value_dict to include a default return of None. If using skip_rule_derived_cells you would potentially encounter an error if there were no records returned by the mdx. Essentially this error handles that problem by returning None.