### PR TITLE
Tm1 v12 support service url

### DIFF
--- a/TM1py/Objects/Chore.py
+++ b/TM1py/Objects/Chore.py
@@ -31,7 +31,7 @@ class Chore(TM1Object):
     def from_json(cls, chore_as_json: str) -> 'Chore':
         """ Alternative constructor
 
-        :param chore_as_json: string, JSON. Response of /api/v1/Chores('x')/Tasks?$expand=*
+        :param chore_as_json: string, JSON. Response of /Chores('x')/Tasks?$expand=*
         :return: Chore, an instance of this class
         """
         chore_as_dict = json.loads(chore_as_json)

--- a/TM1py/Objects/GitProject.py
+++ b/TM1py/Objects/GitProject.py
@@ -274,7 +274,7 @@ class TM1Project(TM1Object):
     @classmethod
     def from_json(cls, tm1project_as_json: str) -> 'TM1Project':
         """
-        :param tm1project_as_json: response of /api/v1/!tm1project
+        :param tm1project_as_json: response of /!tm1project
         :return: an instance of this class
         """
         tm1project_as_dict = json.loads(tm1project_as_json)

--- a/TM1py/Objects/Process.py
+++ b/TM1py/Objects/Process.py
@@ -123,7 +123,7 @@ class Process(TM1Object):
     @classmethod
     def from_json(cls, process_as_json: str) -> 'Process':
         """
-        :param process_as_json: response of /api/v1/Processes('x')?$expand=*
+        :param process_as_json: response of /Processes('x')?$expand=*
         :return: an instance of this class
         """
         process_as_dict = json.loads(process_as_json)

--- a/TM1py/Objects/Server.py
+++ b/TM1py/Objects/Server.py
@@ -6,7 +6,7 @@ class Server:
     """ Abstraction of the TM1 Server
 
         :Notes:
-            contains the information you get from http://localhost:5895/api/v1/Servers
+            contains the information you get from http://localhost:5895/Servers
             no methods so far
     """
     def __init__(self, server_as_dict: Dict):

--- a/TM1py/Services/AnnotationService.py
+++ b/TM1py/Services/AnnotationService.py
@@ -24,7 +24,7 @@ class AnnotationService(ObjectService):
 
         :param cube_name:
         """
-        url = format_url("/api/v1/Cubes('{}')/Annotations?$expand=DimensionalContext($select=Name)", cube_name)
+        url = format_url("/Cubes('{}')/Annotations?$expand=DimensionalContext($select=Name)", cube_name)
         response = self._rest.GET(url, **kwargs)
 
         annotations_as_dict = response.json()['value']
@@ -36,7 +36,7 @@ class AnnotationService(ObjectService):
 
         :param annotation: instance of TM1py.Annotation
         """
