### PR TITLE
Make execute_view_csv with use_blob robust

### DIFF
--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -3483,7 +3483,7 @@ class CellService(ObjectService):
                 mdx=mdx, top=top, skip=skip, skip_zeros=skip_zeros,
                 skip_consolidated_cells=skip_consolidated_cells, skip_rule_derived_cells=skip_rule_derived_cells,
                 value_separator=value_separator, cube_dimensions=cube_dimensions, sandbox_name=sandbox_name,
-                include_headers=include_headers)
+                include_headers=include_headers, quote_character=quote_character)
 
         cube, titles, rows, columns = self._derive_cellset_composition_from_native_view(cube_name, view_name, False)
 
@@ -3579,7 +3579,7 @@ class CellService(ObjectService):
                                   skip_consolidated_cells: bool, skip_rule_derived_cells: bool,
                                   value_separator: str, cube_dimensions: List[str] = None,
                                   sandbox_name: str = None, include_headers: bool = True,
-                                  **kwargs):
+                                  quote_character='"', **kwargs):
         """ Execute MDX and retrieve result as csv, using blobs.
         Function has up to 40% better performance than default execute_mdx_csv on datasets > 1M cells
         and significantly lower memory footprint in all cases.
@@ -3588,8 +3588,10 @@ class CellService(ObjectService):
         :param top: Int, number of cells to return (counting from top)
         :param skip: Int, number of cells to skip (counting from top)
         :param skip_zeros: skip zeros in cellset (irrespective of zero suppression in MDX / view)
-        :param skip_consolidated_cells: skip consolidated cells in cellset
+        :param skip_consolidated_cells: skip consolidated cells in result set
+        :param skip_rule_derived_cells: skip rule derived cells result set
         :param value_separator:
+        :param quote_character:
         :param cube_dimensions: pass dimensions in cube, to allow TM1py to skip retrieval and speed up the execution
         :param sandbox_name: str
         :include_headers: include header line in csv result
@@ -3662,7 +3664,8 @@ class CellService(ObjectService):
                 process_name=unique_name,
                 view_name=unique_name,
                 file_name=file_name,
-                header_line=header_line)
+                header_line=header_line,
+                quote_character=quote_character)
 
             success, status, error_log_file = process_service.execute_process_with_return(process, **kwargs)
             if not success:

--- a/TM1py/Services/ViewService.py
+++ b/TM1py/Services/ViewService.py
@@ -270,3 +270,18 @@ class ViewService(ObjectService):
                         public_views.append(view)
 
         return private_views, public_views
+
+    def is_mdx_view(self, cube_name: str, view_name: str, private=False, **kwargs):
+        url_template = "/api/v1/Cubes('{}')/{}('{}')?select=Name"
+        if private is not None:
+            url = format_url(url_template, cube_name, "PrivateViews" if private else "Views", view_name)
+
+        response = self._rest.GET(url, **kwargs)
+        # e.g.: "ibm.tm1.api.v1.NativeView"
+        odata_type = response.json()["@odata.type"]
+        if odata_type.split('.')[-1] == "NativeView":
+            return False
+        return True
+
+    def is_native_view(self, cube_name: str, view_name: str, private=False):
+        return not self.is_mdx_view(cube_name, view_name, private)

--- a/Tests/ViewService_test.py
+++ b/Tests/ViewService_test.py
@@ -100,11 +100,11 @@ class TestViewService(unittest.TestCase):
             # Suppress Null Values
             native_view.suppress_empty_cells = True
             # create native view on Server
-            self.tm1.cubes.views.create(
+            self.tm1.views.create(
                 view=native_view,
                 private=private)
             # create instance of MDXView
-            nv_view = self.tm1.cubes.views.get_native_view(
+            nv_view = self.tm1.views.get_native_view(
                 cube_name=self.cube_name,
                 view_name=self.native_view_name,
                 private=private)
@@ -114,49 +114,49 @@ class TestViewService(unittest.TestCase):
                 view_name=self.mdx_view_name,
                 MDX=mdx)
             # create mdx view on Server
-            self.tm1.cubes.views.create(
+            self.tm1.views.create(
                 view=mdx_view,
                 private=private)
 
     def test_view_exists(self):
         for private in (True, False):
-            self.assertTrue(self.tm1.cubes.views.exists(
+            self.assertTrue(self.tm1.views.exists(
                 cube_name=self.cube_name,
                 view_name=self.native_view_name,
                 private=private))
-            self.assertTrue(self.tm1.cubes.views.exists(
+            self.assertTrue(self.tm1.views.exists(
                 cube_name=self.cube_name,
                 view_name=self.mdx_view_name,
                 private=private))
-        exists_as_private, exists_as_public = self.tm1.cubes.views.exists(
+        exists_as_private, exists_as_public = self.tm1.views.exists(
             cube_name=self.cube_name,
             view_name=self.mdx_view_name)
         self.assertTrue(exists_as_private)
         self.assertTrue(exists_as_public)
-        exists_as_private, exists_as_public = self.tm1.cubes.views.exists(
+        exists_as_private, exists_as_public = self.tm1.views.exists(
             cube_name=self.cube_name,
             view_name=self.native_view_name)
         self.assertTrue(exists_as_private)
         self.assertTrue(exists_as_public)
 
     def test_get_all_views(self):
-        private_views, public_views = self.tm1.cubes.views.get_all(self.cube_name)
+        private_views, public_views = self.tm1.views.get_all(self.cube_name)
         self.assertGreater(len(public_views + private_views), 0)
 
-        private_view_names, public_view_names = self.tm1.cubes.views.get_all_names(self.cube_name)
+        private_view_names, public_view_names = self.tm1.views.get_all_names(self.cube_name)
         self.assertEqual(len(public_views), len(public_view_names))
         self.assertEqual(len(private_views), len(private_view_names))
 
     def test_get_native_view(self):
         for private in (True, False):
             # generic get
-            view = self.tm1.cubes.views.get(
+            view = self.tm1.views.get(
                 cube_name=self.cube_name,
                 view_name=self.native_view_name,
                 private=private)
 
             # get native view
-            native_view = self.tm1.cubes.views.get_native_view(
+            native_view = self.tm1.views.get_native_view(
                 cube_name=self.cube_name,
                 view_name=self.native_view_name,
                 private=private)
@@ -169,13 +169,13 @@ class TestViewService(unittest.TestCase):
     def test_get_mdx_view(self):
         for private in (True, False):
             # generic get
-            view = self.tm1.cubes.views.get(
+            view = self.tm1.views.get(
                 cube_name=self.cube_name,
                 view_name=self.mdx_view_name,
                 private=private)
 
             # get mdx view
-            mdx_view = self.tm1.cubes.views.get_mdx_view(
+            mdx_view = self.tm1.views.get_mdx_view(
                 cube_name=self.cube_name,
                 view_name=self.mdx_view_name,
                 private=private)
@@ -205,7 +205,7 @@ class TestViewService(unittest.TestCase):
     def test_update_nativeview(self):
         for private in (True, False):
             # get native view
-            native_view_original = self.tm1.cubes.views.get_native_view(
+            native_view_original = self.tm1.views.get_native_view(
                 cube_name=self.cube_name,
                 view_name=self.native_view_name,
                 private=private)
@@ -227,7 +227,7 @@ class TestViewService(unittest.TestCase):
                 dimension_name=self.dimension_names[0],
                 subset=subset)
             # update it on Server
-            self.tm1.cubes.views.update(
+            self.tm1.views.update(
                 view=native_view_original,
                 private=private)
             # Get it and check if its different
@@ -243,7 +243,7 @@ class TestViewService(unittest.TestCase):
     def test_update_mdxview(self):
         for private in (True, False):
             # Get mdx view
-            mdx_view_original = self.tm1.cubes.views.get_mdx_view(
+            mdx_view_original = self.tm1.views.get_mdx_view(
                 cube_name=self.cube_name,
                 view_name=self.mdx_view_name,
                 private=private)
@@ -260,9 +260,9 @@ class TestViewService(unittest.TestCase):
                                                      self.cube_name, self.dimension_names[2])
             mdx_view_original.MDX = mdx
             # Update mdx view on Server
-            self.tm1.cubes.views.update(mdx_view_original, private=private)
+            self.tm1.views.update(mdx_view_original, private=private)
             # Get it and check if its different
-            mdx_view_updated = self.tm1.cubes.views.get_mdx_view(
+            mdx_view_updated = self.tm1.views.get_mdx_view(
                 cube_name=self.cube_name,
                 view_name=self.mdx_view_name,
                 private=private)
@@ -352,10 +352,23 @@ class TestViewService(unittest.TestCase):
         self.assertEqual(0, len(private_views))
         self.assertEqual(0, len(public_views))
 
+    def test_is_native_view(self):
+        for private in (True, False):
+            self.assertTrue(self.tm1.views.is_native_view(
+                cube_name=self.cube_name,
+                view_name=self.native_view_name,
+                private=private))
+
+            self.assertTrue(self.tm1.views.is_mdx_view(
+                cube_name=self.cube_name,
+                view_name=self.mdx_view_name,
+                private=private))
+
+    
     def tearDown(self):
         for private in (True, False):
-            self.tm1.cubes.views.delete(cube_name=self.cube_name, view_name=self.native_view_name, private=private)
-            self.tm1.cubes.views.delete(cube_name=self.cube_name, view_name=self.mdx_view_name, private=private)
+            self.tm1.views.delete(cube_name=self.cube_name, view_name=self.native_view_name, private=private)
+            self.tm1.views.delete(cube_name=self.cube_name, view_name=self.mdx_view_name, private=private)
 
     @classmethod
     def teardown_class(cls):
@@ -363,7 +376,6 @@ class TestViewService(unittest.TestCase):
         for dimension_name in cls.dimension_names:
             cls.tm1.dimensions.delete(dimension_name)
         cls.tm1.logout()
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- eliminate an issue that TI considers elements in title subsets for data source
- allow usage of `execute_view_csv` and `execute_view_dataframe` on MDX view