### PR TITLE
Add `proxies` arg to `TM1Service`

### DIFF
--- a/TM1py/Services/TM1Service.py
+++ b/TM1py/Services/TM1Service.py
@@ -13,6 +13,43 @@ class TM1Service:
     """
 
     def __init__(self, **kwargs):
+        """ Initiate the TM1Service
+
+        :param address: String - address of the TM1 instance
+        :param port: Int - HTTPPortNumber as specified in the tm1s.cfg
+        :param base_url - base url e.g. https://localhost:12354/api/v1
+        :param user: String - name of the user
+        :param password String - password of the user
+        :param decode_b64 - whether password argument is b64 encoded
+        :param namespace String - optional CAM namespace
+        :param ssl: boolean -  as specified in the tm1s.cfg
+        :param cam_passport: String - the cam passport
+        :param session_id: String - TM1SessionId e.g. q7O6e1w49AixeuLVxJ1GZg
+        :param session_context: String - Name of the Application. Controls "Context" column in Arc / TM1top.
+                If None, use default: TM1py
+        :param verify: path to .cer file or 'True' / True / 'False' / False (if no ssl verification is required)
+        :param logging: boolean - switch on/off verbose http logging into sys.stdout
+        :param timeout: Float - Number of seconds that the client will wait to receive the first byte.
+        :param cancel_at_timeout: Abort operation in TM1 when timeout is reached
+        :param async_requests_mode: changes internal REST execution mode to avoid 60s timeout on IBM cloud
+        :param tcp_keepalive: maintain the TCP connection all the time, users should choose either async_requests_mode or tcp_keepalive to run a long-run request
+                If both are True, use async_requests_mode by default
+        :param connection_pool_size - In a multi threaded environment, you should set this value to a
+                higher number, such as the number of threads
+        :param integrated_login: True for IntegratedSecurityMode3
+        :param integrated_login_domain: NT Domain name.
+                Default: '.' for local account.
+        :param integrated_login_service: Kerberos Service type for remote Service Principal Name.
+                Default: 'HTTP'
+        :param integrated_login_host: Host name for Service Principal Name.
+                Default: Extracted from request URI
+        :param integrated_login_delegate: Indicates that the user's credentials are to be delegated to the server.
+                Default: False
+        :param impersonate: Name of user to impersonate
+        :param re_connect_on_session_timeout: attempt to reconnect once if session is timed out
+        :param proxies: pass a dictionary with proxies e.g.
+                {'http': 'http://proxy.example.com:8080', 'https': 'http://secureproxy.example.com:8090'}
+        """
         self._tm1_rest = RestService(**kwargs)
         self.annotations = AnnotationService(self._tm1_rest)
         self.cells = CellService(self._tm1_rest)


### PR DESCRIPTION
Accept `proxies` argument in `TM1Service` constructor

@Cubewise-gtejeda 
please upgrade to this branch and test it.

```
pip uninstall tm1py
pip install https://github.com/cubewise-code/tm1py/archive/refs/heads/feature/support-proxy.zip
```

``` python
proxies = {
   'http': 'http://proxy.example.com:8080',
   'https': 'http://secureproxy.example.com:8090',
}

with TM1Service(**params, proxies=proxies) as tm1:
    print(tm1.server.get_product_version())
}
```