-        url = "/api/v1/Annotations"
+        url = "/Annotations"
 
         from TM1py import CubeService
         cube_dimensions = CubeService(self._rest).get_dimension_names(
@@ -65,7 +65,7 @@ class AnnotationService(ObjectService):
                 cube_dimensions[annotation.object_name] = dimension_names
             payload.append(annotation.construct_body_for_post(dimension_names))
 
-        response = self._rest.POST("/api/v1/Annotations", json.dumps(payload), **kwargs)
+        response = self._rest.POST("/Annotations", json.dumps(payload), **kwargs)
 
         return response
 
@@ -74,7 +74,7 @@ class AnnotationService(ObjectService):
 
         :param annotation_id: String, the id of the annotation
         """
-        request = format_url("/api/v1/Annotations('{}')?$expand=DimensionalContext($select=Name)", annotation_id)
+        request = format_url("/Annotations('{}')?$expand=DimensionalContext($select=Name)", annotation_id)
         response = self._rest.GET(url=request, **kwargs)
         return Annotation.from_json(response.text)
 
@@ -84,7 +84,7 @@ class AnnotationService(ObjectService):
 
         :param annotation: instance of TM1py.Annotation
         """
-        url = format_url("/api/v1/Annotations('{}')", annotation.id)
+        url = format_url("/Annotations('{}')", annotation.id)
         return self._rest.PATCH(url=url, data=annotation.body, **kwargs)
 
     def delete(self, annotation_id: str, **kwargs) -> Response:
@@ -92,5 +92,5 @@ class AnnotationService(ObjectService):
     
         :param annotation_id: string, the id of the annotation
         """
-        url = format_url("/api/v1/Annotations('{}')", annotation_id)
+        url = format_url("/Annotations('{}')", annotation_id)
         return self._rest.DELETE(url=url, **kwargs)

--- a/TM1py/Services/ApplicationService.py
+++ b/TM1py/Services/ApplicationService.py
@@ -50,7 +50,7 @@ class ApplicationService(ObjectService):
             mid = "".join([format_url("/Contents('{}')", element) for element in path.split('/')])
 
         base_url = format_url(
-            "/api/v1/Contents('Applications')" + mid + "/" + contents + "('{application_name}')",
+            "/Contents('Applications')" + mid + "/" + contents + "('{application_name}')",
             application_name=name)
 
         if application_type == ApplicationTypes.CUBE:
@@ -118,13 +118,13 @@ class ApplicationService(ObjectService):
         contents = 'PrivateContents' if private else 'Contents'
         mid = "".join([format_url("/Contents('{}')", element) for element in path.split('/')])
         url = format_url(
-            "/api/v1/Contents('Applications')" + mid + "/" + contents + "('{name}')/Document/Content",
+            "/Contents('Applications')" + mid + "/" + contents + "('{name}')/Document/Content",
             name=name)
 
         content = self._rest.GET(url, **kwargs).content
 
         url = format_url(
-            "/api/v1/Contents('Applications')" + mid + "/" + contents + "('{name}')/Document",
+            "/Contents('Applications')" + mid + "/" + contents + "('{name}')/Document",
             name=name)
         document_fields = self._rest.GET(url, **kwargs).json()
 
@@ -159,7 +159,7 @@ class ApplicationService(ObjectService):
             mid = "".join([format_url("/Contents('{}')", element) for element in path.split('/')])
 
         url = format_url(
-            "/api/v1/Contents('Applications')" + mid + "/" + contents + "('{application_name}')",
+            "/Contents('Applications')" + mid + "/" + contents + "('{application_name}')",
             application_name=application_name)
         return self._rest.DELETE(url, **kwargs)
 
@@ -177,7 +177,7 @@ class ApplicationService(ObjectService):
             mid = "".join([format_url("/Contents('{}')", element) for element in path.split('/')])
 
         url = format_url(
-            "/api/v1/Contents('Applications')" + mid + "/" + contents + "('{application_name}')/tm1.Move",
+            "/Contents('Applications')" + mid + "/" + contents + "('{application_name}')/tm1.Move",
             application_name=application_name)
         data = {"Name": new_application_name}
 
@@ -196,12 +196,12 @@ class ApplicationService(ObjectService):
         mid = ""
         if application.path.strip() != '':
             mid = "".join([format_url("/Contents('{}')", element) for element in application.path.split('/')])
-        url = "/api/v1/Contents('Applications')" + mid + "/" + contents
+        url = "/Contents('Applications')" + mid + "/" + contents
         response = self._rest.POST(url, application.body, **kwargs)
 
         if application.application_type == ApplicationTypes.DOCUMENT:
             url = format_url(
-                "/api/v1/Contents('Applications')" + mid + "/" + contents + "('{name}.blob')/Document/Content",
+                "/Contents('Applications')" + mid + "/" + contents + "('{name}.blob')/Document/Content",
                 name=application.name)
             response = self._rest.PUT(url, application.content, headers=self.BINARY_HTTP_HEADER, **kwargs)
 
@@ -223,11 +223,11 @@ class ApplicationService(ObjectService):
 
         if application.application_type == ApplicationTypes.DOCUMENT:
             url = format_url(
-                "/api/v1/Contents('Applications')" + mid + "/" + contents + "('{name}.blob')/Document/Content",
+                "/Contents('Applications')" + mid + "/" + contents + "('{name}.blob')/Document/Content",
                 name=application.name)
             response = self._rest.PATCH(url, application.content, headers=self.BINARY_HTTP_HEADER, **kwargs)
         else:
-            url = "/api/v1/Contents('Applications')" + mid + "/" + contents
+            url = "/Contents('Applications')" + mid + "/" + contents
             response = self._rest.POST(url, application.body, **kwargs)
 
         return response
@@ -274,7 +274,7 @@ class ApplicationService(ObjectService):
             mid = "".join(["/Contents('{}')".format(element) for element in path.split('/')])
 
         url = format_url(
-            "/api/v1/Contents('Applications')" + mid + "/" + contents + "('{application_name}')",
+            "/Contents('Applications')" + mid + "/" + contents + "('{application_name}')",
             application_name=name)
         return self._exists(url, **kwargs)
 

--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -343,7 +343,7 @@ class CellService(ObjectService):
                 component_fields = f'{component_depth}/Type, {component_depth}/Value, {component_depth}/Statements'
                 select_query = ','.join([select_query, component_fields])
 
-        url = format_url("/api/v1/Cubes('{}')/tm1.TraceCellCalculation?$select=Type,Value,Statements"
+        url = format_url("/Cubes('{}')/tm1.TraceCellCalculation?$select=Type,Value,Statements"
                          "{}&$expand=Tuple($select=Name, UniqueName, Type) {}", cube_name, select_query, expand_query)
 
         url = add_url_parameters(url, **{"!sandbox": sandbox_name})
@@ -388,7 +388,7 @@ class CellService(ObjectService):
         :return: feeder trace
         """
 
-        url = format_url("/api/v1/Cubes('{}')/tm1.TraceFeeders?$select=Statements,FedCells"
+        url = format_url("/Cubes('{}')/tm1.TraceFeeders?$select=Statements,FedCells"
                          "&$expand=FedCells/Tuple($select=Name,UniqueName,Type), "
                          "FedCells/Cube($select=Name)", cube_name)
 
@@ -434,7 +434,7 @@ class CellService(ObjectService):
         :return: fed cell descriptor
         """
 
-        url = format_url("/api/v1/Cubes('{}')/tm1.CheckFeeders"
+        url = format_url("/Cubes('{}')/tm1.CheckFeeders"
                          "?$select=Fed"
                          "&$expand=Tuple($select=Name,UniqueName,Type),Cube($select=Name)", cube_name)
 
@@ -608,7 +608,7 @@ class CellService(ObjectService):
         :param kwargs:
         :return:
         """
-        url = format_url("/api/v1/Cellsets('{}')/tm1.Update", cellset_id)
+        url = format_url("/Cellsets('{}')/tm1.Update", cellset_id)
         url = add_url_parameters(url, **{"!sandbox": sandbox_name})
         return self._rest.POST(url=url, data=json.dumps(payload), **kwargs)
 
@@ -829,7 +829,7 @@ class CellService(ObjectService):
         """
         if not dimensions:
             dimensions = self.get_dimension_names_for_writing(cube_name=cube_name)
-        url = format_url("/api/v1/Cubes('{}')/tm1.Update", cube_name)
+        url = format_url("/Cubes('{}')/tm1.Update", cube_name)
         url = add_url_parameters(url, **{"!sandbox": sandbox_name})
         body_as_dict = OrderedDict()
         body_as_dict["Cells"] = [{}]
@@ -1498,7 +1498,7 @@ class CellService(ObjectService):
         """
         if not dimensions:
             dimensions = self.get_dimension_names_for_writing(cube_name=cube_name, **kwargs)
-        url = format_url("/api/v1/Cubes('{}')/tm1.Update", cube_name)
+        url = format_url("/Cubes('{}')/tm1.Update", cube_name)
         url = add_url_parameters(url, **{"!sandbox": sandbox_name})
         url = add_url_parameters(url, **{"!ChangeSet": changeset})
 
@@ -1577,7 +1577,7 @@ class CellService(ObjectService):
         :return:
         """
 
-        url = format_url("/api/v1/Cellsets('{}')/Cells", cellset_id)
+        url = format_url("/Cellsets('{}')/Cells", cellset_id)
         url = add_url_parameters(url, **{"!sandbox": sandbox_name})
         url = add_url_parameters(url, **{"!ChangeSet": changeset})
         data = []
@@ -2693,7 +2693,7 @@ class CellService(ObjectService):
         # if top_cells is set to N => it will be sufficient to get only the first N tuples in Axes, top_tuples does this
         # if skip_cells is used => trick not applicable, all tuples must be extracted
 
-        url = "/api/v1/Cellsets('{cellset_id}')?$expand=" \
+        url = "/Cellsets('{cellset_id}')?$expand=" \
               "Cube($select=Name;$expand=Dimensions($select=Name))," \
               "Axes({filter_axis}$expand={hierarchies}Tuples($expand=Members({select_member_properties}" \
               "{expand_elem_properties}){top_tuples}))," \
@@ -2821,7 +2821,7 @@ class CellService(ObjectService):
         # if top_cells is set to N => it will be sufficient to get only the first N tuples in Axes, top_tuples does this
         # if skip_cells is used => trick not applicable, all tuples must be extracted
 
-        url = "/api/v1/Cellsets('{cellset_id}')?$expand=" \
+        url = "/Cellsets('{cellset_id}')?$expand=" \
               "Cube($select=Name;$expand=Dimensions($select=Name))," \
               "Axes({filter_axis}$expand={hierarchies}Tuples($expand=Members({select_member_properties}" \
               "{expand_elem_properties}){top_tuples}))" \
@@ -2875,7 +2875,7 @@ class CellService(ObjectService):
 
             filter_cells = " and ".join(filters)
 
-        url = "/api/v1/Cellsets('{cellset_id}')?$expand=" \
+        url = "/Cellsets('{cellset_id}')?$expand=" \
               "Cells($select={cell_properties}{top_cells}{skip_cells}{filter_cells})" \
             .format(cellset_id=cellset_id,
                     cell_properties=",".join(cell_properties),
@@ -2916,7 +2916,7 @@ class CellService(ObjectService):
             filter_cells = " and ".join(filters)
 
         url = format_url(
-            "/api/v1/Cellsets('{}')?$expand=Cells($select=Value{})",
+            "/Cellsets('{}')?$expand=Cells($select=Value{})",
             cellset_id,
             f";$filter={filter_cells}" if filter_cells else "")
         url = add_url_parameters(url, **{"!sandbox": sandbox_name})
@@ -2939,7 +2939,7 @@ class CellService(ObjectService):
         :param sandbox_name: str
         :return:
         """
-        url = "/api/v1/Cellsets('{}')?$expand=" \
+        url = "/Cellsets('{}')?$expand=" \
               "Axes($filter=Ordinal eq 1;$expand=Tuples(" \
               "$expand=Members($select=Element;$expand=Element($select={}))))," \
               "Cells($select=Value)".format(cellset_id, "UniqueName" if element_unique_names else "Name")
@@ -2983,7 +2983,7 @@ class CellService(ObjectService):
         :param sandbox_name: str
         :return:
         """
-        url = "/api/v1/Cellsets('{}')?$expand=" \
+        url = "/Cellsets('{}')?$expand=" \
               "Cube($select=Name)," \
               "Axes($expand=Hierarchies($select=UniqueName))".format(cellset_id)
         url = add_url_parameters(url, **{"!sandbox": sandbox_name})
@@ -3013,7 +3013,7 @@ class CellService(ObjectService):
         :param kwargs:
         :return:
         """
-        url = "/api/v1/Cellsets('{}')/Cells/$count".format(cellset_id)
+        url = "/Cellsets('{}')/Cells/$count".format(cellset_id)
         url = add_url_parameters(url, **{"!sandbox": sandbox_name})
         response = self._rest.GET(url, **kwargs)
         return int(response.content)
@@ -3309,7 +3309,7 @@ class CellService(ObjectService):
         :param infer_dtype: bool, if True, lets pandas infer dtypes, otherwise all columns will be of type str.
 
         """
-        url = "/api/v1/Cellsets('{}')?$expand=" \
+        url = "/Cellsets('{}')?$expand=" \
               "Axes($filter=Ordinal eq 0 or Ordinal eq 1;$expand=Tuples(" \
               "$expand=Members($select=Name{})),Hierarchies($select=Name))," \
               "Cells($select=Value)".format(cellset_id, ',Attributes' if display_attribute else '')
@@ -3476,7 +3476,7 @@ class CellService(ObjectService):
         :param sandbox_name: str
         :return:
         """
-        url = '/api/v1/ExecuteMDX'
+        url = '/ExecuteMDX'
         url = add_url_parameters(url, **{"!sandbox": sandbox_name})
         data = {
             'MDX': mdx.to_mdx() if isinstance(mdx, MdxBuilder) else mdx
@@ -3496,7 +3496,7 @@ class CellService(ObjectService):
         :param sandbox_name: str
         :return:
         """
-        url = format_url("/api/v1/Cubes('{cube_name}')/{views}('{view_name}')/tm1.Execute",
+        url = format_url("/Cubes('{cube_name}')/{views}('{view_name}')/tm1.Execute",
                          cube_name=cube_name,
                          views='PrivateViews' if private else 'Views',
                          view_name=view_name)
@@ -3537,7 +3537,7 @@ class CellService(ObjectService):
         :return: Change set ID
         """
 
-        url = "/api/v1/BeginChangeSet"
+        url = "/BeginChangeSet"
         return self._rest.POST(url).json()['value']
 
     def end_changeset(self, change_set: str) -> Response:
@@ -3546,7 +3546,7 @@ class CellService(ObjectService):
         :return: Change set ID
         """
 
-        url = "/api/v1/EndChangeSet"
+        url = "/EndChangeSet"
         data = {"ChangeSetID": change_set}
         return self._rest.POST(url, data=json.dumps(data, ensure_ascii=False))
 
@@ -3556,7 +3556,7 @@ class CellService(ObjectService):
         :return: Change set ID
         """
 
-        url = "/api/v1/UndoChangeSet"
+        url = "/UndoChangeSet"
         data = {"ChangeSetID": changeset}
         return self._rest.POST(url, data=json.dumps(data, ensure_ascii=False))
 
@@ -3567,7 +3567,7 @@ class CellService(ObjectService):
         :param sandbox_name: str
         :return:
         """
-        url = "/api/v1/Cellsets('{}')".format(cellset_id)
+        url = "/Cellsets('{}')".format(cellset_id)
         url = add_url_parameters(url, **{"!sandbox": sandbox_name})
         return self._rest.DELETE(url, **kwargs)
 

--- a/TM1py/Services/ChoreService.py
+++ b/TM1py/Services/ChoreService.py
@@ -76,7 +76,7 @@ class ChoreService(ObjectService):
         :return: instance of TM1py.Chore
         """
         url = format_url(
-            "/api/v1/Chores('{}')?$expand=Tasks($expand=*,Process($select=Name),Chore($select=Name))",
+            "/Chores('{}')?$expand=Tasks($expand=*,Process($select=Name),Chore($select=Name))",
             chore_name)
         response = self._rest.GET(url, **kwargs)
         return Chore.from_dict(response.json())
@@ -85,7 +85,7 @@ class ChoreService(ObjectService):
         """ get a List of all Chores
         :return: List of TM1py.Chore
         """
-        url = "/api/v1/Chores?$expand=Tasks($expand=*,Process($select=Name),Chore($select=Name))"
+        url = "/Chores?$expand=Tasks($expand=*,Process($select=Name),Chore($select=Name))"
         response = self._rest.GET(url, **kwargs)
         return [Chore.from_dict(chore_as_dict) for chore_as_dict in response.json()['value']]
 
@@ -93,7 +93,7 @@ class ChoreService(ObjectService):
         """ get a List of all Chores
         :return: List of TM1py.Chore
         """
-        url = "/api/v1/Chores?$select=Name"
+        url = "/Chores?$select=Name"
         response = self._rest.GET(url, **kwargs)
         return [chore['Name'] for chore in response.json()['value']]
 
@@ -102,7 +102,7 @@ class ChoreService(ObjectService):
         :param chore: instance of TM1py.Chore
         :return:
         """
-        url = "/api/v1/Chores"
+        url = "/Chores"
         response = self._rest.POST(url=url, data=chore.body, **kwargs)
 
         if chore.dst_sensitivity:
@@ -117,7 +117,7 @@ class ChoreService(ObjectService):
         :param chore_name:
         :return: response
         """
-        url = format_url("/api/v1/Chores('{}')", chore_name)
+        url = format_url("/Chores('{}')", chore_name)
         response = self._rest.DELETE(url, **kwargs)
         return response
 
@@ -127,7 +127,7 @@ class ChoreService(ObjectService):
         :param chore_name:
         :return:
         """
-        url = format_url("/api/v1/Chores('{}')", chore_name)
+        url = format_url("/Chores('{}')", chore_name)
         return self._exists(url, **kwargs)
 
     def search_for_process_name(self, process_name: str, **kwargs) -> List[Chore]:
@@ -136,7 +136,7 @@ class ChoreService(ObjectService):
         :param process_name: string, a valid ti process name; spaces will be elimniated
         """
         url = format_url(
-            "/api/v1/Chores?$filter=Tasks/any(t: replace(tolower(t/Process/Name), ' ', '') eq '{}')"
+            "/Chores?$filter=Tasks/any(t: replace(tolower(t/Process/Name), ' ', '') eq '{}')"
             "&$expand=Tasks($expand=*,Chore($select=Name),Process($select=Name))",
             process_name.lower().replace(' ', '')
         )
@@ -150,7 +150,7 @@ class ChoreService(ObjectService):
         :param parameter_value: string, will search wildcard for string in parameter value using Contains(string)
         """
         url = format_url(
-            "/api/v1/Chores?"
+            "/Chores?"
             "$filter=Tasks/any(t: t/Parameters/any(p: isof(p/Value, Edm.String) and contains(tolower(p/Value), '{}')))"
             "&$expand=Tasks($expand=*,Process($select=Name),Chore($select=Name))",
             parameter_value.lower()
@@ -166,7 +166,7 @@ class ChoreService(ObjectService):
         :return:
         """
         # Update StartTime, ExecutionMode, Frequency
-        url = format_url("/api/v1/Chores('{}')", chore.name)
+        url = format_url("/Chores('{}')", chore.name)
         # Remove Tasks from Body. Tasks to be managed individually
         chore_dict_without_tasks = chore.body_as_dict
         chore_dict_without_tasks.pop("Tasks")
@@ -198,7 +198,7 @@ class ChoreService(ObjectService):
         :param chore_name:
         :return: response
         """
-        url = format_url("/api/v1/Chores('{}')/tm1.Activate", chore_name)
+        url = format_url("/Chores('{}')/tm1.Activate", chore_name)
         return self._rest.POST(url, '', **kwargs)
 
     def deactivate(self, chore_name: str, **kwargs) -> Response:
@@ -206,7 +206,7 @@ class ChoreService(ObjectService):
         :param chore_name:
         :return: response
         """
-        url = format_url("/api/v1/Chores('{}')/tm1.Deactivate", chore_name)
+        url = format_url("/Chores('{}')/tm1.Deactivate", chore_name)
         return self._rest.POST(url, '', **kwargs)
 
     @deactivate_activate
@@ -216,7 +216,7 @@ class ChoreService(ObjectService):
         :param date_time:
         :return:
         """
-        url = format_url("/api/v1/Chores('{}')/tm1.SetServerLocalStartTime", chore_name)
+        url = format_url("/Chores('{}')/tm1.SetServerLocalStartTime", chore_name)
         data = {
             "StartDate": "{}-{}-{}".format(
                 date_time.year, date_time.month, date_time.day),
@@ -230,14 +230,14 @@ class ChoreService(ObjectService):
             :param chore_name: String, name of the chore to be executed
             :return: the response
         """
-        return self._rest.POST(format_url("/api/v1/Chores('{}')/tm1.Execute", chore_name), '', **kwargs)
+        return self._rest.POST(format_url("/Chores('{}')/tm1.Execute", chore_name), '', **kwargs)
 
     def _get_tasks_count(self, chore_name: str, **kwargs) -> int:
         """ Query Chore tasks count on TM1 Server
         :param chore_name: name of Chore to count tasks
         :return: int
         """
-        url = format_url("/api/v1/Chores('{}')/Tasks/$count", chore_name)
+        url = format_url("/Chores('{}')/Tasks/$count", chore_name)
         response = self._rest.GET(url, **kwargs)
         return int(response.text)
 
@@ -248,7 +248,7 @@ class ChoreService(ObjectService):
         :return: instance of TM1py.ChoreTask
         """
         url = format_url(
-            "/api/v1/Chores('{}')/Tasks({})?$expand=*,Process($select=Name),Chore($select=Name)", chore_name, str(step))
+            "/Chores('{}')/Tasks({})?$expand=*,Process($select=Name),Chore($select=Name)", chore_name, str(step))
         response = self._rest.GET(url, **kwargs)
         return ChoreTask.from_dict(response.json())
 
@@ -258,7 +258,7 @@ class ChoreService(ObjectService):
         :param step: integer
         :return: response
         """
-        url = format_url("/api/v1/Chores('{}')/Tasks({})", chore_name, str(step))
+        url = format_url("/Chores('{}')/Tasks({})", chore_name, str(step))
         response = self._rest.DELETE(url, **kwargs)
         return response
 
@@ -272,7 +272,7 @@ class ChoreService(ObjectService):
         if chore.active:
             self.deactivate(chore_name, **kwargs)
         try:
-            url = format_url("/api/v1/Chores('{}')/Tasks", chore_name)
+            url = format_url("/Chores('{}')/Tasks", chore_name)
             response = self._rest.POST(url, chore_task.body, **kwargs)
         except Exception as e:
             raise e
@@ -287,7 +287,7 @@ class ChoreService(ObjectService):
         :param chore_task: instance TM1py.ChoreTask
         :return: response
         """
-        url = format_url("/api/v1/Chores('{}')/Tasks({})", chore_name, str(chore_task.step))
+        url = format_url("/Chores('{}')/Tasks({})", chore_name, str(chore_task.step))
         return self._rest.PATCH(url, chore_task.body, **kwargs)
 
     @staticmethod

--- a/TM1py/Services/CubeService.py
+++ b/TM1py/Services/CubeService.py
@@ -32,7 +32,7 @@ class CubeService(ObjectService):
         :param cube: instance of TM1py.Cube
         :return: response
         """
-        url = "/api/v1/Cubes"
+        url = "/Cubes"
         return self._rest.POST(url=url, data=cube.body, **kwargs)
 
     def get(self, cube_name: str, **kwargs) -> Cube:
@@ -41,7 +41,7 @@ class CubeService(ObjectService):
         :param cube_name:
         :return: instance of TM1py.Cube
         """
-        url = format_url("/api/v1/Cubes('{}')?$expand=Dimensions($select=Name)", cube_name)
+        url = format_url("/Cubes('{}')?$expand=Dimensions($select=Name)", cube_name)
         response = self._rest.GET(url=url, **kwargs)
         cube = Cube.from_json(response.text)
         # cater for potential EnableSandboxDimension=T setup
@@ -50,7 +50,7 @@ class CubeService(ObjectService):
         return cube
 
     def get_last_data_update(self, cube_name: str, **kwargs) -> str:
-        url = format_url("/api/v1/Cubes('{}')/LastDataUpdate/$value", cube_name)
+        url = format_url("/Cubes('{}')/LastDataUpdate/$value", cube_name)
         response = self._rest.GET(url=url, **kwargs)
         return response.text
 
@@ -59,7 +59,7 @@ class CubeService(ObjectService):
 
         :return: List of TM1py.Cube instances
         """
-        url = "/api/v1/Cubes?$expand=Dimensions($select=Name)"
+        url = "/Cubes?$expand=Dimensions($select=Name)"
         response = self._rest.GET(url, **kwargs)
         cubes = [Cube.from_dict(cube_as_dict=cube) for cube in response.json()['value']]
         return cubes
@@ -69,7 +69,7 @@ class CubeService(ObjectService):
 
         :return: List of TM1py.Cube instances
         """
-        url = "/api/v1/ModelCubes()?$expand=Dimensions($select=Name)"
+        url = "/ModelCubes()?$expand=Dimensions($select=Name)"
         response = self._rest.GET(url, **kwargs)
         cubes = [Cube.from_dict(cube_as_dict=cube) for cube in response.json()['value']]
         return cubes
@@ -79,7 +79,7 @@ class CubeService(ObjectService):
 
         :return: List of TM1py.Cube instances
         """
-        url = "/api/v1/ControlCubes()?$expand=Dimensions($select=Name)"
+        url = "/ControlCubes()?$expand=Dimensions($select=Name)"
         response = self._rest.GET(url, **kwargs)
         cubes = [Cube.from_dict(cube_as_dict=cube) for cube in response.json()['value']]
         return cubes
@@ -91,14 +91,14 @@ class CubeService(ObjectService):
         :return: int, count
         """
         if skip_control_cubes:
-            response = self._rest.GET(url=format_url("/api/v1/ModelCubes()?$select=Name&$top=0&$count"), **kwargs)
+            response = self._rest.GET(url=format_url("/ModelCubes()?$select=Name&$top=0&$count"), **kwargs)
             return int(response.json()['@odata.count'])
 
-        return int(self._rest.GET(url=format_url("/api/v1/Cubes/$count"), **kwargs).text)
+        return int(self._rest.GET(url=format_url("/Cubes/$count"), **kwargs).text)
 
     def get_measure_dimension(self, cube_name: str, **kwargs) -> str:
         url = format_url(
-            "/api/v1/Cubes('{}')/Dimensions?$select=Name",
+            "/Cubes('{}')/Dimensions?$select=Name",
             cube_name)
         response = self._rest.GET(url, **kwargs)
         return response.json()['value'][-1]['Name']
@@ -109,7 +109,7 @@ class CubeService(ObjectService):
         :param cube: instance of TM1py.Cube
         :return: response
         """
-        url = format_url("/api/v1/Cubes('{}')", cube.name)
+        url = format_url("/Cubes('{}')", cube.name)
         return self._rest.PATCH(url, cube.body, **kwargs)
 
     def update_or_create(self, cube: Cube, **kwargs) -> Response:
@@ -129,7 +129,7 @@ class CubeService(ObjectService):
         :param cube_name: name of a cube
         :return: response
         """
-        url = format_url("/api/v1/Cubes('{}')/tm1.CheckRules", cube_name)
+        url = format_url("/Cubes('{}')/tm1.CheckRules", cube_name)
 
         response = self._rest.POST(url, **kwargs)
         errors = response.json()["value"]
@@ -142,7 +142,7 @@ class CubeService(ObjectService):
         :param cube_name:
         :return: response
         """
-        url = format_url("/api/v1/Cubes('{}')", cube_name)
+        url = format_url("/Cubes('{}')", cube_name)
         return self._rest.DELETE(url, **kwargs)
 
     def exists(self, cube_name: str, **kwargs) -> bool:
@@ -151,7 +151,7 @@ class CubeService(ObjectService):
         :param cube_name: 
         :return: Boolean 
         """
-        url = format_url("/api/v1/Cubes('{}')", cube_name)
+        url = format_url("/Cubes('{}')", cube_name)
         return self._exists(url, **kwargs)
 
     def get_all_names(self, skip_control_cubes: bool = False, **kwargs) -> List[str]:
@@ -161,7 +161,7 @@ class CubeService(ObjectService):
         :return: List of Strings
         """
         url = format_url(
-            "/api/v1/{}?$select=Name",
+            "/{}?$select=Name",
             'ModelCubes()' if skip_control_cubes else 'Cubes'
         )
 
@@ -176,7 +176,7 @@ class CubeService(ObjectService):
         :return: List of Strings
         """
         url = format_url(
-            "/api/v1/{}?$select=Name,Rules&$filter=Rules ne null",
+            "/{}?$select=Name,Rules&$filter=Rules ne null",
             'ModelCubes()' if skip_control_cubes else 'Cubes'
         )
 
@@ -191,7 +191,7 @@ class CubeService(ObjectService):
         """
 
         url = format_url(
-            "/api/v1/{}?$select=Name,Rules&$filter=Rules eq null",
+            "/{}?$select=Name,Rules&$filter=Rules eq null",
             'ModelCubes()' if skip_control_cubes else 'Cubes'
         )
 
@@ -206,7 +206,7 @@ class CubeService(ObjectService):
         :param skip_sandbox_dimension:
         :return:  List : [dim1, dim2, dim3, etc.]
         """
-        url = format_url("/api/v1/Cubes('{}')/Dimensions?$select=Name", cube_name)
+        url = format_url("/Cubes('{}')/Dimensions?$select=Name", cube_name)
         response = self._rest.GET(url, **kwargs)
         dimension_names = [element['Name'] for element in response.json()['value']]
         if skip_sandbox_dimension and dimension_names[0] == CellService.SANDBOX_DIMENSION:
@@ -221,7 +221,7 @@ class CubeService(ObjectService):
         :param skip_control_cubes: bool, True will exclude control cubes from result
         """
         url = format_url(
-            "/api/v1/{}?$select=Name&$filter=Dimensions/any(d: replace(tolower(d/Name), ' ', '') eq '{}')",
+            "/{}?$select=Name&$filter=Dimensions/any(d: replace(tolower(d/Name), ' ', '') eq '{}')",
             'ModelCubes()' if skip_control_cubes else 'Cubes',
             dimension_name.lower().replace(' ', '')
         )
@@ -239,7 +239,7 @@ class CubeService(ObjectService):
         substring = substring.lower().replace(' ', '')
 
         url = format_url(
-            "/api/v1/{}?$select=Name&$filter=Dimensions/any(d: contains(replace(tolower(d/Name), ' ', ''),'{}'))" +
+            "/{}?$select=Name&$filter=Dimensions/any(d: contains(replace(tolower(d/Name), ' ', ''),'{}'))" +
             "&$expand=Dimensions($select=Name;$filter=contains(replace(tolower(Name), ' ', ''), '{}'))",
             'ModelCubes()' if skip_control_cubes else 'Cubes',
             substring,
@@ -271,7 +271,7 @@ class CubeService(ObjectService):
         else:
             url_filter += format_url("Rules,'{}')", substring)
 
-        url = f"/api/v1/{'ModelCubes()' if skip_control_cubes else 'Cubes'}?$filter={url_filter}" \
+        url = f"/{'ModelCubes()' if skip_control_cubes else 'Cubes'}?$filter={url_filter}" \
               f"&$expand=Dimensions($select=Name)"
 
         response = self._rest.GET(url, **kwargs)
@@ -285,7 +285,7 @@ class CubeService(ObjectService):
         :param cube_name:
         :return: List of dimension names
         """
-        url = format_url("/api/v1/Cubes('{}')/tm1.DimensionsStorageOrder()?$select=Name", cube_name)
+        url = format_url("/Cubes('{}')/tm1.DimensionsStorageOrder()?$select=Name", cube_name)
         response = self._rest.GET(url, **kwargs)
         return [dimension["Name"] for dimension in response.json()["value"]]
 
@@ -298,7 +298,7 @@ class CubeService(ObjectService):
         :param dimension_names:
         :return:  Float: -23.076489699337078 (percent change in memory usage)
         """
-        url = format_url("/api/v1/Cubes('{}')/tm1.ReorderDimensions", cube_name)
+        url = format_url("/Cubes('{}')/tm1.ReorderDimensions", cube_name)
         payload = dict()
         payload['Dimensions@odata.bind'] = [format_url("Dimensions('{}')", dimension)
                                             for dimension
@@ -314,7 +314,7 @@ class CubeService(ObjectService):
         :param cube_name:
         :return:
         """
-        url = format_url("/api/v1/Cubes('{}')/tm1.Load", cube_name)
+        url = format_url("/Cubes('{}')/tm1.Load", cube_name)
         return self._rest.POST(url=url, **kwargs)
 
     @require_admin
@@ -325,7 +325,7 @@ class CubeService(ObjectService):
         :param cube_name:
         :return:
         """
-        url = format_url("/api/v1/Cubes('{}')/tm1.Unload", cube_name)
+        url = format_url("/Cubes('{}')/tm1.Unload", cube_name)
         return self._rest.POST(url=url, **kwargs)
 
     def lock(self, cube_name: str, **kwargs) -> Response:
@@ -334,7 +334,7 @@ class CubeService(ObjectService):
         :param cube_name:
         :return:
         """
-        url = format_url("/api/v1/Cubes('{}')/tm1.Lock", cube_name)
+        url = format_url("/Cubes('{}')/tm1.Lock", cube_name)
         return self._rest.POST(url=url, **kwargs)
 
     def unlock(self, cube_name: str, **kwargs) -> Response:
@@ -343,7 +343,7 @@ class CubeService(ObjectService):
         :param cube_name:
         :return:
         """
-        url = format_url("/api/v1/Cubes('{}')/tm1.Unlock", cube_name)
+        url = format_url("/Cubes('{}')/tm1.Unlock", cube_name)
         return self._rest.POST(url=url, **kwargs)
 
     @require_admin

--- a/TM1py/Services/DimensionService.py
+++ b/TM1py/Services/DimensionService.py
@@ -37,7 +37,7 @@ class DimensionService(ObjectService):
         # If not all subsequent calls successful -> undo everything that has been done in this function
         try:
             # Create Dimension, Hierarchies, Elements, Edges.
-            url = "/api/v1/Dimensions"
+            url = "/Dimensions"
             response = self._rest.POST(url, dimension.body, **kwargs)
             # Create ElementAttributes
             for hierarchy in dimension:
@@ -56,7 +56,7 @@ class DimensionService(ObjectService):
         :param dimension_name:
         :return:
         """
-        url = format_url("/api/v1/Dimensions('{}')?$expand=Hierarchies($expand=*)", dimension_name)
+        url = format_url("/Dimensions('{}')?$expand=Hierarchies($expand=*)", dimension_name)
         response = self._rest.GET(url, **kwargs)
         return Dimension.from_json(response.text)
 
@@ -118,7 +118,7 @@ class DimensionService(ObjectService):
         :param dimension_name: Name of the dimension
         :return:
         """
-        url = format_url("/api/v1/Dimensions('{}')", dimension_name)
+        url = format_url("/Dimensions('{}')", dimension_name)
         return self._rest.DELETE(url, **kwargs)
 
     def exists(self, dimension_name: str, **kwargs) -> bool:
@@ -126,7 +126,7 @@ class DimensionService(ObjectService):
         
         :return: 
         """
-        url = format_url("/api/v1/Dimensions('{}')", dimension_name)
+        url = format_url("/Dimensions('{}')", dimension_name)
         return self._exists(url, **kwargs)
 
     def get_all_names(self, skip_control_dims: bool = False, **kwargs) -> List[str]:
@@ -137,7 +137,7 @@ class DimensionService(ObjectService):
             List of Strings
         """
         url = format_url(
-            "/api/v1/{}?$select=Name",
+            "/{}?$select=Name",
             'ModelDimensions()' if skip_control_dims else 'Dimensions'
         )
 
@@ -154,10 +154,10 @@ class DimensionService(ObjectService):
         """
 
         if skip_control_dims:
-            response = self._rest.GET("/api/v1/ModelDimensions()?$select=Name&$top=0&$count", **kwargs)
+            response = self._rest.GET("/ModelDimensions()?$select=Name&$top=0&$count", **kwargs)
             return response.json()['@odata.count']
 
-        return int(self._rest.GET("/api/v1/Dimensions/$count", **kwargs).text)
+        return int(self._rest.GET("/Dimensions/$count", **kwargs).text)
 
     def execute_mdx(self, dimension_name: str, mdx: str, **kwargs) -> List:
         """ Execute MDX against Dimension. 
@@ -176,7 +176,7 @@ class DimensionService(ObjectService):
                        "{{ [}}ElementAttributes_{}].DefaultMember }} ON COLUMNS  " \
                        "FROM [}}ElementAttributes_{}]"
         mdx_full = mdx_skeleton.format(mdx, dimension_name, dimension_name)
-        request = '/api/v1/ExecuteMDX?$expand=Axes(' \
+        request = '/ExecuteMDX?$expand=Axes(' \
                   '$filter=Ordinal eq 1;' \
                   '$expand=Tuples($expand=Members($select=Ordinal;$expand=Element($select=Name))))'
         payload = {"MDX": mdx_full}

--- a/TM1py/Services/ElementService.py
+++ b/TM1py/Services/ElementService.py
@@ -37,21 +37,21 @@ class ElementService(ObjectService):
 
     def get(self, dimension_name: str, hierarchy_name: str, element_name: str, **kwargs) -> Element:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements('{}')?$expand=*",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements('{}')?$expand=*",
             dimension_name, hierarchy_name, element_name)
         response = self._rest.GET(url, **kwargs)
         return Element.from_dict(response.json())
 
     def create(self, dimension_name: str, hierarchy_name: str, element: Element, **kwargs) -> Response:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements",
             dimension_name,
             hierarchy_name)
         return self._rest.POST(url, element.body, **kwargs)
 
     def update(self, dimension_name: str, hierarchy_name: str, element: Element, **kwargs) -> Response:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements('{}')",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements('{}')",
             dimension_name,
             hierarchy_name,
             element.name)
@@ -59,7 +59,7 @@ class ElementService(ObjectService):
 
     def exists(self, dimension_name: str, hierarchy_name: str, element_name: str, **kwargs) -> bool:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements('{}')",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements('{}')",
             dimension_name,
             hierarchy_name,
             element_name)
@@ -67,7 +67,7 @@ class ElementService(ObjectService):
 
     def delete(self, dimension_name: str, hierarchy_name: str, element_name: str, **kwargs) -> Response:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements('{}')",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements('{}')",
             dimension_name,
             hierarchy_name,
             element_name)
