### PR TITLE
Spreading on write with use_blob & use_ti

### DIFF
--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -1140,7 +1140,10 @@ class CellService(ObjectService):
 
         # Define TI write function based on parameter 'increment' and nature of the cube
 
-        numeric_function_str = "CellPutN" if cube_name.lower().startswith("}elementattributes_") else  "CellIncrementN"
+        if cube_name.lower().startswith("}elementattributes_"):
+            numeric_function_str = "CellPutN"
+        else:
+            numeric_function_str = "CellIncrementN" if increment else "CellPutN"
 
         # Define input statement depending on measure element's type: numeric or string
         # For non-existing-element attempt to write to trigger error

--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -839,7 +839,7 @@ class CellService(ObjectService):
               deactivate_transaction_log: bool = False, reactivate_transaction_log: bool = False,
               sandbox_name: str = None, use_ti: bool = False, use_blob: bool = False, use_changeset: bool = False,
               precision: int = None, skip_non_updateable: bool = False, measure_dimension_elements: Dict = None,
-              remove_blob: bool = True, allow_spread:bool=False, **kwargs) -> Optional[str]:
+              remove_blob: bool = True, allow_spread: bool=False, **kwargs) -> Optional[str]:
         """ Write values to a cube
 
         Same signature as `write_values` method, but faster since it uses `write_values_through_cellset`
@@ -989,6 +989,8 @@ class CellService(ObjectService):
                 skip_non_updateable=skip_non_updateable)
 
         else:
+            if not dimensions and allow_spread:
+                dimensions = self.get_dimension_names_for_writing(cube_name=cube_name, **kwargs)
             statements = self._build_cell_update_statements(
                 cube_name=cube_name,
                 cellset_as_dict=cellset_as_dict,

--- a/Tests/CellService_test.py
+++ b/Tests/CellService_test.py
@@ -477,6 +477,38 @@ class TestCellService(unittest.TestCase):
 
         self.assertEqual(self.tm1.cells.execute_mdx_values(mdx=query.to_mdx()), [1234])
 
+    def test_write_use_blob_allow_spread(self):
+        cells = {("Element 1", "Element4", "Element9"): 1,
+                 ("Element 1", "Element4", "TOTAL_TM1py_Tests_Cell_Dimension3_With_Consolidations"): 54321}
+        try:
+            self.tm1.cubes.cells.write(self.cube_with_consolidations_name, cells, use_blob=True, allow_spread=True)
+        except (TM1pyWriteFailureException, TM1pyWritePartialFailureException) as ex:
+            for log_file in ex.error_log_files:
+                print(self.tm1.processes.get_error_log_file_content(log_file))
+        query = MdxBuilder.from_cube(self.cube_with_consolidations_name)
+        query.add_member_tuple_to_columns(
+            f"[{self.dimensions_with_consolidations_names[0]}].[Element 1]",
+            f"[{self.dimensions_with_consolidations_names[1]}].[Element 4]",
+            f"[{self.dimensions_with_consolidations_names[2]}].[TOTAL_TM1py_Tests_Cell_Dimension3_With_Consolidations]")
+
+        self.assertEqual(self.tm1.cells.execute_mdx_values(mdx=query.to_mdx()), [54321])
+
+    def test_write_use_ti_allow_spread(self):
+        cells = {("Element 1", "Element4", "Element9"): 1,
+                 ("Element 1", "Element4", "TOTAL_TM1py_Tests_Cell_Dimension3_With_Consolidations"): 54321}
+        try:
+            self.tm1.cubes.cells.write(self.cube_with_consolidations_name, cells, use_ti=True, allow_spread=True)
+        except (TM1pyWriteFailureException, TM1pyWritePartialFailureException) as ex:
+            for log_file in ex.error_log_files:
+                print(self.tm1.processes.get_error_log_file_content(log_file))
+        query = MdxBuilder.from_cube(self.cube_with_consolidations_name)
+        query.add_member_tuple_to_columns(
+            f"[{self.dimensions_with_consolidations_names[0]}].[Element 1]",
+            f"[{self.dimensions_with_consolidations_names[1]}].[Element 4]",
+            f"[{self.dimensions_with_consolidations_names[2]}].[TOTAL_TM1py_Tests_Cell_Dimension3_With_Consolidations]")
+
+        self.assertEqual(self.tm1.cells.execute_mdx_values(mdx=query.to_mdx()), [54321])
+
     def test_write_use_ti_skip_non_updateable(self):
         cells = CaseAndSpaceInsensitiveTuplesDict()
         cells["Element 1", "Element4", "TOTAL_" + self.dimensions_with_consolidations_names[2]] = 5


### PR DESCRIPTION
A concept to allow simple proportional spreads in case any of the elements (coordinates) is c level and the value to write is numerical when using use_ti or use_blob.

**Usage**
Specify allow_spread=True and write to one or more c level elements. 

**Tests** 
Scripts included in tm1py/Tests, further tests required.

**Limitations**
- Does not increment, 
- Speed not compared between allow_spread=True and allow_spread=False.
- Implementation on use_ti not very clean. Although, it's in the same style as the current code in the write_through_unbound_process function.