### PR TITLE
Implement `use_blob` for `execute_mdx_csv` function

### DIFF
--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -3453,8 +3453,8 @@ class CellService(ObjectService):
     def _execute_view_csv_use_blob(self, cube_name: str, view_name: str, top: int, skip: int, skip_zeros: bool,
                                    skip_consolidated_cells: bool, skip_rule_derived_cells: bool,
                                    value_separator: str, cube_dimensions: List[str] = None,
-                                   include_headers: bool = True,
-                                   sandbox_name: str = None, **kwargs):
+                                   include_headers: bool = True, sandbox_name: str = None, quote_character: str = '"',
+                                   **kwargs):
         """ Execute existing view and retrieve result as csv, using blobs.
         Function has up to 40% better performance than default execute_view_csv on datasets > 1M cells
         and significantly lower memory footprint in all cases.
@@ -3466,6 +3466,7 @@ class CellService(ObjectService):
         :param skip_zeros: skip zeros in cellset (irrespective of zero suppression in view)
         :param skip_consolidated_cells: skip consolidated cells in cellset
         :param value_separator:
+        :param quote_character:
         :param cube_dimensions: pass dimensions in cube, to allow TM1py to skip retrieval and speed up the execution
         :param sandbox_name: str
         :include_headers: include header line in csv result
@@ -3530,6 +3531,7 @@ class CellService(ObjectService):
                 skip_zeros=skip_zeros,
                 skip_consolidated_cells=skip_consolidated_cells,
                 skip_rule_derived_cells=skip_rule_derived_cells,
+                quote_character=quote_character,
                 value_separator=value_separator,
                 sandbox_name=sandbox_name,
                 process_name=unique_name,

--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -1189,6 +1189,8 @@ class CellService(ObjectService):
             ENDIF;
             """
         if top:
+            if skip:
+                top += skip
             data_procedure_pre += f"""
             IF (nRecord > {top});
               ProcessBreak;

--- a/TM1py/Services/ObjectService.py
+++ b/TM1py/Services/ObjectService.py
@@ -25,15 +25,15 @@ class ObjectService:
         """
         self._rest = rest_service
 
-    def suggest_unique_object_name(self, random_seed: float = None):
+    def suggest_unique_object_name(self, random_seed: float = None) -> str:
         """
         Generate hash based on tm1-session-id, local-thread-id and random id to guarantee unique name
         avoids name conflicts in multithreading operations
         """
         if not random_seed:
             random_seed = random.random()
-        unique_string = f"tm1py.{self._rest.session_id}{threading.get_ident()}{random_seed}"
-        unique_hash = hashlib.sha256(unique_string.encode('utf-8')).hexdigest()[:12]
+        unique_string = f"{self._rest.session_id}{threading.get_ident()}{random_seed}"
+        unique_hash = "tm1py." + hashlib.sha256(unique_string.encode('utf-8')).hexdigest()[:12]
         return unique_hash
 
     def determine_actual_object_name(self, object_class: str, object_name: str, **kwargs) -> str:

--- a/TM1py/Services/ObjectService.py
+++ b/TM1py/Services/ObjectService.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+import hashlib
+import random
+import threading
 
 from TM1py.Exceptions import TM1pyRestException
 from TM1py.Services import RestService