@@ -75,7 +75,7 @@ class ElementService(ObjectService):
 
     def get_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[Element]:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?select=Name,Type",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?select=Name,Type",
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
@@ -247,7 +247,7 @@ class ElementService(ObjectService):
 
     def get_edges(self, dimension_name: str, hierarchy_name: str, **kwargs) -> Dict[Tuple[str, str], int]:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Edges?select=ParentName,ComponentName,Weight",
+            "/Dimensions('{}')/Hierarchies('{}')/Edges?select=ParentName,ComponentName,Weight",
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
@@ -256,14 +256,14 @@ class ElementService(ObjectService):
 
     def get_leaf_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[Element]:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type ne 3",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type ne 3",
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
         return [Element.from_dict(element) for element in response.json()["value"]]
 
     def get_leaf_element_names(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[str]:
-        url = format_url("/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type ne 3",
+        url = format_url("/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type ne 3",
                          dimension_name,
                          hierarchy_name)
         response = self._rest.GET(url, **kwargs)
@@ -271,14 +271,14 @@ class ElementService(ObjectService):
 
     def get_consolidated_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[Element]:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type eq 3",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type eq 3",
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
         return [Element.from_dict(element) for element in response.json()["value"]]
 
     def get_consolidated_element_names(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[str]:
-        url = format_url("/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type eq 3",
+        url = format_url("/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type eq 3",
                          dimension_name,
                          hierarchy_name)
         response = self._rest.GET(url, **kwargs)
@@ -286,14 +286,14 @@ class ElementService(ObjectService):
 
     def get_numeric_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[Element]:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type eq 1",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type eq 1",
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
         return [Element.from_dict(element) for element in response.json()["value"]]
 
     def get_numeric_element_names(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[str]:
-        url = format_url("/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type eq 1",
+        url = format_url("/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type eq 1",
                          dimension_name,
                          hierarchy_name)
         response = self._rest.GET(url, **kwargs)
@@ -301,14 +301,14 @@ class ElementService(ObjectService):
 
     def get_string_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[Element]:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type eq 2",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type eq 2",
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
         return [Element.from_dict(element) for element in response.json()["value"]]
 
     def get_string_element_names(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[str]:
-        url = format_url("/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type eq 2",
+        url = format_url("/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type eq 2",
                          dimension_name,
                          hierarchy_name)
         response = self._rest.GET(url, **kwargs)
@@ -322,7 +322,7 @@ class ElementService(ObjectService):
         :return: Generator of element-names
         """
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name",
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
@@ -330,7 +330,7 @@ class ElementService(ObjectService):
 
     def get_number_of_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> int:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements/$count",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements/$count",
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
@@ -338,7 +338,7 @@ class ElementService(ObjectService):
 
     def get_number_of_consolidated_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> int:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements/$count?$filter=Type eq 3",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements/$count?$filter=Type eq 3",
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
@@ -346,7 +346,7 @@ class ElementService(ObjectService):
 
     def get_number_of_leaf_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> int:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements/$count?$filter=Type ne 3",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements/$count?$filter=Type ne 3",
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
@@ -354,7 +354,7 @@ class ElementService(ObjectService):
 
     def get_number_of_numeric_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> int:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements/$count?$filter=Type eq 1",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements/$count?$filter=Type eq 1",
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
@@ -362,7 +362,7 @@ class ElementService(ObjectService):
 
     def get_number_of_string_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> int:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements/$count?$filter=Type eq 2",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements/$count?$filter=Type eq 2",
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
@@ -388,7 +388,7 @@ class ElementService(ObjectService):
         :return: List of element names
         """
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Level eq {}",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Level eq {}",
             dimension_name,
             hierarchy_name,
             str(level))
@@ -409,7 +409,7 @@ class ElementService(ObjectService):
         if level is not None:
             filter_elements = filter_elements + f" and Level eq {level}"
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=" + filter_elements,
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=" + filter_elements,
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
@@ -523,7 +523,7 @@ class ElementService(ObjectService):
 
     def get_level_names(self, dimension_name: str, hierarchy_name: str, descending: bool = True, **kwargs) -> List[str]:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Levels?$select=Name",
+            "/Dimensions('{}')/Hierarchies('{}')/Levels?$select=Name",
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
@@ -533,14 +533,14 @@ class ElementService(ObjectService):
             return [level["Name"] for level in response.json()["value"]]
 
     def get_levels_count(self, dimension_name: str, hierarchy_name: str, **kwargs) -> int:
-        url = format_url("/api/v1/Dimensions('{}')/Hierarchies('{}')/Levels/$count", dimension_name, hierarchy_name)
+        url = format_url("/Dimensions('{}')/Hierarchies('{}')/Levels/$count", dimension_name, hierarchy_name)
         response = self._rest.GET(url, **kwargs)
         return int(response.text)
 
     def get_element_types(self, dimension_name: str, hierarchy_name: str,
                           skip_consolidations: bool = False, **kwargs) -> CaseAndSpaceInsensitiveDict:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name,Type",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name,Type",
             dimension_name,
             hierarchy_name)
         if skip_consolidations:
@@ -555,7 +555,7 @@ class ElementService(ObjectService):
     def get_element_types_from_all_hierarchies(
             self, dimension_name: str, skip_consolidations: bool = False, **kwargs) -> CaseAndSpaceInsensitiveDict:
         url = format_url(
-            "/api/v1/Dimensions('{}')?$expand=Hierarchies($select=Elements;$expand=Elements($select=Name,Type",
+            "/Dimensions('{}')?$expand=Hierarchies($select=Elements;$expand=Elements($select=Name,Type",
             dimension_name)
         url += ";$filter=Type ne 3))" if skip_consolidations else "))"
         response = self._rest.GET(url, **kwargs)
@@ -567,7 +567,7 @@ class ElementService(ObjectService):
         return result
 
     def attribute_cube_exists(self, dimension_name: str, **kwargs) -> bool:
-        url = format_url("/api/v1/Cubes('{}')", self.ELEMENT_ATTRIBUTES_PREFIX + dimension_name)
+        url = format_url("/Cubes('{}')", self.ELEMENT_ATTRIBUTES_PREFIX + dimension_name)
         return self._exists(url, **kwargs)
 
     def _retrieve_mdx_rows_and_cell_values_as_string_set(self, mdx: str, exclude_empty_cells=True, **kwargs):
@@ -598,7 +598,7 @@ class ElementService(ObjectService):
         :return:
         """
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/ElementAttributes",
+            "/Dimensions('{}')/Hierarchies('{}')/ElementAttributes",
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
@@ -613,7 +613,7 @@ class ElementService(ObjectService):
         :return:
         """
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/ElementAttributes?$select=Name",
+            "/Dimensions('{}')/Hierarchies('{}')/ElementAttributes?$select=Name",
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
@@ -660,7 +660,7 @@ class ElementService(ObjectService):
         :return:
         """
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/ElementAttributes",
+            "/Dimensions('{}')/Hierarchies('{}')/ElementAttributes",
             dimension_name,
             hierarchy_name)
         return self._rest.POST(url, element_attribute.body, **kwargs)
@@ -675,7 +675,7 @@ class ElementService(ObjectService):
         :return:
         """
         url = format_url(
-            "/api/v1/Dimensions('}}ElementAttributes_{}')/Hierarchies('}}ElementAttributes_{}')/Elements('{}')",
+            "/Dimensions('}}ElementAttributes_{}')/Hierarchies('}}ElementAttributes_{}')/Elements('{}')",
             dimension_name,
             hierarchy_name,
             element_attribute)
@@ -716,7 +716,7 @@ class ElementService(ObjectService):
         edges = CaseAndSpaceInsensitiveTuplesDict()
 
         # build url
-        bare_url = "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements('{}')?"
+        bare_url = "/Dimensions('{}')/Hierarchies('{}')/Elements('{}')?"
         url = format_url(bare_url, dimension_name, hierarchy_name, consolidation)
         for d in range(depth):
             if d == 0:
@@ -757,7 +757,7 @@ class ElementService(ObjectService):
         # members to return
         members = []
         # build url
-        bare_url = "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements('{}')?$select=Name,Type&$expand=Components("
+        bare_url = "/Dimensions('{}')/Hierarchies('{}')/Elements('{}')?$select=Name,Type&$expand=Components("
         url = format_url(bare_url, dimension_name, hierarchy_name, consolidation)
         for _ in range(depth):
             url += "$select=Name,Type;$expand=Components("
@@ -844,7 +844,7 @@ class ElementService(ObjectService):
         else:
             expand_properties = ""
 
-        url = f'/api/v1/ExecuteMDXSetExpression?$expand=Tuples({top}' \
+        url = f'/ExecuteMDXSetExpression?$expand=Tuples({top}' \
               f'$expand=Members({select_member_properties}' \
               f'{expand_properties}))'
 
@@ -864,7 +864,7 @@ class ElementService(ObjectService):
         """
 
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements('{}')/Edges(ParentName='{}',ComponentName='{}')",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements('{}')/Edges(ParentName='{}',ComponentName='{}')",
             dimension_name,
             hierarchy_name,
             parent,
@@ -885,7 +885,7 @@ class ElementService(ObjectService):
         if not hierarchy_name:
             hierarchy_name = dimension_name
 
-        url = format_url("/api/v1/Dimensions('{}')/Hierarchies('{}')/Edges", dimension_name, hierarchy_name)
+        url = format_url("/Dimensions('{}')/Hierarchies('{}')/Edges", dimension_name, hierarchy_name)
         body = [{"ParentName": parent, "ComponentName": component, "Weight": float(weight)}
                 for (parent, component), weight
                 in edges.items()]
@@ -900,7 +900,7 @@ class ElementService(ObjectService):
         :param elements:
         :return:
         """
-        url = format_url("/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements", dimension_name, hierarchy_name)
+        url = format_url("/Dimensions('{}')/Hierarchies('{}')/Elements", dimension_name, hierarchy_name)
         body = [element.body_as_dict for element in elements]
 
         return self._rest.POST(url=url, data=json.dumps(body), **kwargs)
@@ -914,14 +914,14 @@ class ElementService(ObjectService):
         :param element_attributes:
         :return:
         """
-        url = format_url("/api/v1/Dimensions('{}')/Hierarchies('{}')/ElementAttributes", dimension_name, hierarchy_name)
+        url = format_url("/Dimensions('{}')/Hierarchies('{}')/ElementAttributes", dimension_name, hierarchy_name)
         body = [element_attribute.body_as_dict for element_attribute in element_attributes]
 
         return self._rest.POST(url=url, data=json.dumps(body), **kwargs)
 
     def get_parents(self, dimension_name: str, hierarchy_name: str, element_name: str, **kwargs) -> List[str]:
         url = format_url(
-            "/api/v1/Dimensions('{dimension_name}')/Hierarchies('{hierarchy_name}')/Elements('{element_name}')/Parents"
+            "/Dimensions('{dimension_name}')/Hierarchies('{hierarchy_name}')/Elements('{element_name}')/Parents"
             f"?$select=Name",
             dimension_name=dimension_name,
             hierarchy_name=hierarchy_name,
@@ -933,7 +933,7 @@ class ElementService(ObjectService):
 
     def get_parents_of_all_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> Dict[str, List[str]]:
         url = format_url(
-            f"/api/v1/Dimensions('{dimension_name}')/Hierarchies('{hierarchy_name}')/Elements?$select=Name"
+            f"/Dimensions('{dimension_name}')/Hierarchies('{hierarchy_name}')/Elements?$select=Name"
             f"&$expand=Parents($select=Name)",
         )
         response = self._rest.GET(url=url, **kwargs)
@@ -945,7 +945,7 @@ class ElementService(ObjectService):
         return element.name
 
     def _get_mdx_set_cardinality(self, mdx: str) -> int:
-        url = format_url("/api/v1/ExecuteMDXSetExpression?$select=Cardinality")
+        url = format_url("/ExecuteMDXSetExpression?$select=Cardinality")
         payload = {"MDX": mdx}
         response = self._rest.POST(url, json.dumps(payload, ensure_ascii=False))
         return response.json()['Cardinality']

--- a/TM1py/Services/FileService.py
+++ b/TM1py/Services/FileService.py
@@ -18,13 +18,13 @@ class FileService(ObjectService):
 
     def get(self, file_name: str, **kwargs) -> bytes:
         url = format_url(
-            "/api/v1/Contents('Blobs')/Contents('{name}')/Content",
+            "/Contents('Blobs')/Contents('{name}')/Content",
             name=file_name)
 
         return self._rest.GET(url, **kwargs).content
 
     def create(self, file_name: str, file_content: bytes, **kwargs):
-        url = "/api/v1/Contents('Blobs')/Contents"
+        url = "/Contents('Blobs')/Contents"
         body = {
             "@odata.type": "#ibm.tm1.api.v1.Document",
             "ID": file_name,
@@ -33,14 +33,14 @@ class FileService(ObjectService):
         self._rest.POST(url, json.dumps(body), **kwargs)
 
         url = format_url(
-            "/api/v1/Contents('Blobs')/Contents('{name}')/Content",
+            "/Contents('Blobs')/Contents('{name}')/Content",
             name=file_name)
 
         return self._rest.PUT(url, file_content, headers=self.BINARY_HTTP_HEADER, **kwargs)
 
     def update(self, file_name: str, file_content: bytes, **kwargs):
         url = format_url(
-            "/api/v1/Contents('Blobs')/Contents('{name}')/Content",
+            "/Contents('Blobs')/Contents('{name}')/Content",
             name=file_name)
 
         return self._rest.PUT(url, file_content, headers=self.BINARY_HTTP_HEADER, **kwargs)
@@ -53,14 +53,14 @@ class FileService(ObjectService):
 
     def exists(self, file_name: str, **kwargs):
         url = format_url(
-            "/api/v1/Contents('Blobs')/Contents('{name}')",
+            "/Contents('Blobs')/Contents('{name}')",
             name=file_name)
 
         return self._exists(url, **kwargs)
 
     def delete(self, file_name: str, **kwargs):
         url = format_url(
-            "/api/v1/Contents('Blobs')/Contents('{name}')",
+            "/Contents('Blobs')/Contents('{name}')",
             name=file_name)
 
         return self._rest.DELETE(url, **kwargs)

--- a/TM1py/Services/GitService.py
+++ b/TM1py/Services/GitService.py
@@ -25,7 +25,7 @@ class GitService(ObjectService):
     def tm1project_get(self) -> TM1Project:
         """_summary_
         """
-        url = '/api/v1/!tm1project'
+        url = '/!tm1project'
         response = self._rest.GET(url)
         if not response.content:
             return None
@@ -33,7 +33,7 @@ class GitService(ObjectService):
         return TM1Project.from_dict(response.json())
     
     def tm1project_delete(self):
-        url = '/api/v1/!tm1project'
+        url = '/!tm1project'
         empty_dict = {}
         body_json = json.dumps(empty_dict)
         
@@ -41,7 +41,7 @@ class GitService(ObjectService):
         return TM1Project.from_dict(response.json())
         
     def tm1project_put(self, tm1_project: TM1Project) -> TM1Project:
-        url = '/api/v1/!tm1project'
+        url = '/!tm1project'
         body_json = tm1_project.body
 
         # we need to ensure that async_requests_mode=False for this specific request as the response will not include
@@ -63,7 +63,7 @@ class GitService(ObjectService):
         :param force: reset git context on True
         :param config: Dictionary containing git configuration parameters
         """
-        url = "/api/v1/GitInit"
+        url = "/GitInit"
         body = {'URL': git_url, 'Deployment': deployment}
 
         for key, value in locals().items():
@@ -80,7 +80,7 @@ class GitService(ObjectService):
 
         :param force: clean up git context when True
         """
-        url = "/api/v1/GitUninit"
+        url = "/GitUninit"
         body = json.dumps(force)
         return self._rest.POST(url=url, data=body, **kwargs)
 
@@ -93,7 +93,7 @@ class GitService(ObjectService):
         :param private_key: SSH private key, available from PAA V2.0.9.4
         :param passphrase: Passphrase for decrypting private key, if set
         """
-        url = "/api/v1/GitStatus"
+        url = "/GitStatus"
         body = {}
 
         for key, value in locals().items():
@@ -124,7 +124,7 @@ class GitService(ObjectService):
         :param execute: Executes the plan right away if True
 
         """
-        url = "/api/v1/GitPush"
+        url = "/GitPush"
         body = {}
 
         for key, value in locals().items():
@@ -152,7 +152,7 @@ class GitService(ObjectService):
         :param private_key: SSH private key, available from PAA V2.0.9.4
         :param passphrase: Passphrase for decrypting private key, if set
         """
-        url = "/api/v1/GitPull"
+        url = "/GitPull"
         body = {}
 
         for key, value in locals().items():
@@ -172,13 +172,13 @@ class GitService(ObjectService):
         """ Executes a plan based on the planid
         :param plan_id: GitPlan id
         """
-        url = format_url("/api/v1/GitPlans('{}')/tm1.Execute", plan_id)
+        url = format_url("/GitPlans('{}')/tm1.Execute", plan_id)
         return self._rest.POST(url=url, **kwargs)
 
     def git_get_plans(self, **kwargs) -> List[GitPlan]:
         """ Gets a list of currently available GIT plans
         """
-        url = "/api/v1/GitPlans"
+        url = "/GitPlans"
         plans = []
 
         response = self._rest.GET(url=url, **kwargs)

--- a/TM1py/Services/HierarchyService.py
+++ b/TM1py/Services/HierarchyService.py
@@ -33,7 +33,7 @@ class HierarchyService(ObjectService):
         :param hierarchy:
         :return:
         """
-        url = format_url("/api/v1/Dimensions('{}')/Hierarchies", hierarchy.dimension_name)
+        url = format_url("/Dimensions('{}')/Hierarchies", hierarchy.dimension_name)
         response = self._rest.POST(url, hierarchy.body, **kwargs)
 
         self.update_element_attributes(hierarchy, **kwargs)
@@ -48,7 +48,7 @@ class HierarchyService(ObjectService):
         :return:
         """
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')?$expand=Edges,Elements,ElementAttributes,Subsets,DefaultMember",
+            "/Dimensions('{}')/Hierarchies('{}')?$expand=Edges,Elements,ElementAttributes,Subsets,DefaultMember",
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
@@ -60,7 +60,7 @@ class HierarchyService(ObjectService):
         :param dimension_name:
         :return:
         """
-        url = format_url("/api/v1/Dimensions('{}')/Hierarchies?$select=Name", dimension_name)
+        url = format_url("/Dimensions('{}')/Hierarchies?$select=Name", dimension_name)
         response = self._rest.GET(url, **kwargs)
         return [hierarchy["Name"] for hierarchy in response.json()["value"]]
 
@@ -79,7 +79,7 @@ class HierarchyService(ObjectService):
         # functions returns multiple responses
         responses = list()
         # 1. Update Hierarchy
-        url = format_url("/api/v1/Dimensions('{}')/Hierarchies('{}')", hierarchy.dimension_name, hierarchy.name)
+        url = format_url("/Dimensions('{}')/Hierarchies('{}')", hierarchy.dimension_name, hierarchy.name)
         # Workaround EDGES: Handle Issue, that Edges cant be created in one batch with the Hierarchy in certain versions
         hierarchy_body = hierarchy.body_as_dict
         if self.version[0:8] in self.EDGES_WORKAROUND_VERSIONS:
@@ -125,17 +125,17 @@ class HierarchyService(ObjectService):
         :param hierarchy_name: 
         :return: 
         """
-        url = format_url("/api/v1/Dimensions('{}')/Hierarchies('{}')", dimension_name, hierarchy_name)
+        url = format_url("/Dimensions('{}')/Hierarchies('{}')", dimension_name, hierarchy_name)
         return self._exists(url, **kwargs)
 
     def delete(self, dimension_name: str, hierarchy_name: str, **kwargs) -> Response:
-        url = format_url("/api/v1/Dimensions('{}')/Hierarchies('{}')", dimension_name, hierarchy_name)
+        url = format_url("/Dimensions('{}')/Hierarchies('{}')", dimension_name, hierarchy_name)
         return self._rest.DELETE(url, **kwargs)
 
     def get_hierarchy_summary(self, dimension_name: str, hierarchy_name: str, **kwargs) -> Dict[str, int]:
         hierarchy_properties = ("Elements", "Edges", "ElementAttributes", "Members", "Levels")
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')?$expand=Edges/$count,Elements/$count,"
+            "/Dimensions('{}')/Hierarchies('{}')?$expand=Edges/$count,Elements/$count,"
             "ElementAttributes/$count,Members/$count,Levels/$count&$select=Cardinality",
             dimension_name,
             hierarchy_name)
@@ -214,7 +214,7 @@ class HierarchyService(ObjectService):
         :return: String, name of Member
         """
         url = format_url(
-            "/api/v1/Dimensions('{dimension}')/Hierarchies('{hierarchy}')/DefaultMember",
+            "/Dimensions('{dimension}')/Hierarchies('{hierarchy}')/DefaultMember",
             dimension=dimension_name,
             hierarchy=hierarchy_name if hierarchy_name else dimension_name)
         response = self._rest.GET(url=url, **kwargs)
@@ -253,7 +253,7 @@ class HierarchyService(ObjectService):
     def remove_all_edges(self, dimension_name: str, hierarchy_name: str = None, **kwargs) -> Response:
         if not hierarchy_name:
             hierarchy_name = dimension_name
-        url = format_url("/api/v1/Dimensions('{}')/Hierarchies('{}')", dimension_name, hierarchy_name)
+        url = format_url("/Dimensions('{}')/Hierarchies('{}')", dimension_name, hierarchy_name)
         body = {
             "Edges": []
         }
@@ -320,7 +320,7 @@ class HierarchyService(ObjectService):
         :return:
         """
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Structure/$value",
+            "/Dimensions('{}')/Hierarchies('{}')/Structure/$value",
             dimension_name,
             hierarchy_name)
         structure = int(self._rest.GET(url, **kwargs).text)

--- a/TM1py/Services/MonitoringService.py
+++ b/TM1py/Services/MonitoringService.py
@@ -23,7 +23,7 @@ class MonitoringService(ObjectService):
             :return:
                 dict: the response
         """
-        url = '/api/v1/Threads'
+        url = '/Threads'
         response = self._rest.GET(url, **kwargs)
         return response.json()['value']
 
@@ -33,7 +33,7 @@ class MonitoringService(ObjectService):
             :return:
                 list: TM1 threads as dict
         """
-        url = "/api/v1/Threads?$filter=Function ne 'GET /api/v1/Threads' and State ne 'Idle'"
+        url = "/Threads?$filter=Function ne 'GET /Threads' and State ne 'Idle'"
         response = self._rest.GET(url, **kwargs)
         return response.json()['value']
 
@@ -43,7 +43,7 @@ class MonitoringService(ObjectService):
         :param thread_id: 
         :return: 
         """
-        url = format_url("/api/v1/Threads('{}')/tm1.CancelOperation", str(thread_id))
+        url = format_url("/Threads('{}')/tm1.CancelOperation", str(thread_id))
         response = self._rest.POST(url, **kwargs)
         return response
 
@@ -57,7 +57,7 @@ class MonitoringService(ObjectService):
                 continue
             if thread["Name"] == "Pseudo":
                 continue
-            if thread["Function"] == "GET /api/v1/Threads":
+            if thread["Function"] == "GET /Threads":
                 continue
             self.cancel_thread(thread["ID"], **kwargs)
             canceled_threads.append(thread)
@@ -68,7 +68,7 @@ class MonitoringService(ObjectService):
 
         :return: List of TM1py.User instances
         """
-        url = '/api/v1/Users?$filter=IsActive eq true&$expand=Groups'
+        url = '/Users?$filter=IsActive eq true&$expand=Groups'
         response = self._rest.GET(url, **kwargs)
         users = [User.from_dict(user) for user in response.json()['value']]
         return users
@@ -79,7 +79,7 @@ class MonitoringService(ObjectService):
         :param user_name:
         :return: Boolean
         """
-        url = format_url("/api/v1/Users('{}')/IsActive", user_name)
+        url = format_url("/Users('{}')/IsActive", user_name)
         response = self._rest.GET(url, **kwargs)
         return bool(response.json()['value'])
 
@@ -89,12 +89,12 @@ class MonitoringService(ObjectService):
         :param user_name: 
         :return: 
         """
-        url = format_url("/api/v1/Users('{}')/tm1.Disconnect", user_name)
+        url = format_url("/Users('{}')/tm1.Disconnect", user_name)
         response = self._rest.POST(url, **kwargs)
         return response
 
     def get_active_session_threads(self, exclude_idle: bool = True, **kwargs):
-        url = "/api/v1/ActiveSession/Threads?$filter=Function ne 'GET /api/v1/ActiveSession/Threads'"
+        url = "/ActiveSession/Threads?$filter=Function ne 'GET /ActiveSession/Threads'"
         if exclude_idle:
             url += " and State ne 'Idle'"
 
@@ -102,7 +102,7 @@ class MonitoringService(ObjectService):
         return response.json()['value']
 
     def get_sessions(self, include_user: bool = True, include_threads: bool = True, **kwargs) -> List:
-        url = "/api/v1/Sessions"
+        url = "/Sessions"
         if include_user or include_threads:
             expands = list()
             if include_user:
@@ -126,7 +126,7 @@ class MonitoringService(ObjectService):
         return disconnected_users
 
     def close_session(self, session_id, **kwargs) -> Response:
-        url = format_url(f"/api/v1/Sessions('{session_id}')/tm1.Close")
+        url = format_url(f"/Sessions('{session_id}')/tm1.Close")
         return self._rest.POST(url, **kwargs)
 
     @require_admin

--- a/TM1py/Services/ObjectService.py
+++ b/TM1py/Services/ObjectService.py
@@ -38,7 +38,7 @@ class ObjectService:
 
     def determine_actual_object_name(self, object_class: str, object_name: str, **kwargs) -> str:
         url = format_url(
-            "/api/v1/{}?$filter=tolower(replace(Name, ' ', '')) eq '{}'",
+            "/{}?$filter=tolower(replace(Name, ' ', '')) eq '{}'",
             object_class,
             object_name.replace(" ", "").lower())
         response = self._rest.GET(url, **kwargs)

--- a/TM1py/Services/ProcessService.py
+++ b/TM1py/Services/ProcessService.py
@@ -32,7 +32,7 @@ class ProcessService(ObjectService):
         :return: Instance of the TM1py.Process
         """
         url = format_url(
-            "/api/v1/Processes('{}')?$select=*,UIData,VariablesUIData,"
+            "/Processes('{}')?$select=*,UIData,VariablesUIData,"
             "DataSource/dataSourceNameForServer,"
             "DataSource/dataSourceNameForClient,"
             "DataSource/asciiDecimalSeparator,"
@@ -58,7 +58,7 @@ class ProcessService(ObjectService):
         """
         model_process_filter = "&$filter=startswith(Name,'}') eq false and startswith(Name,'{') eq false"
 
-        url = "/api/v1/Processes?$select=*,UIData,VariablesUIData," \
+        url = "/Processes?$select=*,UIData,VariablesUIData," \
               "DataSource/dataSourceNameForServer," \
               "DataSource/dataSourceNameForClient," \
               "DataSource/asciiDecimalSeparator," \
@@ -86,7 +86,7 @@ class ProcessService(ObjectService):
             List of Strings
         """
         model_process_filter = "&$filter=startswith(Name,'}') eq false and startswith(Name,'{') eq false"
-        url = "/api/v1/Processes?$select=Name{}".format(model_process_filter if skip_control_processes else "")
+        url = "/Processes?$select=Name{}".format(model_process_filter if skip_control_processes else "")
 
         response = self._rest.GET(url, **kwargs)
         processes = list(process['Name'] for process in response.json()['value'])
@@ -103,7 +103,7 @@ class ProcessService(ObjectService):
         """
         search_string = search_string.lower().replace(' ', '')
         model_process_filter = "and (startswith(Name,'}') eq false and startswith(Name,'{') eq false)"
-        url = format_url("/api/v1/Processes?$select=Name&$filter="
+        url = format_url("/Processes?$select=Name&$filter="
                          "contains(tolower(replace(PrologProcedure, ' ', '')),'{}') "
                          "or contains(tolower(replace(MetadataProcedure, ' ', '')),'{}') "
                          "or contains(tolower(replace(DataProcedure, ' ', '')),'{}') "
@@ -130,7 +130,7 @@ class ProcessService(ObjectService):
         if name_contains_operator not in ("and", "or"):
             raise ValueError("'name_contains_operator' must be either 'AND' or 'OR'")
 
-        url = "/api/v1/Processes?$select=Name"
+        url = "/Processes?$select=Name"
         name_filters = []
 
         if name_startswith:
@@ -159,7 +159,7 @@ class ProcessService(ObjectService):
         :param process: Instance of TM1py.Process class
         :return: Response
         """
-        url = "/api/v1/Processes"
+        url = "/Processes"
         # Adjust process body if TM1 version is lower than 11 due to change in Process Parameters structure
         # https://www.ibm.com/developerworks/community/forums/html/topic?id=9188d139-8905-4895-9229-eaaf0e7fa683
         if int(self.version[0:2]) < 11:
@@ -173,7 +173,7 @@ class ProcessService(ObjectService):
         :param process: Instance of TM1py.Process class
         :return: Response
         """
-        url = format_url("/api/v1/Processes('{}')", process.name)
+        url = format_url("/Processes('{}')", process.name)
         # Adjust process body if TM1 version is lower than 11 due to change in Process Parameters structure
         # https://www.ibm.com/developerworks/community/forums/html/topic?id=9188d139-8905-4895-9229-eaaf0e7fa683
         if int(self.version[0:2]) < 11:
@@ -198,7 +198,7 @@ class ProcessService(ObjectService):
         :param name: 
         :return: Response
         """
-        url = format_url("/api/v1/Processes('{}')", name)
+        url = format_url("/Processes('{}')", name)
         response = self._rest.DELETE(url, **kwargs)
         return response
 
@@ -208,7 +208,7 @@ class ProcessService(ObjectService):
         :param name: 
         :return: 
         """
-        url = format_url("/api/v1/Processes('{}')", name)
+        url = format_url("/Processes('{}')", name)
         return self._exists(url, **kwargs)
 
     def compile(self, name: str, **kwargs) -> List:
@@ -217,7 +217,7 @@ class ProcessService(ObjectService):
         :param name: 
         :return: 
         """
-        url = format_url("/api/v1/Processes('{}')/tm1.Compile", name)
+        url = format_url("/Processes('{}')/tm1.Compile", name)
         response = self._rest.POST(url, **kwargs)
         syntax_errors = response.json()["value"]
         return syntax_errors
@@ -228,7 +228,7 @@ class ProcessService(ObjectService):
         :param process:
         :return:
         """
-        url = "/api/v1/CompileProcess"
+        url = "/CompileProcess"
 
         payload = json.loads('{"Process":' + process.body + '}')
 
@@ -251,7 +251,7 @@ class ProcessService(ObjectService):
         :param cancel_at_timeout: Abort operation in TM1 when timeout is reached
         :return:
         """
-        url = format_url("/api/v1/Processes('{}')/tm1.Execute", process_name)
+        url = format_url("/Processes('{}')/tm1.Execute", process_name)
         if not parameters:
             if kwargs:
                 parameters = {"Parameters": []}
@@ -273,7 +273,7 @@ class ProcessService(ObjectService):
         :param kwargs: dictionary of process parameters and values
         :return: success (boolean), status (String), error_log_file (String)
         """
-        url = "/api/v1/ExecuteProcessWithReturn?$expand=*"
+        url = "/ExecuteProcessWithReturn?$expand=*"
         if kwargs:
             for parameter_name, parameter_value in kwargs.items():
                 process.remove_parameter(name=parameter_name)
@@ -313,7 +313,7 @@ class ProcessService(ObjectService):
         :param kwargs: dictionary of process parameters and values
         :return: success (boolean), status (String), error_log_file (String)
         """
-        url = format_url("/api/v1/Processes('{}')/tm1.ExecuteWithReturn?$expand=*", process_name)
+        url = format_url("/Processes('{}')/tm1.ExecuteWithReturn?$expand=*", process_name)
         parameters = dict()
         if kwargs:
             parameters = {"Parameters": []}
@@ -359,7 +359,7 @@ class ProcessService(ObjectService):
         :param file_name: name of the error log file in the TM1 log directory
         :return: String, content of the file
         """
-        url = format_url("/api/v1/ErrorLogFiles('{}')/Content", file_name)
+        url = format_url("/ErrorLogFiles('{}')/Content", file_name)
         response = self._rest.GET(url=url, **kwargs)
         return response.text
 
@@ -369,7 +369,7 @@ class ProcessService(ObjectService):
         :param process_name: name of the process
         :return: list - Collection of ProcessErrorLogs
         """
-        url = format_url("/api/v1/Processes('{}')/ErrorLogs", process_name)
+        url = format_url("/Processes('{}')/ErrorLogs", process_name)
         response = self._rest.GET(url=url, **kwargs)
         return response.json()['value']
 
@@ -383,7 +383,7 @@ class ProcessService(ObjectService):
         logs_as_list = self.get_processerrorlogs(process_name, **kwargs)
         if len(logs_as_list) > 0:
             timestamp = logs_as_list[-1]['Timestamp']
-            url = format_url("/api/v1/Processes('{}')/ErrorLogs('{}')/Content", process_name, timestamp)
+            url = format_url("/Processes('{}')/ErrorLogs('{}')/Content", process_name, timestamp)
             # response is plain text - due to entity type Edm.Stream
             response = self._rest.GET(url=url, **kwargs)
             return response.text
@@ -392,7 +392,7 @@ class ProcessService(ObjectService):
         """ 
         Start debug session for specified process; debug session id is returned in response        
         """
-        raw_url = "/api/v1/Processes('{}')/tm1.Debug?$expand=Breakpoints," \
+        raw_url = "/Processes('{}')/tm1.Debug?$expand=Breakpoints," \
                   "Thread,CallStack($expand=Variables,Process($select=Name))"
         url = format_url(raw_url, process_name)
 
@@ -414,14 +414,14 @@ class ProcessService(ObjectService):
         Runs a single statement in the process
         If ExecuteProcess is next function, will NOT debug child process
         """
-        url = format_url("/api/v1/ProcessDebugContexts('{}')/tm1.StepOver", debug_id)
+        url = format_url("/ProcessDebugContexts('{}')/tm1.StepOver", debug_id)
         self._rest.POST(url, **kwargs)
 
         # digest time  necessary for TM1 <= 11.8
         # ToDo: remove in later versions of TM1 once issue in TM1 server is resolved
         time.sleep(0.1)
 
-        raw_url = "/api/v1/ProcessDebugContexts('{}')?$expand=Breakpoints," \
+        raw_url = "/ProcessDebugContexts('{}')?$expand=Breakpoints," \
                   "Thread,CallStack($expand=Variables,Process($select=Name))"
         url = format_url(raw_url, debug_id)
         response = self._rest.GET(url, **kwargs)
@@ -433,14 +433,14 @@ class ProcessService(ObjectService):
         Runs a single statement in the process
         If ExecuteProcess is next function, will pause at first statement inside child process
         """
-        url = format_url("/api/v1/ProcessDebugContexts('{}')/tm1.StepIn", debug_id)
+        url = format_url("/ProcessDebugContexts('{}')/tm1.StepIn", debug_id)
         self._rest.POST(url, **kwargs)
 
         # digest time  necessary for TM1 <= 11.8
         # ToDo: remove in later versions of TM1 once issue in TM1 server is resolved
         time.sleep(0.1)
 
-        raw_url = "/api/v1/ProcessDebugContexts('{}')?$expand=Breakpoints," \
+        raw_url = "/ProcessDebugContexts('{}')?$expand=Breakpoints," \
                   "Thread,CallStack($expand=Variables,Process($select=Name))"
         url = format_url(raw_url, debug_id)
         response = self._rest.GET(url, **kwargs)
@@ -451,14 +451,14 @@ class ProcessService(ObjectService):
         """
         Resumes execution and runs until current process has finished.
         """
-        url = format_url("/api/v1/ProcessDebugContexts('{}')/tm1.StepOut", debug_id)
+        url = format_url("/ProcessDebugContexts('{}')/tm1.StepOut", debug_id)
         self._rest.POST(url, **kwargs)
 
         # digest time  necessary for TM1 <= 11.8
         # ToDo: remove in later versions of TM1 once issue in TM1 server is resolved
         time.sleep(0.1)
 
-        raw_url = "/api/v1/ProcessDebugContexts('{}')?$expand=Breakpoints," \
+        raw_url = "/ProcessDebugContexts('{}')?$expand=Breakpoints," \
                   "Thread,CallStack($expand=Variables,Process($select=Name))"
         url = format_url(raw_url, debug_id)
         response = self._rest.GET(url, **kwargs)
@@ -470,14 +470,14 @@ class ProcessService(ObjectService):
         Resumes execution until next breakpoint
         
         """
-        url = format_url("/api/v1/ProcessDebugContexts('{}')/tm1.Continue", debug_id)
+        url = format_url("/ProcessDebugContexts('{}')/tm1.Continue", debug_id)
         self._rest.POST(url, **kwargs)
 
         # digest time  necessary for TM1 <= 11.8
         # ToDo: remove in later versions of TM1 once issue in TM1 server is resolved
         time.sleep(0.1)
 
-        raw_url = "/api/v1/ProcessDebugContexts('{}')?$expand=Breakpoints," \
+        raw_url = "/ProcessDebugContexts('{}')?$expand=Breakpoints," \
                   "Thread,CallStack($expand=Variables,Process($select=Name))"
         url = format_url(raw_url, debug_id)
         response = self._rest.GET(url, **kwargs)
@@ -485,7 +485,7 @@ class ProcessService(ObjectService):
         return response.json()
 
     def debug_get_breakpoints(self, debug_id: str, **kwargs) -> List[ProcessDebugBreakpoint]:
-        url = format_url("/api/v1/ProcessDebugContexts('{}')/Breakpoints", debug_id)
+        url = format_url("/ProcessDebugContexts('{}')/Breakpoints", debug_id)
 
         response = self._rest.GET(url, **kwargs)
         return [ProcessDebugBreakpoint.from_dict(b) for b in response.json()['value']]
@@ -495,7 +495,7 @@ class ProcessService(ObjectService):
 
     def debug_add_breakpoints(self, debug_id: str, break_points: Iterable[ProcessDebugBreakpoint] = None,
                               **kwargs) -> Response:
-        url = format_url("/api/v1/ProcessDebugContexts('{}')/Breakpoints", debug_id)
+        url = format_url("/ProcessDebugContexts('{}')/Breakpoints", debug_id)
 
         body = json.dumps([break_point.body_as_dict for break_point in break_points])
 
@@ -503,14 +503,14 @@ class ProcessService(ObjectService):
         return response
 
     def debug_remove_breakpoint(self, debug_id: str, breakpoint_id: int, **kwargs) -> Response:
-        url = format_url("/api/v1/ProcessDebugContexts('{}')/Breakpoints('{}')", debug_id, str(breakpoint_id))
+        url = format_url("/ProcessDebugContexts('{}')/Breakpoints('{}')", debug_id, str(breakpoint_id))
 
         response = self._rest.DELETE(url, **kwargs)
         return response
 
     def debug_update_breakpoint(self, debug_id: str, break_point: ProcessDebugBreakpoint, **kwargs) -> Response:
         url = format_url(
-            "/api/v1/ProcessDebugContexts('{}')/Breakpoints('{}')",
+            "/ProcessDebugContexts('{}')/Breakpoints('{}')",
             debug_id,
             str(break_point.breakpoint_id))
 
@@ -518,7 +518,7 @@ class ProcessService(ObjectService):
         return response
 
     def debug_get_variable_values(self, debug_id: str, **kwargs) -> CaseInsensitiveDict:
-        raw_url = "/api/v1/ProcessDebugContexts('{}')?$expand=" \
+        raw_url = "/ProcessDebugContexts('{}')?$expand=" \
                   "CallStack($expand=Variables)"
         url = format_url(raw_url, debug_id)
 
@@ -529,7 +529,7 @@ class ProcessService(ObjectService):
         return CaseInsensitiveDict({entry["Name"]: entry["Value"] for entry in call_stack})
 
     def debug_get_single_variable_value(self, debug_id: str, variable_name: str, **kwargs) -> str:
-        raw_url = "/api/v1/ProcessDebugContexts('{}')?$expand=" \
+        raw_url = "/ProcessDebugContexts('{}')?$expand=" \
                   "CallStack($expand=Variables($filter=tolower(Name) eq '{}';$select=Value))"
         url = format_url(raw_url, debug_id, variable_name.lower())
 
@@ -541,7 +541,7 @@ class ProcessService(ObjectService):
             raise ValueError(f"'{variable_name}' not found in collection")
 
     def debug_get_process_procedure(self, debug_id: str, **kwargs) -> str:
-        raw_url = "/api/v1/ProcessDebugContexts('{}')?$expand=" \
+        raw_url = "/ProcessDebugContexts('{}')?$expand=" \
                   "CallStack($select=Procedure)"
         url = format_url(raw_url, debug_id)
 
@@ -549,7 +549,7 @@ class ProcessService(ObjectService):
         return response.json()['CallStack'][0]['Procedure']
 
     def debug_get_process_line_number(self, debug_id: str, **kwargs) -> str:
-        raw_url = "/api/v1/ProcessDebugContexts('{}')?$expand=" \
+        raw_url = "/ProcessDebugContexts('{}')?$expand=" \
                   "CallStack($select=LineNumber)"
         url = format_url(raw_url, debug_id)
 
@@ -557,7 +557,7 @@ class ProcessService(ObjectService):
         return response.json()['CallStack'][0]['LineNumber']
 
     def debug_get_record_number(self, debug_id: str, **kwargs) -> str:
-        raw_url = "/api/v1/ProcessDebugContexts('{}')?$expand=" \
+        raw_url = "/ProcessDebugContexts('{}')?$expand=" \
                   "CallStack($select=RecordNumber)"
         url = format_url(raw_url, debug_id)
 
@@ -565,7 +565,7 @@ class ProcessService(ObjectService):
         return response.json()['CallStack'][0]['RecordNumber']
 
     def debug_get_current_breakpoint(self, debug_id: str, **kwargs) -> ProcessDebugBreakpoint:
-        raw_url = "/api/v1/ProcessDebugContexts('{}')?$expand=CurrentBreakpoint"
+        raw_url = "/ProcessDebugContexts('{}')?$expand=CurrentBreakpoint"
 
         url = format_url(raw_url, debug_id)
 

--- a/TM1py/Services/RestService.py
+++ b/TM1py/Services/RestService.py
@@ -346,7 +346,7 @@ class RestService:
     @httpmethod
     def PATCH(self, url: str, data: Union[str, bytes], headers: Dict = None, timeout: float = None, **kwargs):
         """ PATCH request against the TM1 instance
-        :param url: String, for instance : /api/v1/Dimensions('plan_business_unit')
+        :param url: String, for instance : /Dimensions('plan_business_unit')
         :param data: the payload
         :param headers: custom headers
         :param timeout: Number of seconds that the client will wait to receive the first byte.
@@ -362,7 +362,7 @@ class RestService:
     @httpmethod
     def PUT(self, url: str, data: Union[str, bytes], headers: Dict = None, timeout: float = None, **kwargs):
         """ PUT request against the TM1 instance
-        :param url: String, for instance : /api/v1/Dimensions('plan_business_unit')
+        :param url: String, for instance : /Dimensions('plan_business_unit')
         :param data: the payload
         :param headers: custom headers
         :param timeout: Number of seconds that the client will wait to receive the first byte.
@@ -378,7 +378,7 @@ class RestService:
     @httpmethod
     def DELETE(self, url: str, data: Union[str, bytes], headers: Dict = None, timeout: float = None, **kwargs):
         """ Delete request against TM1 instance
-        :param url:  String, for instance : /api/v1/Dimensions('plan_business_unit')
+        :param url:  String, for instance : /Dimensions('plan_business_unit')
         :param data: the payload
         :param headers: custom headers
         :param timeout: Number of seconds that the client will wait to receive the first byte.
@@ -397,7 +397,7 @@ class RestService:
         # Easier to ask for forgiveness than permission
         try:
             # ProductVersion >= TM1 10.2.2 FP 6
-            self.POST('/api/v1/ActiveSession/tm1.Close', '', headers={"Connection": "close"}, timeout=timeout,
+            self.POST('/ActiveSession/tm1.Close', '', headers={"Connection": "close"}, timeout=timeout,
                       async_requests_mode=False, **kwargs)
         except TM1pyRestException:
             # ProductVersion < TM1 10.2.2 FP 6
@@ -431,7 +431,7 @@ class RestService:
                 self._verify)
             self.add_http_header('Authorization', token)
 
-        url = '/api/v1/Configuration/ProductVersion/$value'
+        url = '/Configuration/ProductVersion/$value'
         try:
             additional_headers = dict()
             if impersonate:
@@ -469,13 +469,13 @@ class RestService:
             Boolean
         """
         try:
-            self.GET('/api/v1/Configuration/ServerName/$value')
+            self.GET('/Configuration/ServerName/$value')
             return True
         except:
             return False
 
     def set_version(self):
-        url = '/api/v1/Configuration/ProductVersion/$value'
+        url = '/Configuration/ProductVersion/$value'
         response = self.GET(url=url)
         self._version = response.text
 
@@ -486,7 +486,7 @@ class RestService:
     @property
     def is_admin(self) -> bool:
         if self._is_admin is None:
-            response = self.GET("/api/v1/ActiveUser/Groups")
+            response = self.GET("/ActiveUser/Groups")
             self._is_admin = "ADMIN" in CaseAndSpaceInsensitiveSet(
                 *[group["Name"] for group in response.json()["value"]])
 
@@ -495,7 +495,7 @@ class RestService:
     @property
     def sandboxing_disabled(self):
         if self._sandboxing_disabled is None:
-            value = self.GET("/api/v1/ActiveConfiguration/Administration/DisableSandboxing/$value")
+            value = self.GET("/ActiveConfiguration/Administration/DisableSandboxing/$value")
             self._sandboxing_disabled = value
 
         return self._sandboxing_disabled
@@ -607,11 +607,11 @@ class RestService:
         return original_header
 
     def retrieve_async_response(self, async_id: str, **kwargs) -> Response:
-        url = self._base_url + f"/api/v1/_async('{async_id}')"
+        url = self._base_url + f"/_async('{async_id}')"
         return self._s.get(url, **kwargs)
 
     def cancel_async_operation(self, async_id: str, **kwargs):
-        url = self._base_url + f"/api/v1/_async('{async_id}')"
+        url = self._base_url + f"/_async('{async_id}')"
         response = self._s.delete(url, **kwargs)
         self.verify_response(response)
 

--- a/TM1py/Services/RestService.py
+++ b/TM1py/Services/RestService.py
@@ -236,7 +236,7 @@ class RestService:
             self._base_url = kwargs['base_url']
             self._ssl = self._determine_ssl_based_on_base_url()
         else:
-            self._base_url = "http{}://{}:{}".format(
+            self._base_url = "http{}://{}:{}/api/v1".format(
                 's' if self._ssl else '',
                 'localhost' if len(self._address) == 0 else self._address,
                 self._port)

--- a/TM1py/Services/SandboxService.py
+++ b/TM1py/Services/SandboxService.py
@@ -23,7 +23,7 @@ class SandboxService(ObjectService):
         :param sandbox_name: str
         :return: instance of TM1py.Sandbox
         """
-        url = format_url("/api/v1/Sandboxes('{}')", sandbox_name)
+        url = format_url("/Sandboxes('{}')", sandbox_name)
         response = self._rest.GET(url=url, **kwargs)
         sandbox = Sandbox.from_json(response.text)
         return sandbox
@@ -33,7 +33,7 @@ class SandboxService(ObjectService):
 
         :return: List of TM1py.Sandbox instances
         """
-        url = "/api/v1/Sandboxes?$select=Name,IncludeInSandboxDimension,IsLoaded,IsActive,IsQueued"
+        url = "/Sandboxes?$select=Name,IncludeInSandboxDimension,IsLoaded,IsActive,IsQueued"
         response = self._rest.GET(url, **kwargs)
         sandboxes = [
             Sandbox.from_dict(sandbox_as_dict=sandbox)
@@ -47,7 +47,7 @@ class SandboxService(ObjectService):
         :param kwargs:
         :return:
         """
-        url = "/api/v1/Sandboxes?$select=Name"
+        url = "/Sandboxes?$select=Name"
         response = self._rest.GET(url, **kwargs)
         return [entry["Name"] for entry in response.json()["value"]]
 
@@ -57,7 +57,7 @@ class SandboxService(ObjectService):
         :param sandbox: Sandbox
         :return: response
         """
-        url = "/api/v1/Sandboxes"
+        url = "/Sandboxes"
         return self._rest.POST(url=url, data=sandbox.body, **kwargs)
 
     def update(self, sandbox: Sandbox, **kwargs) -> Response:
@@ -66,7 +66,7 @@ class SandboxService(ObjectService):
         :param sandbox:
         :return: response
         """
-        url = format_url("/api/v1/Sandboxes('{}')", sandbox.name)
+        url = format_url("/Sandboxes('{}')", sandbox.name)
         return self._rest.PATCH(url=url, data=sandbox.body, **kwargs)
 
     def delete(self, sandbox_name: str, **kwargs) -> Response:
@@ -75,7 +75,7 @@ class SandboxService(ObjectService):
         :param sandbox_name:
         :return: response
         """
-        url = format_url("/api/v1/Sandboxes('{}')", sandbox_name)
+        url = format_url("/Sandboxes('{}')", sandbox_name)
         return self._rest.DELETE(url, **kwargs)
 
     def publish(self, sandbox_name: str, **kwargs) -> Response:
@@ -84,7 +84,7 @@ class SandboxService(ObjectService):
         :param sandbox_name: str
         :return: response
         """
-        url = format_url("/api/v1/Sandboxes('{}')/tm1.Publish", sandbox_name)
+        url = format_url("/Sandboxes('{}')/tm1.Publish", sandbox_name)
         return self._rest.POST(url=url, **kwargs)
 
     def reset(self, sandbox_name: str, **kwargs) -> Response:
@@ -93,7 +93,7 @@ class SandboxService(ObjectService):
         :param sandbox_name: str
         :return: response
         """
-        url = format_url("/api/v1/Sandboxes('{}')/tm1.DiscardChanges", sandbox_name)
+        url = format_url("/Sandboxes('{}')/tm1.DiscardChanges", sandbox_name)
         return self._rest.POST(url=url, **kwargs)
 
     def merge(
@@ -110,7 +110,7 @@ class SandboxService(ObjectService):
         :param clean_after: bool: Reset source sandbox after merging
         :return: response
         """
-        url = format_url("/api/v1/Sandboxes('{}')/tm1.Merge", source_sandbox_name)
+        url = format_url("/Sandboxes('{}')/tm1.Merge", source_sandbox_name)
         payload = dict()
         payload["Target@odata.bind"] = format_url(
             "Sandboxes('{}')", target_sandbox_name
@@ -124,7 +124,7 @@ class SandboxService(ObjectService):
         :param sandbox_name: String
         :return: bool
         """
-        url = format_url("/api/v1/Sandboxes('{}')", sandbox_name)
+        url = format_url("/Sandboxes('{}')", sandbox_name)
         return self._exists(url, **kwargs)
     
     def load(self, sandbox_name: str, **kwargs) -> Response:
@@ -133,7 +133,7 @@ class SandboxService(ObjectService):
         :param sandbox_name: str
         :return: response
         """
-        url = format_url("/api/v1/Sandboxes('{}')/tm1.Load", sandbox_name)
+        url = format_url("/Sandboxes('{}')/tm1.Load", sandbox_name)
         return self._rest.POST(url=url, **kwargs)
     
     def unload(self, sandbox_name: str, **kwargs) -> Response:
@@ -142,5 +142,5 @@ class SandboxService(ObjectService):
         :param sandbox_name: str
         :return: response
         """
-        url = format_url("/api/v1/Sandboxes('{}')/tm1.Unload", sandbox_name)
+        url = format_url("/Sandboxes('{}')/tm1.Unload", sandbox_name)
         return self._rest.POST(url=url, **kwargs)

--- a/TM1py/Services/SecurityService.py
+++ b/TM1py/Services/SecurityService.py
@@ -32,7 +32,7 @@ class SecurityService(ObjectService):
         :param user: instance of TM1py.User
         :return: response
         """
-        url = '/api/v1/Users'
+        url = '/Users'
         return self._rest.POST(url, user.body, **kwargs)
 
     @require_admin
@@ -42,7 +42,7 @@ class SecurityService(ObjectService):
         :param group_name:
         :return:
         """
-        url = '/api/v1/Groups'
+        url = '/Groups'
         return self._rest.POST(url, json.dumps({"Name": group_name}), **kwargs)
 
     def get_user(self, user_name: str, **kwargs) -> User:
@@ -53,7 +53,7 @@ class SecurityService(ObjectService):
         """
         user_name = self.determine_actual_user_name(user_name, **kwargs)
         url = format_url(
-            "/api/v1/Users('{}')?$select=Name,FriendlyName,Password,Type,Enabled&$expand=Groups",
+            "/Users('{}')?$select=Name,FriendlyName,Password,Type,Enabled&$expand=Groups",
             user_name)
         response = self._rest.GET(url, **kwargs)
         return User.from_dict(response.json())
@@ -63,7 +63,7 @@ class SecurityService(ObjectService):
 
         :return: instance of TM1py.User
         """
-        url = "/api/v1/ActiveUser?$select=Name,FriendlyName,Password,Type,Enabled&$expand=Groups"
+        url = "/ActiveUser?$select=Name,FriendlyName,Password,Type,Enabled&$expand=Groups"
         response = self._rest.GET(url, **kwargs)
         return User.from_dict(response.json())
 
@@ -78,11 +78,11 @@ class SecurityService(ObjectService):
         for current_group in self.get_groups(user.name, **kwargs):
             if current_group not in user.groups:
                 self.remove_user_from_group(current_group, user.name, **kwargs)
-        url = format_url("/api/v1/Users('{}')", user.name)
+        url = format_url("/Users('{}')", user.name)
         return self._rest.PATCH(url, user.body, **kwargs)
 
     def update_user_password(self, user_name: str, password: str, **kwargs) -> Response:
-        url = format_url("/api/v1/Users('{}')", user_name)
+        url = format_url("/Users('{}')", user_name)
         body = {"Password": password}
         return self._rest.PATCH(url, json.dumps(body), **kwargs)
 
@@ -94,7 +94,7 @@ class SecurityService(ObjectService):
         :return: response
         """
         user_name = self.determine_actual_user_name(user_name, **kwargs)
-        url = format_url("/api/v1/Users('{}')", user_name)
+        url = format_url("/Users('{}')", user_name)
         return self._rest.DELETE(url, **kwargs)
 
     @require_admin
@@ -105,7 +105,7 @@ class SecurityService(ObjectService):
         :return:
         """
         group_name = self.determine_actual_group_name(group_name, **kwargs)
-        url = format_url("/api/v1/Groups('{}')", group_name)
+        url = format_url("/Groups('{}')", group_name)
         return self._rest.DELETE(url, **kwargs)
 
     def get_all_users(self, **kwargs):
@@ -113,7 +113,7 @@ class SecurityService(ObjectService):
 
         :return: List of TM1py.User instances
         """
-        url = '/api/v1/Users?$select=Name,FriendlyName,Password,Type,Enabled&$expand=Groups'
+        url = '/Users?$select=Name,FriendlyName,Password,Type,Enabled&$expand=Groups'
         response = self._rest.GET(url, **kwargs)
         users = [User.from_dict(user) for user in response.json()['value']]
         return users
@@ -123,7 +123,7 @@ class SecurityService(ObjectService):
 
         :return: List of TM1py.User instances
         """
-        url = '/api/v1/Users?select=Name'
+        url = '/Users?select=Name'
         response = self._rest.GET(url, **kwargs)
         users = [user["Name"] for user in response.json()['value']]
         return users
@@ -135,7 +135,7 @@ class SecurityService(ObjectService):
         :return: List of TM1py.User instances
         """
         url = format_url(
-            "/api/v1/Groups('{}')?$expand=Users($select=Name,FriendlyName,Password,Type,Enabled;$expand=Groups)",
+            "/Groups('{}')?$expand=Users($select=Name,FriendlyName,Password,Type,Enabled;$expand=Groups)",
             group_name)
         response = self._rest.GET(url, **kwargs)
         users = [User.from_dict(user) for user in response.json()['Users']]
@@ -147,7 +147,7 @@ class SecurityService(ObjectService):
         :param group_name:
         :return: List of strings
         """
-        url = format_url("/api/v1/Groups('{}')?$expand=Users($expand=Groups)", group_name)
+        url = format_url("/Groups('{}')?$expand=Users($expand=Groups)", group_name)
         response = self._rest.GET(url, **kwargs)
         users = [user["Name"] for user in response.json()['Users']]
         return users
@@ -159,7 +159,7 @@ class SecurityService(ObjectService):
         :return: List of strings
         """
         user_name = self.determine_actual_user_name(user_name, **kwargs)
-        url = format_url("/api/v1/Users('{}')/Groups", user_name)
+        url = format_url("/Users('{}')/Groups", user_name)
         response = self._rest.GET(url, **kwargs)
         return [group['Name'] for group in response.json()['value']]
 
@@ -172,7 +172,7 @@ class SecurityService(ObjectService):
         :return: response
         """
         user_name = self.determine_actual_user_name(user_name, **kwargs)
-        url = format_url("/api/v1/Users('{}')", user_name)
+        url = format_url("/Users('{}')", user_name)
         body = {
             "Name": user_name,
             "Groups@odata.bind": [
@@ -192,7 +192,7 @@ class SecurityService(ObjectService):
         """
         user_name = self.determine_actual_user_name(user_name, **kwargs)
         group_name = self.determine_actual_group_name(group_name, **kwargs)
-        url = format_url("/api/v1/Users('{}')/Groups?$id=Groups('{}')", user_name, group_name)
+        url = format_url("/Users('{}')/Groups?$id=Groups('{}')", user_name, group_name)
         return self._rest.DELETE(url, **kwargs)
 
     def get_all_groups(self, **kwargs) -> List[str]:
@@ -200,7 +200,7 @@ class SecurityService(ObjectService):
 
         :return: List of strings
         """
-        url = '/api/v1/Groups?$select=Name'
+        url = '/Groups?$select=Name'
         response = self._rest.GET(url, **kwargs)
         groups = [entry['Name'] for entry in response.json()['value']]
         return groups
@@ -213,11 +213,11 @@ class SecurityService(ObjectService):
         return process_service.execute_ti_code(ti, **kwargs)
 
     def user_exists(self, user_name: str, **kwargs) -> bool:
-        url = format_url("/api/v1/Users('{}')", user_name)
+        url = format_url("/Users('{}')", user_name)
         return self._exists(url, **kwargs)
 
     def group_exists(self, group_name: str, **kwargs) -> bool:
-        url = format_url("/api/v1/Groups('{}')", group_name)
+        url = format_url("/Groups('{}')", group_name)
         return self._exists(url, **kwargs)
 
     def get_custom_security_groups(self, **kwargs) -> List[str]:

--- a/TM1py/Services/ServerService.py
+++ b/TM1py/Services/ServerService.py
@@ -51,7 +51,7 @@ class ServerService(ObjectService):
 
     @odata_track_changes_header
     def initialize_transaction_log_delta_requests(self, filter=None, **kwargs):
-        url = "/api/v1/TailTransactionLog()"
+        url = "/TailTransactionLog()"
         if filter:
             url += "?$filter={}".format(filter)
         response = self._rest.GET(url=url, **kwargs)
@@ -62,14 +62,14 @@ class ServerService(ObjectService):
     @odata_track_changes_header
     def execute_transaction_log_delta_request(self, **kwargs) -> Dict:
         response = self._rest.GET(
-            url="/api/v1/" + self.tlog_last_delta_request, **kwargs)
+            url="/" + self.tlog_last_delta_request, **kwargs)
         self.tlog_last_delta_request = response.text[response.text.rfind(
             "TransactionLogEntries/!delta('"):-2]
         return response.json()['value']
 
     @odata_track_changes_header
     def initialize_audit_log_delta_requests(self, filter=None, **kwargs):
-        url = "/api/v1/TailAuditLog()"
+        url = "/TailAuditLog()"
         if filter:
             url += "?$filter={}".format(filter)
         response = self._rest.GET(url=url, **kwargs)
@@ -80,14 +80,14 @@ class ServerService(ObjectService):
     @odata_track_changes_header
     def execute_audit_log_delta_request(self, **kwargs) -> Dict:
         response = self._rest.GET(
-            url="/api/v1/" + self.alog_last_delta_request, **kwargs)
+            url="/" + self.alog_last_delta_request, **kwargs)
         self.alog_last_delta_request = response.text[response.text.rfind(
             "AuditLogEntries/!delta('"):-2]
         return response.json()['value']
 
     @odata_track_changes_header
     def initialize_message_log_delta_requests(self, filter=None, **kwargs):
-        url = "/api/v1/TailMessageLog()"
+        url = "/TailMessageLog()"
         if filter:
             url += "?$filter={}".format(filter)
         response = self._rest.GET(url=url, **kwargs)
@@ -98,7 +98,7 @@ class ServerService(ObjectService):
     @odata_track_changes_header
     def execute_message_log_delta_request(self, **kwargs) -> Dict:
         response = self._rest.GET(
-            url="/api/v1/" + self.mlog_last_delta_request, **kwargs)
+            url="/" + self.mlog_last_delta_request, **kwargs)
         self.mlog_last_delta_request = response.text[response.text.rfind(
             "MessageLogEntries/!delta('"):-2]
         return response.json()['value']
@@ -127,7 +127,7 @@ class ServerService(ObjectService):
                 "'msg_contains_operator' must be either 'AND' or 'OR'")
 
         reverse = 'desc' if reverse else 'asc'
-        url = '/api/v1/MessageLogEntries?$orderby=TimeStamp {}'.format(reverse)
+        url = '/MessageLogEntries?$orderby=TimeStamp {}'.format(reverse)
 
         if since or until or logger or level or msg_contains:
             log_filters = []
@@ -225,7 +225,7 @@ class ServerService(ObjectService):
             raise NotImplementedError("Feature expected in upcoming releases of TM1, TM1py")
 
         reverse = 'desc' if reverse else 'asc'
-        url = '/api/v1/TransactionLogEntries?$orderby=TimeStamp {} '.format(reverse)
+        url = '/TransactionLogEntries?$orderby=TimeStamp {} '.format(reverse)
 
         # filter on user, cube, time and elements
         if any([user, cube, since, until, element_tuple_filter, element_position_filter]):
@@ -270,7 +270,7 @@ class ServerService(ObjectService):
         :return:
         """
 
-        url = '/api/v1/AuditLogEntries?$expand=AuditDetails'
+        url = '/AuditLogEntries?$expand=AuditDetails'
         # filter on user, object_type, object_name  and time
         if any([user, object_type, object_name, since, until]):
             log_filters = []
@@ -309,7 +309,7 @@ class ServerService(ObjectService):
             :return: String - the message, for instance: "Ausführung normal beendet, verstrichene Zeit 0.03  Sekunden"
         """
         url = format_url(
-            "/api/v1/MessageLog()?$orderby='TimeStamp'&$filter=Logger eq 'TM1.Process' and contains(Message, '{}')",
+            "/MessageLog()?$orderby='TimeStamp'&$filter=Logger eq 'TM1.Process' and contains(Message, '{}')",
             process_name)
         response = self._rest.GET(url=url, **kwargs)
         response_as_list = response.json()['value']
@@ -323,7 +323,7 @@ class ServerService(ObjectService):
         :Returns:
             String, the server name
         """
-        url = '/api/v1/Configuration/ServerName/$value'
+        url = '/Configuration/ServerName/$value'
         return self._rest.GET(url, **kwargs).text
 
     def get_product_version(self, **kwargs) -> str:
@@ -332,19 +332,19 @@ class ServerService(ObjectService):
         :Returns:
             String, the version
         """
-        url = '/api/v1/Configuration/ProductVersion/$value'
+        url = '/Configuration/ProductVersion/$value'
         return self._rest.GET(url, **kwargs).text
 
     def get_admin_host(self, **kwargs) -> str:
-        url = '/api/v1/Configuration/AdminHost/$value'
+        url = '/Configuration/AdminHost/$value'
         return self._rest.GET(url, **kwargs).text
 
     def get_data_directory(self, **kwargs) -> str:
-        url = '/api/v1/Configuration/DataBaseDirectory/$value'
+        url = '/Configuration/DataBaseDirectory/$value'
         return self._rest.GET(url, **kwargs).text
 
     def get_configuration(self, **kwargs) -> Dict:
-        url = '/api/v1/Configuration'
+        url = '/Configuration'
         config = self._rest.GET(url, **kwargs).json()
         del config["@odata.context"]
         return config
@@ -355,7 +355,7 @@ class ServerService(ObjectService):
 
         :return: config as dictionary
         """
-        url = '/api/v1/StaticConfiguration'
+        url = '/StaticConfiguration'
         config = self._rest.GET(url, **kwargs).json()
         del config["@odata.context"]
         return config
@@ -366,7 +366,7 @@ class ServerService(ObjectService):
 
         :return: config as dictionary
         """
-        url = '/api/v1/ActiveConfiguration'
+        url = '/ActiveConfiguration'
         config = self._rest.GET(url, **kwargs).json()
         del config["@odata.context"]
         return config
@@ -378,7 +378,7 @@ class ServerService(ObjectService):
         :param configuration:
         :return: Response
         """
-        url = '/api/v1/StaticConfiguration'
+        url = '/StaticConfiguration'
         return self._rest.PATCH(url, json.dumps(configuration))
 
     @require_admin

--- a/TM1py/Services/SubsetService.py
+++ b/TM1py/Services/SubsetService.py
@@ -30,7 +30,7 @@ class SubsetService(ObjectService):
         """
         subsets = "PrivateSubsets" if private else "Subsets"
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/{}",
+            "/Dimensions('{}')/Hierarchies('{}')/{}",
             subset.dimension_name,
             subset.hierarchy_name,
             subsets)
@@ -52,7 +52,7 @@ class SubsetService(ObjectService):
             hierarchy_name = dimension_name
         subsets = "PrivateSubsets" if private else "Subsets"
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/{}('{}')?$expand=Hierarchy($select=Dimension,Name),"
+            "/Dimensions('{}')/Hierarchies('{}')/{}('{}')?$expand=Hierarchy($select=Dimension,Name),"
             "Elements($select=Name)&$select=*,Alias", dimension_name, hierarchy_name, subsets, subset_name)
         response = self._rest.GET(url=url, **kwargs)
         return Subset.from_dict(response.json())
@@ -70,7 +70,7 @@ class SubsetService(ObjectService):
 
         subsets = "PrivateSubsets" if private else "Subsets"
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/{}?$select=Name",
+            "/Dimensions('{}')/Hierarchies('{}')/{}?$select=Name",
             dimension_name, hierarchy_name, subsets)
         response = self._rest.GET(url=url, **kwargs)
         subsets = response.json()['value']
@@ -92,7 +92,7 @@ class SubsetService(ObjectService):
                 **kwargs)
         subsets = "PrivateSubsets" if private else "Subsets"
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/{}('{}')",
+            "/Dimensions('{}')/Hierarchies('{}')/{}('{}')",
             subset.dimension_name, subset.hierarchy_name, subsets, subset.name)
         return self._rest.PATCH(url=url, data=subset.body, **kwargs)
 
@@ -113,7 +113,7 @@ class SubsetService(ObjectService):
         payload['MakePrivate'] = True if private else False
         payload['MakeStatic'] = True
         subsets = "PrivateSubsets" if private else "Subsets"
-        url = format_url("/api/v1/Dimensions('{}')/Hierarchies('{}')/{}('{}')/tm1.SaveAs", dimension_name,
+        url = format_url("/Dimensions('{}')/Hierarchies('{}')/{}('{}')/tm1.SaveAs", dimension_name,
                          hierarchy_name, subsets, subset_name)
         return self._rest.POST(url=url, data=json.dumps(payload))
 
@@ -147,7 +147,7 @@ class SubsetService(ObjectService):
         hierarchy_name = hierarchy_name if hierarchy_name else dimension_name
         subsets = "PrivateSubsets" if private else "Subsets"
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/{}('{}')",
+            "/Dimensions('{}')/Hierarchies('{}')/{}('{}')",
             dimension_name, hierarchy_name, subsets, subset_name)
         response = self._rest.DELETE(url=url, **kwargs)
         return response
@@ -165,7 +165,7 @@ class SubsetService(ObjectService):
         hierarchy_name = hierarchy_name if hierarchy_name else dimension_name
         subset_type = 'PrivateSubsets' if private else "Subsets"
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/{}('{}')",
+            "/Dimensions('{}')/Hierarchies('{}')/{}('{}')",
             dimension_name, hierarchy_name, subset_type, subset_name)
         return self._exists(url, **kwargs)
 
@@ -173,7 +173,7 @@ class SubsetService(ObjectService):
                                            private: bool, **kwargs) -> Response:
         subsets = "PrivateSubsets" if private else "Subsets"
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/{}('{}')/Elements/$ref",
+            "/Dimensions('{}')/Hierarchies('{}')/{}('{}')/Elements/$ref",
             dimension_name, hierarchy_name, subsets, subset_name)
         return self._rest.DELETE(url=url, **kwargs)
 

