### PR TITLE
Order args in `get_transaction_log_entries`

### DIFF
--- a/TM1py/Services/ServerService.py
+++ b/TM1py/Services/ServerService.py
@@ -8,8 +8,8 @@ from typing import Dict, Optional
 
 import pytz
 from requests import Response
-from TM1py.Objects.Process import Process
 
+from TM1py.Objects.Process import Process
 from TM1py.Services.ObjectService import ObjectService
 from TM1py.Services.RestService import RestService
 from TM1py.Utils import format_url
@@ -203,21 +203,22 @@ class ServerService(ObjectService):
         return timestamp_utc
 
     @require_admin
-    def get_transaction_log_entries(self, reverse: bool = True, user: str = None, cube: str = None, elements: Dict = None,
-                                    since: datetime = None, until: datetime = None, top: int = None, **kwargs) -> Dict:
+    def get_transaction_log_entries(self, reverse: bool = True, user: str = None, cube: str = None,
+                                    since: datetime = None, until: datetime = None, top: int = None,
+                                    elements: Dict[str, str] = None, **kwargs) -> Dict:
         """
         :param reverse: Boolean
         :param user: UserName
         :param cube: CubeName
-        :param elements: of type dict. Filtervalue as key and comparison operator as value tuple={'Filtervalue1':'eq','Filtervalue2': 'ge'}
         :param since: of type datetime. If it doesn't have tz information, UTC is assumed.
         :param until: of type datetime. If it doesn't have tz information, UTC is assumed.
         :param top: int
+        :param elements: of type dict. Element name as key and comparison operator as value
+        tuple={'Actual':'eq','2020': 'ge'}
         :return:
         """
         reverse = 'desc' if reverse else 'asc'
-        url = '/api/v1/TransactionLogEntries?$orderby=TimeStamp {} '.format(
-            reverse)
+        url = '/api/v1/TransactionLogEntries?$orderby=TimeStamp {} '.format(reverse)
         # filter on user, cube and time
         if user or cube or since or until:
             log_filters = []
@@ -227,7 +228,7 @@ class ServerService(ObjectService):
                 log_filters.append(format_url("Cube eq '{}'", cube))
             if elements:
                 log_filters.append(format_url(
-                    "Tuple/any(t: {})".format(" or ".join([f"t {v} '{k}'" for k, v in elements.items()]))))
+                    "Tuple/any(e: {})".format(" or ".join([f"e {v} '{k}'" for k, v in elements.items()]))))
             if since:
                 # If since doesn't have tz information, UTC is assumed
                 if not since.tzinfo:

--- a/Tests/ServerService_test.py
+++ b/Tests/ServerService_test.py
@@ -55,18 +55,21 @@ class TestServerService(unittest.TestCase):
             cls.tm1.dimensions.update_or_create(d)
 
         if not cls.tm1.cubes.exists(cls.cube_name):
-            cube = Cube(cls.cube_name, [
-                        cls.dimension_name1, cls.dimension_name2])
+            cube = Cube(
+                cls.cube_name,
+                [cls.dimension_name1, cls.dimension_name2])
             cls.tm1.cubes.update_or_create(cube)
 
         # inject process with ItemReject
-        cls.process1 = Process(name=cls.process_name1,
-                               prolog_procedure="ItemReject('TM1py Tests');")
+        cls.process1 = Process(
+            name=cls.process_name1,
+            prolog_procedure="ItemReject('TM1py Tests');")
         cls.tm1.processes.update_or_create(cls.process1)
 
         # inject process that does nothing and runs successful
-        cls.process2 = Process(name=cls.process_name2,
-                               prolog_procedure="sText = 'text';")
+        cls.process2 = Process(
+            name=cls.process_name2,
+            prolog_procedure="sText = 'text';")
         cls.tm1.processes.update_or_create(cls.process2)
 
         cls.tm1.server.activate_audit_log()
@@ -156,36 +159,7 @@ class TestServerService(unittest.TestCase):
         self.assertFalse(regex.search(log_entry))
 
     def test_get_last_transaction_log_entries(self):
