### PR TITLE
Introduce shaped arg to execute_mdx_dataframe

### DIFF
--- a/TM1py/Services/ElementService.py
+++ b/TM1py/Services/ElementService.py
@@ -124,7 +124,8 @@ class ElementService(ObjectService):
 
         if not isinstance(elements, str):
             if isinstance(elements, Iterable):
-                elements = "{" + ",".join(f"[{dimension_name}].[{hierarchy_name}].[{member}]" for member in elements) + "}"
+                elements = "{" + ",".join(
+                    f"[{dimension_name}].[{hierarchy_name}].[{member}]" for member in elements) + "}"
             else:
                 raise ValueError("Argument 'element_selection' must be None or str")
 
@@ -534,10 +535,11 @@ class ElementService(ObjectService):
     def get_element_types(self, dimension_name: str, hierarchy_name: str,
                           skip_consolidations: bool = False, **kwargs) -> CaseAndSpaceInsensitiveDict:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name,Type{}",
+            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name,Type",
             dimension_name,
-            hierarchy_name,
-            "&$filter=Type ne 3" if skip_consolidations else "")
+            hierarchy_name)
+        if skip_consolidations:
+            url += "&$filter=Type ne 3"
         response = self._rest.GET(url, **kwargs)
 
         result = CaseAndSpaceInsensitiveDict()
@@ -548,9 +550,9 @@ class ElementService(ObjectService):
     def get_element_types_from_all_hierarchies(
             self, dimension_name: str, skip_consolidations: bool = False, **kwargs) -> CaseAndSpaceInsensitiveDict:
         url = format_url(
-            "/api/v1/Dimensions('{}')?$expand=Hierarchies($select=Elements;$expand=Elements($select=Name,Type{}",
-            dimension_name,
-            ";$filter=Type ne 3))" if skip_consolidations else "))")
+            "/api/v1/Dimensions('{}')?$expand=Hierarchies($select=Elements;$expand=Elements($select=Name,Type",
+            dimension_name)
+        url += ";$filter=Type ne 3))" if skip_consolidations else "))"
         response = self._rest.GET(url, **kwargs)
 
         result = CaseAndSpaceInsensitiveDict()

--- a/TM1py/Services/PowerBiService.py
+++ b/TM1py/Services/PowerBiService.py
@@ -27,8 +27,14 @@ class PowerBiService:
         return self.cells.execute_mdx_dataframe_shaped(mdx, **kwargs)
 
     @require_pandas
