### PR TITLE
fix to tm1projecttask

### DIFF
--- a/TM1py/Objects/GitProject.py
+++ b/TM1py/Objects/GitProject.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+    # -*- coding: utf-8 -*-
 
 import json
 from typing import Optional, Dict, List
@@ -69,13 +69,20 @@ class TM1ProjectTask:
             body["Dependencies"] = self.dependencies
 
         if self.chore:
-            body["Chore"] = self.chore
-
+            if not self.chore.startswith("Chores('"):
+                body = {
+                    "Chore": f"Chores('{self.chore}')"
+                }
+            else:
+                body["Chore"] = self.chore
         else:
-            body = {
-                "Process": f"Processes('{self.process}')",
-                "Parameters": self.parameters
-            }
+            if not self.process.startswith("Processes('"):
+                body = {
+                    "Process": f"Processes('{self.process}')",
+                }
+            else:
+                body["Process"] = self.process
+            body.update({"Parameters": self.parameters})
 
         return body
 


### PR DESCRIPTION
when loading a tm1project from file the tm1projecttask was repeating the task property: "Tasks": {"init_new_model": {"Process": "Processes('Processes('sys_initialize_new_model')')"}, "reset_instructions": {"Process": "Processes('Processes('sys_file_instructions_reset')')"}} Also the Chores option didn't have the "Chores" property fixed at the beginning of the string