-        self.tm1.processes.execute_ti_code(
-            lines_prolog="CubeSetLogChanges('{}', {});".format(self.cube_name, 1))
-
-        tmstp = datetime.datetime.utcnow()
-
-        # Generate 3 random numbers
-        random_values = [random.uniform(-10, 10) for _ in range(3)]
-        # Write value 1 to cube
-        cellset = {
-            ('2000', 'Value'): random_values[0]
-        }
-        self.tm1.cubes.cells.write_values(self.cube_name, cellset)
-
-        # Digest time in TM1
-        time.sleep(1)
-
-        # Write value 2 to cube
-        cellset = {
-            ('2001', 'Value'): random_values[1]
-        }
-        self.tm1.cubes.cells.write_values(self.cube_name, cellset)
-
-        # Digest time in TM1
-        time.sleep(1)
-
-        # Write value 3 to cube
-        cellset = {
-            ('2002', 'Value'): random_values[2]
-        }
-        self.tm1.cubes.cells.write_values(self.cube_name, cellset)
+        random_values, tmstp = self.write_values_to_cube()
 
         # Digest time in TM1
         time.sleep(8)
@@ -216,6 +190,15 @@ class TestServerService(unittest.TestCase):
         for v1, v2, v3 in zip(random_values, reversed(values_from_top), reversed(values_from_since)):
             self.assertAlmostEqual(v1, v2, delta=0.000000001)
 
+    def test_get_last_transaction_log_entries_filter_by_elements(self):
+        random_values, tmstp = self.write_values_to_cube()
+
+        # Digest time in TM1
+        time.sleep(8)
+
+        user = self.config['tm1srv01']['user']
+        cube = self.cube_name
+
         # Query transaction log with Since and Elements filter
         entries = self.tm1.server.get_transaction_log_entries(
             reverse=True,
@@ -229,6 +212,39 @@ class TestServerService(unittest.TestCase):
         # Compare value written to cube vs. value from filtered log
         # second value written to cube was  ('2001', 'Value'): random_values[1]
         self.assertAlmostEqual(values_from_elements[0], random_values[1])
+
+    def write_values_to_cube(self):
+        self.tm1.processes.execute_ti_code(
+            lines_prolog="CubeSetLogChanges('{}', {});".format(self.cube_name, 1))
+        tmstp = datetime.datetime.utcnow()
+
+        # Generate 3 random numbers
+        random_values = [random.uniform(-10, 10) for _ in range(3)]
+
+        # Write value 1 to cube
+        cellset = {
+            ('2000', 'Value'): random_values[0]
+        }
+        self.tm1.cubes.cells.write_values(self.cube_name, cellset)
+
+        # Digest time in TM1
+        time.sleep(1)
+
+        # Write value 2 to cube
+        cellset = {
+            ('2001', 'Value'): random_values[1]
+        }
+        self.tm1.cubes.cells.write_values(self.cube_name, cellset)
+
+        # Digest time in TM1
+        time.sleep(1)
+
+        # Write value 3 to cube
+        cellset = {
+            ('2002', 'Value'): random_values[2]
+        }
+        self.tm1.cubes.cells.write_values(self.cube_name, cellset)
+        return random_values, tmstp
 
     def test_get_transaction_log_entries_from_today(self):
         # get datetime from today at 00:00:00

--- a/Tests/ServerService_test.py
+++ b/Tests/ServerService_test.py
@@ -203,7 +203,7 @@ class TestServerService(unittest.TestCase):
         entries = self.tm1.server.get_transaction_log_entries(
             reverse=True,
             cube=cube,
-            elements={'2001': 'eq'},
+            element_tuple_filter={'2001': 'eq'},
             since=tmstp,
             top=10)
         values_from_elements = [entry['NewValue'] for entry in entries]


### PR DESCRIPTION
@ldelberg please approve.

For backward compatibility, I moved the elements as the last argument in the function.

I wonder how we should support position-based filtering in the function once the REST API allows for it.
I am not sure if we could manage it through the same argument. Maybe we introduce two arguments:
- `element_tuple_filter`
- `element_position_filter`

```
element_tuple_filter={'2020': 'gt', 'Actual': 'eq', 'Revenue': 'eq'}
```

```
element_position_filter={
0: {'2020': 'gt'},
2: {'Actual': 'eq', 'Budget': 'eq'},
7: {'Revenue': 'eq'}
}
```
What do you think?