@@ -21,6 +24,17 @@ class ObjectService:
         :param rest_service: 
         """
         self._rest = rest_service
+
+    def suggest_unique_object_name(self, random_seed: float = None):
+        """
+        Generate hash based on tm1-session-id, local-thread-id and random id to guarantee unique name
+        avoids name conflicts in multithreading operations
+        """
+        if not random_seed:
+            random_seed = random.random()
+        unique_string = f"tm1py.{self._rest.session_id}{threading.get_ident()}{random_seed}"
+        unique_hash = hashlib.sha256(unique_string.encode('utf-8')).hexdigest()[:12]
+        return unique_hash
 
     def determine_actual_object_name(self, object_class: str, object_name: str, **kwargs) -> str:
         url = format_url(

--- a/TM1py/Services/ViewService.py
+++ b/TM1py/Services/ViewService.py
@@ -63,7 +63,7 @@ class ViewService(ObjectService):
 
     def get(self, cube_name: str, view_name: str, private: bool = False, **kwargs) -> View:
         view_type = "PrivateViews" if private else "Views"
-        url = format_url("/api/v1/Cubes('{}')/{}('{}')?$expand=*,ViewAxisSelection", cube_name, view_type, view_name)
+        url = format_url("/api/v1/Cubes('{}')/{}('{}')?$expand=*", cube_name, view_type, view_name)
         response = self._rest.GET(url, **kwargs)
         view_as_dict = response.json()
         if "MDX" in view_as_dict:

--- a/TM1py/Services/ViewService.py
+++ b/TM1py/Services/ViewService.py
@@ -63,7 +63,7 @@ class ViewService(ObjectService):
 
     def get(self, cube_name: str, view_name: str, private: bool = False, **kwargs) -> View:
         view_type = "PrivateViews" if private else "Views"
-        url = format_url("/api/v1/Cubes('{}')/{}('{}')?$expand=*", cube_name, view_type, view_name)
+        url = format_url("/api/v1/Cubes('{}')/{}('{}')?$expand=*,ViewAxisSelection", cube_name, view_type, view_name)
         response = self._rest.GET(url, **kwargs)
         view_as_dict = response.json()
         if "MDX" in view_as_dict:

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -367,7 +367,10 @@ def build_csv_from_cellset_dict(
         return ""
 
     if csv_dialect is None:
-        csv.register_dialect("TM1py", delimiter=value_separator, lineterminator=line_separator)
+        csv.register_dialect(
+            "TM1py",
+            delimiter=value_separator,
+            lineterminator=line_separator)
         csv_dialect = csv.get_dialect("TM1py")
 
     csv_content = StringIO()
@@ -420,6 +423,18 @@ def build_csv_from_cellset_dict(
         csv_writer.writerow(line)
 
     return csv_content.getvalue().strip()
+
+
+def build_dataframe_from_csv(raw_csv, sep='~', **kwargs) -> 'pd.DataFrame':
+    if not raw_csv:
+        return pd.DataFrame()
+
+    memory_file = StringIO(raw_csv)
+    # make sure all element names are strings and values column is derived from data
+    if 'dtype' not in kwargs:
+        kwargs['dtype'] = {'Value': None, **{col: str for col in range(999)}}
+
+    return pd.read_csv(memory_file, sep=sep, na_values=["", None], keep_default_na=False, **kwargs)
 
 
 def _build_csv_line_items_from_axis_tuple(members: Dict, include_attributes: bool = False) -> List[str]:

--- a/Tests/CellService_test.py
+++ b/Tests/CellService_test.py
@@ -2759,6 +2759,22 @@ class TestCellService(unittest.TestCase):
             self.total_value,
             sum(values))
 
+    def test_execute_mdx_dataframe_use_blob_with_top_skip(self):
+        mdx = MdxBuilder.from_cube(self.cube_name) \
+            .add_hierarchy_set_to_row_axis(MdxHierarchySet.tm1_subset_all(self.dimension_names[0])) \
+            .add_hierarchy_set_to_column_axis(MdxHierarchySet.member(Member.of(self.dimension_names[1], "Element3"))) \
+            .where(Member.of(self.dimension_names[2], "Element3")) \
+            .to_mdx()
+
+        df = self.tm1.cubes.cells.execute_mdx_dataframe(mdx=mdx, top=1, skip=2, use_blob=True, skip_zeros=False)
+        self.assertEqual(len(df), 1)
+
+        expected_df = pd.DataFrame({
+            'TM1py_Tests_Cell_Dimension1': {0: 'Element 3'},
+            'TM1py_Tests_Cell_Dimension2': {0: 'Element 3'},
+            'Value': {0: 1.0}})
+        self.assertEqual(expected_df.to_csv(), df.to_csv())
+
     def test_execute_mdx_cellcount(self):
         mdx = MdxBuilder.from_cube(self.cube_name) \
             .rows_non_empty() \

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-SCHEDULE_VERSION = '1.10.2'
+SCHEDULE_VERSION = '1.11'
 SCHEDULE_DOWNLOAD_URL = (
         'https://github.com/Cubewise-code/TM1py/tarball/' + SCHEDULE_VERSION
 )


### PR DESCRIPTION
Solves #884

Add `use_blob` to `execute_mdx_csv`, `execute_mdx_dataframe`, `execute_view_csv`, `execute_view_dataframe`

Reduces time to execute MDX by 20-40%
Reduces time to execute NativeView by 40-50%
Reduces memory footprint of Python process significantly in all cases.