-    def execute_view(self, cube_name, view_name, private, **kwargs) -> 'pd.DataFrame':
-        return self.cells.execute_view_dataframe_shaped(cube_name, view_name, private, **kwargs)
+    def execute_view(self, cube_name, view_name, private, use_iterative_json=False, use_blob=False, **kwargs) -> 'pd.DataFrame':
+        return self.cells.execute_view_dataframe_shaped(
+            cube_name,
+            view_name,
+            private,
+            use_iterative_json=use_iterative_json,
+            use_blob=use_blob,
+            **kwargs)
 
     @require_pandas
     def get_member_properties(self, dimension_name: str = None, hierarchy_name: str = None,

--- a/TM1py/Services/PowerBiService.py
+++ b/TM1py/Services/PowerBiService.py
@@ -27,7 +27,8 @@ class PowerBiService:
         return self.cells.execute_mdx_dataframe_shaped(mdx, **kwargs)
 
     @require_pandas
-    def execute_view(self, cube_name, view_name, private, use_iterative_json=False, use_blob=False, **kwargs) -> 'pd.DataFrame':
+    def execute_view(self, cube_name: str, view_name: str, private: bool, use_iterative_json=False, use_blob=False,
+                     **kwargs) -> 'pd.DataFrame':
         return self.cells.execute_view_dataframe_shaped(
             cube_name,
             view_name,

--- a/Tests/ServerService_test.py
+++ b/Tests/ServerService_test.py
@@ -7,6 +7,7 @@ import unittest
 from datetime import timedelta
 from pathlib import Path
 
+import pytest
 from dateutil import parser
 
 from TM1py.Exceptions import TM1pyRestException
@@ -14,6 +15,7 @@ from TM1py.Objects import Cube, Dimension, Hierarchy, Process
 from TM1py.Services import TM1Service
 
 
+@pytest.mark.skip(reason="Too slow for regular tests. Only run before releases")
 class TestServerService(unittest.TestCase):
     tm1: TM1Service
 

--- a/Tests/Utils_test.py
+++ b/Tests/Utils_test.py
@@ -9,7 +9,7 @@ from TM1py.Utils import (
     integerize_version,
     verify_version, get_cube, resembles_mdx, format_url, add_url_parameters, extract_cell_updateable_property,
     CellUpdateableProperty, cell_is_updateable, extract_cell_properties_from_odata_context,
-    map_cell_properties_to_compact_json_response, frame_to_significant_digits
+    map_cell_properties_to_compact_json_response, frame_to_significant_digits, drop_dimension_properties
 )
 
 
@@ -406,6 +406,74 @@ class TestUtilsMethods(unittest.TestCase):
     def test_element_name_from_element_unique_name_with_double_closing_square_bracket(self):
         element_name = Utils.element_name_from_element_unique_name("[d1].[other [please specify]]]")
         self.assertEqual("other [please specify]", element_name)
+
+    def test_drop_dimension_properties_member_name(self):
+        mdx = """
+        SELECT
+        {[d1].[e1]} DIMENSION PROPERTIES MEMBER_NAME ON 0,
+        {[d2].[e1]} DIMENSION PROPERTIES MEMBER_NAME ON 1
+        FROM [c1]
+        """
+        expected_mdx = """
+        SELECT
+        {[d1].[e1]} ON 0,
+        {[d2].[e1]} ON 1
+        FROM [c1]
+        """
+        self.assertEqual(
+            expected_mdx,
+            drop_dimension_properties(mdx))
+
+    def test_drop_dimension_properties_member_name_lower_case(self):
+        mdx = """
+        SELECT
+        {[d1].[e1]} dimension properties member_name ON 0,
+        {[d2].[e1]} dimension properties member_name ON 1
+        FROM [c1]
+        """
+        expected_mdx = """
+        SELECT
+        {[d1].[e1]} ON 0,
+        {[d2].[e1]} ON 1
+        FROM [c1]
+        """
+        self.assertEqual(
+            expected_mdx,
+            drop_dimension_properties(mdx))
+
+    def test_drop_dimension_properties_one_axis(self):
+        mdx = """
+        SELECT
+        {[d1].[e1]} * {[d2].[e1]} dimension properties member_name ON 0
+        FROM [c1]
+        """
+        expected_mdx = """
+        SELECT
+        {[d1].[e1]} * {[d2].[e1]} ON 0
+        FROM [c1]
+        """
+        self.assertEqual(
+            expected_mdx,
+            drop_dimension_properties(mdx))
+
+    def test_drop_dimension_properties_attributes(self):
+        mdx = """
+            SELECT
+            NON EMPTY {[dim2].[dim2].[elem2]} DIMENSION PROPERTIES [dim2].[dim2].[name] ON 0,
+            NON EMPTY {TM1FILTERBYLEVEL({TM1SUBSETALL([dim1].[dim1])},0)} DIMENSION PROPERTIES [dim1].[dim1].[codeandname] ON 1
+            FROM [cube]
+            WHERE ([dim3].[dim3].[elem3],[dim4].[dim4].[elem4])
+        """
+        expected_mdx = """
+            SELECT
+            NON EMPTY {[dim2].[dim2].[elem2]} ON 0,
+            NON EMPTY {TM1FILTERBYLEVEL({TM1SUBSETALL([dim1].[dim1])},0)} ON 1
+            FROM [cube]
+            WHERE ([dim3].[dim3].[elem3],[dim4].[dim4].[elem4])
+        """
+        self.assertEqual(
+            expected_mdx,
+            drop_dimension_properties(mdx))
 
     @classmethod
     def tearDownClass(cls):

--- a/Tests/Utils_test.py
+++ b/Tests/Utils_test.py
@@ -466,6 +466,74 @@ class TestUtilsMethods(unittest.TestCase):
         """
         expected_mdx = """
             SELECT
+            NON EMPTY {[dim2].[dim2].[elem2]}  ON 0,
+            NON EMPTY {TM1FILTERBYLEVEL({TM1SUBSETALL([dim1].[dim1])},0)}  ON 1
+            FROM [cube]
+            WHERE ([dim3].[dim3].[elem3],[dim4].[dim4].[elem4])
+        """
+        self.assertEqual(
+            expected_mdx,
+            drop_dimension_properties(mdx))
+
+    def test_drop_dimension_properties_member_name(self):
+        mdx = """
+        SELECT
+        {[d1].[e1]} PROPERTIES MEMBER_NAME ON 0,
+        {[d2].[e1]} PROPERTIES MEMBER_NAME ON 1
+        FROM [c1]
+        """
+        expected_mdx = """
+        SELECT
+        {[d1].[e1]} ON 0,
+        {[d2].[e1]} ON 1
+        FROM [c1]
+        """
+        self.assertEqual(
+            expected_mdx,
+            drop_dimension_properties(mdx))
+
+    def test_drop_dimension_properties_member_name_lower_case(self):
+        mdx = """
+        SELECT
+        {[d1].[e1]} properties member_name ON 0,
+        {[d2].[e1]} properties member_name ON 1
+        FROM [c1]
+        """
+        expected_mdx = """
+        SELECT
+        {[d1].[e1]} ON 0,
+        {[d2].[e1]} ON 1
+        FROM [c1]
+        """
+        self.assertEqual(
+            expected_mdx,
+            drop_dimension_properties(mdx))
+
+    def test_drop_dimension_properties_one_axis(self):
+        mdx = """
+        SELECT
+        {[d1].[e1]} * {[d2].[e1]} properties member_name ON 0
+        FROM [c1]
+        """
+        expected_mdx = """
+        SELECT
+        {[d1].[e1]} * {[d2].[e1]} ON 0
+        FROM [c1]
+        """
+        self.assertEqual(
+            expected_mdx,
+            drop_dimension_properties(mdx))
+
+    def test_drop_properties_attributes(self):
+        mdx = """
+            SELECT
+            NON EMPTY {[dim2].[dim2].[elem2]} PROPERTIES [dim2].[dim2].[name] ON 0,
+            NON EMPTY {TM1FILTERBYLEVEL({TM1SUBSETALL([dim1].[dim1])},0)} PROPERTIES [dim1].[dim1].[codeandname] ON 1
+            FROM [cube]
+            WHERE ([dim3].[dim3].[elem3],[dim4].[dim4].[elem4])
+        """
+        expected_mdx = """
+            SELECT
             NON EMPTY {[dim2].[dim2].[elem2]} ON 0,
             NON EMPTY {TM1FILTERBYLEVEL({TM1SUBSETALL([dim1].[dim1])},0)} ON 1
             FROM [cube]


### PR DESCRIPTION
Inspired by
https://github.com/Kevin-Dekker/tm1py/commit/8ab9901b0c04c63c221077d8cdfd1d20f113e62e#diff-5242c6c19161de7f529a4e5b0d0b33ca9c15f69be65fa5409881b3d8310ff655R2799-R2802

`execute_mdx_dataframe`, `execute_view_datafame` can be run with `shaped=True` to retrieve a similar but not fully equivalent result to `execute_mdx_dataframe_shaped`.
 
This allows retrieving a shaped data frame while specifying options that are not available in `execute_mdx_dataframe_shaped`. One example is the usage of `use_iterative_json=True` and `use_blob=True` which optimizes memory usage during string to json / dict conversion prior to the creation of the data frame.
 
Fixes #888