--- a/TM1py/Services/ViewService.py
+++ b/TM1py/Services/ViewService.py
@@ -31,7 +31,7 @@ class ViewService(ObjectService):
         :return: Response
         """
         view_type = "PrivateViews" if private else "Views"
-        url = format_url("/api/v1/Cubes('{}')/{}", view.cube, view_type)
+        url = format_url("/Cubes('{}')/{}", view.cube, view_type)
         return self._rest.POST(url, view.body, **kwargs)
 
     def exists(self, cube_name: str, view_name: str, private: bool = None, **kwargs):
@@ -43,7 +43,7 @@ class ViewService(ObjectService):
 
         :return boolean tuple
         """
-        url_template = "/api/v1/Cubes('{}')/{}('{}')"
+        url_template = "/Cubes('{}')/{}('{}')"
         if private is not None:
             url = format_url(url_template, cube_name, "PrivateViews" if private else "Views", view_name)
             return self._exists(url, **kwargs)
@@ -63,7 +63,7 @@ class ViewService(ObjectService):
 
     def get(self, cube_name: str, view_name: str, private: bool = False, **kwargs) -> View:
         view_type = "PrivateViews" if private else "Views"
-        url = format_url("/api/v1/Cubes('{}')/{}('{}')?$expand=*", cube_name, view_type, view_name)
+        url = format_url("/Cubes('{}')/{}('{}')?$expand=*", cube_name, view_type, view_name)
         response = self._rest.GET(url, **kwargs)
         view_as_dict = response.json()
         if "MDX" in view_as_dict:
@@ -82,7 +82,7 @@ class ViewService(ObjectService):
         """
         view_type = "PrivateViews" if private else "Views"
         url = format_url(
-            "/api/v1/Cubes('{}')/{}('{}')?$expand="
+            "/Cubes('{}')/{}('{}')?$expand="
             "tm1.NativeView/Rows/Subset($expand=Hierarchy($select=Name;"
             "$expand=Dimension($select=Name)),Elements($select=Name);"
             "$select=Expression,UniqueName,Name, Alias),  "
@@ -108,7 +108,7 @@ class ViewService(ObjectService):
         :return: instance of TM1py.MDXView
         """
         view_type = 'PrivateViews' if private else 'Views'
-        url = format_url("/api/v1/Cubes('{}')/{}('{}')?$expand=*", cube_name, view_type, view_name)
+        url = format_url("/Cubes('{}')/{}('{}')?$expand=*", cube_name, view_type, view_name)
         response = self._rest.GET(url, **kwargs)
         mdx_view = MDXView.from_json(view_as_json=response.text)
         return mdx_view
@@ -125,7 +125,7 @@ class ViewService(ObjectService):
         private_views, public_views = [], []
         for view_type in ('PrivateViews', 'Views'):
             url = format_url(
-                "/api/v1/Cubes('{}')/{}?$expand="
+                "/Cubes('{}')/{}?$expand="
                 "tm1.NativeView/Rows/Subset($expand=Hierarchy($select=Name;"
                 "$expand=Dimension($select=Name)),Elements($select=Name{});"
                 "$select=Expression,UniqueName,Name, Alias),  "
@@ -158,7 +158,7 @@ class ViewService(ObjectService):
         """
         private_views, public_views = [], []
         for view_type in ('PrivateViews', 'Views'):
-            url = format_url("/api/v1/Cubes('{}')/{}?$select=Name", cube_name, view_type)
+            url = format_url("/Cubes('{}')/{}?$select=Name", cube_name, view_type)
             response = self._rest.GET(url, **kwargs)
             response_as_list = response.json()['value']
 
@@ -178,7 +178,7 @@ class ViewService(ObjectService):
         :return: response
         """
         view_type = 'PrivateViews' if private else 'Views'
-        url = format_url("/api/v1/Cubes('{}')/{}('{}')", view.cube, view_type, view.name)
+        url = format_url("/Cubes('{}')/{}('{}')", view.cube, view_type, view.name)
         response = self._rest.PATCH(url, view.body, **kwargs)
         return response
 
@@ -205,7 +205,7 @@ class ViewService(ObjectService):
         :return: String, the response
         """
         view_type = 'PrivateViews' if private else 'Views'
-        url = format_url("/api/v1/Cubes('{}')/{}('{}')", cube_name, view_type, view_name)
+        url = format_url("/Cubes('{}')/{}('{}')", cube_name, view_type, view_name)
         response = self._rest.DELETE(url, **kwargs)
         return response
 
@@ -226,10 +226,10 @@ class ViewService(ObjectService):
         element_filter = ";$top=0" if not include_elements else ""
         if cube_name:
             base_url = format_url(
-                "/api/v1/Cubes?$select=Name&$filter=replace(tolower(Name),' ', '') eq '{}'",
+                "/Cubes?$select=Name&$filter=replace(tolower(Name),' ', '') eq '{}'",
                 cube_name.lower().replace(' ', ''))
         else:
-            base_url = "/api/v1/Cubes?$select=Name"
+            base_url = "/Cubes?$select=Name"
 
         private_views, public_views = [], []
         for view_type in ('PrivateViews', 'Views'):
@@ -272,7 +272,7 @@ class ViewService(ObjectService):
         return private_views, public_views
 
     def is_mdx_view(self, cube_name: str, view_name: str, private=False, **kwargs):
-        url_template = "/api/v1/Cubes('{}')/{}('{}')?select=Name"
+        url_template = "/Cubes('{}')/{}('{}')?select=Name"
         if private is not None:
             url = format_url(url_template, cube_name, "PrivateViews" if private else "Views", view_name)
 

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -90,7 +90,7 @@ def get_all_servers_from_adminhost(adminhost='localhost', port=None, use_ssl=Fal
         conn = http_client.HTTPConnection(adminhost, port or 5895)
     else:
         conn = http_client.HTTPSConnection(adminhost, port or 5898, context=ssl._create_unverified_context())
-    request = '/api/v1/Servers'
+    request = '/Servers'
     conn.request('GET', request, body='')
     response = conn.getresponse().read().decode('utf-8')
     response_as_dict = json.loads(response)
@@ -126,7 +126,7 @@ def create_server_on_adminhost(adminhost: str = 'localhost', server_as_dict: Dic
     if not adminhost:
         adminhost = 'localhost'
 
-    url = f"http://{adminhost}:5895/api/v1/Servers"
+    url = f"http://{adminhost}:5895/Servers"
     response = requests.post(url, data=json.dumps(server_as_dict), headers={'Content-Type': 'application/json'})
     response.raise_for_status()
 
@@ -140,7 +140,7 @@ def delete_server_on_adminhost(adminhost: str = None, server_name: str = None):
     if not adminhost:
         adminhost = 'localhost'
 
-    url = f"http://{adminhost}:5895/api/v1/Servers('{server_name}')"
+    url = f"http://{adminhost}:5895/Servers('{server_name}')"
     response = requests.delete(url, headers={'Content-Type': 'application/json'})
     response.raise_for_status()
 
@@ -170,7 +170,7 @@ def update_server_on_adminhost(adminhost: str = 'localhost', server_as_dict: Dic
     if not adminhost:
         adminhost = 'localhost'
 
-    url = f"http://{adminhost}:5895/api/v1/Servers"
+    url = f"http://{adminhost}:5895/Servers"
     response = requests.patch(url, body=json.dumps(server_as_dict), headers={'Content-Type': 'application/json'})
     response.raise_for_status()
 

--- a/Tests/CellService_test.py
+++ b/Tests/CellService_test.py
@@ -2796,7 +2796,7 @@ class TestCellService(unittest.TestCase):
 
         df = self.tm1.cubes.cells.execute_mdx_dataframe(query, use_blob=True)
         self.assertEqual(
-            [["NA", "Element 1", 4.0]],
+            [["Element 1", "NA", 4.0]],
             df.values.tolist())
 
     @skip_if_no_pandas

--- a/Tests/MonitoringService_test.py
+++ b/Tests/MonitoringService_test.py
@@ -22,7 +22,7 @@ class TestMonitoringService(unittest.TestCase):
 
     def test_get_threads(self):
         threads = self.tm1.monitoring.get_threads()
-        self.assertTrue(any(thread["Function"] == "GET /api/v1/Threads" for thread in threads))
+        self.assertTrue(any(thread["Function"] == "GET /Threads" for thread in threads))
 
     def test_get_active_users(self):
         current_user = self.tm1.security.get_current_user()

--- a/Tests/ServerService_test.py
+++ b/Tests/ServerService_test.py
@@ -427,7 +427,7 @@ class TestServerService(unittest.TestCase):
     def test_session_context_default(self):
         threads = self.tm1.monitoring.get_threads()
         for thread in threads:
-            if "GET /api/v1/Threads" in thread["Function"] and thread["Name"] == self.config['tm1srv01']['user']:
+            if "GET /Threads" in thread["Function"] and thread["Name"] == self.config['tm1srv01']['user']:
                 self.assertTrue(thread["Context"] == "TM1py")
                 return
         raise Exception("Did not find my own Thread")
@@ -437,7 +437,7 @@ class TestServerService(unittest.TestCase):
         with TM1Service(**self.config['tm1srv01'], session_context=app_name) as tm1:
             threads = tm1.monitoring.get_threads()
             for thread in threads:
-                if "GET /api/v1/Threads" in thread["Function"] and thread["Name"] == self.config['tm1srv01']['user']:
+                if "GET /Threads" in thread["Function"] and thread["Name"] == self.config['tm1srv01']['user']:
                     self.assertTrue(thread["Context"] == app_name)
                     return
         raise Exception("Did not find my own Thread")

--- a/Tests/Utils_test.py
+++ b/Tests/Utils_test.py
@@ -229,71 +229,71 @@ class TestUtilsMethods(unittest.TestCase):
         self.assertTrue(resembles_mdx(mdx))
 
     def test_format_url_args_no_single_quote(self):
-        url = "/api/v1/Processes('{}')/tm1.ExecuteWithReturn?$expand=*"
+        url = "/Processes('{}')/tm1.ExecuteWithReturn?$expand=*"
         process_name = "process"
         escaped_url = format_url(url, process_name)
         self.assertEqual(
-            "/api/v1/Processes('process')/tm1.ExecuteWithReturn?$expand=*", escaped_url
+            "/Processes('process')/tm1.ExecuteWithReturn?$expand=*", escaped_url
         )
 
     def test_format_url_args_one_single_quote(self):
-        url = "/api/v1/Processes('{}')/tm1.ExecuteWithReturn?$expand=*"
+        url = "/Processes('{}')/tm1.ExecuteWithReturn?$expand=*"
         process_name = "pro'cess"
         escaped_url = format_url(url, process_name)
         self.assertEqual(
-            "/api/v1/Processes('pro''cess')/tm1.ExecuteWithReturn?$expand=*",
+            "/Processes('pro''cess')/tm1.ExecuteWithReturn?$expand=*",
             escaped_url,
         )
 
     def test_format_url_args_multi_single_quote(self):
-        url = "/api/v1/Processes('{}')/tm1.ExecuteWithReturn?$expand=*"
+        url = "/Processes('{}')/tm1.ExecuteWithReturn?$expand=*"
         process_name = "pro'ces's"
         escaped_url = format_url(url, process_name)
         self.assertEqual(
-            "/api/v1/Processes('pro''ces''s')/tm1.ExecuteWithReturn?$expand=*",
+            "/Processes('pro''ces''s')/tm1.ExecuteWithReturn?$expand=*",
             escaped_url,
         )
 
     def test_format_url_kwargs_no_single_quote(self):
-        url = "/api/v1/Processes('{process_name}')/tm1.ExecuteWithReturn?$expand=*"
+        url = "/Processes('{process_name}')/tm1.ExecuteWithReturn?$expand=*"
         process_name = "process"
         escaped_url = format_url(url, process_name=process_name)
         self.assertEqual(
-            "/api/v1/Processes('process')/tm1.ExecuteWithReturn?$expand=*", escaped_url
+            "/Processes('process')/tm1.ExecuteWithReturn?$expand=*", escaped_url
         )
 
     def test_format_url_kwargs_one_single_quote(self):
-        url = "/api/v1/Processes('{process_name}')/tm1.ExecuteWithReturn?$expand=*"
+        url = "/Processes('{process_name}')/tm1.ExecuteWithReturn?$expand=*"
         process_name = "pro'cess"
         escaped_url = format_url(url, process_name=process_name)
         self.assertEqual(
-            "/api/v1/Processes('pro''cess')/tm1.ExecuteWithReturn?$expand=*",
+            "/Processes('pro''cess')/tm1.ExecuteWithReturn?$expand=*",
             escaped_url,
         )
 
     def test_format_url_kwargs_multi_single_quote(self):
-        url = "/api/v1/Processes('{process_name}')/tm1.ExecuteWithReturn?$expand=*"
+        url = "/Processes('{process_name}')/tm1.ExecuteWithReturn?$expand=*"
         process_name = "pro'ces's"
         escaped_url = format_url(url, process_name=process_name)
         self.assertEqual(
-            "/api/v1/Processes('pro''ces''s')/tm1.ExecuteWithReturn?$expand=*",
+            "/Processes('pro''ces''s')/tm1.ExecuteWithReturn?$expand=*",
             escaped_url,
         )
 
     def test_url_parameters_add(self):
-        url = "/api/v1/Cubes('cube')/tm1.Update"
+        url = "/Cubes('cube')/tm1.Update"
         url = add_url_parameters(url, **{"!sandbox": "sandbox1"})
 
         self.assertEqual(
-            "/api/v1/Cubes('cube')/tm1.Update?!sandbox=sandbox1",
+            "/Cubes('cube')/tm1.Update?!sandbox=sandbox1",
             url)
 
     def test_url_parameters_add_with_query_options(self):
-        url = "/api/v1/Cellsets('abcd')?$expand=Cells($select=Value)"
+        url = "/Cellsets('abcd')?$expand=Cells($select=Value)"
         url = add_url_parameters(url, **{"!sandbox": "sandbox1"})
 
         self.assertEqual(
-            "/api/v1/Cellsets('abcd')?$expand=Cells($select=Value)&!sandbox=sandbox1",
+            "/Cellsets('abcd')?$expand=Cells($select=Value)&!sandbox=sandbox1",
             url)
 
     def test_get_seconds_from_duration(self):

--- a/Tests/config.ini
+++ b/Tests/config.ini
@@ -1,13 +1,13 @@
-[tm1srv01]
+[tm1srv02]
 address=localhost
 port=12354
 user=admin
 password=apple
 ssl=True
 
-[tm1srv02]
-address=10.77.19.60
-port=9699
+[tm1srv01]
+address=awstm1-ux-d01
+port=8010
 user=Admin
 password=apple
-ssl=False
+ssl=True


### PR DESCRIPTION
Changes how TM1py understands the service root. api/v1/ has been moved out of the URL specifications in each service and relocated to the Rest service. The Rest service has been updated to maintain backwards compatibility with v11 using the the address property (most common use case). This update will require the full service root to be specified if users specify base address property. This new structure will allow TM1py to support v12. 