### PR TITLE
Enable support for TM1 v12

### DIFF
--- a/TM1py/Exceptions/Exceptions.py
+++ b/TM1py/Exceptions/Exceptions.py
@@ -23,6 +23,15 @@ class TM1pyVersionException(Exception):
         return f"Function '{self.function}' requires TM1 server version >= '{self.required_version}'"
 
 
+class TM1pyVersionDeprecationException(Exception):
+    def __init__(self, function: str, deprecated_in_version):
+        self.function = function
+        self.deprecated_in_version = deprecated_in_version
+
+    def __str__(self):
+        return f"Function '{self.function}' has been deprecated in TM1 server version >= '{self.deprecated_in_version}'"
+
+
 class TM1pyNotAdminException(Exception):
     def __init__(self, function: str):
         self.function = function

--- a/TM1py/Objects/Chore.py
+++ b/TM1py/Objects/Chore.py
@@ -31,7 +31,7 @@ class Chore(TM1Object):
     def from_json(cls, chore_as_json: str) -> 'Chore':
         """ Alternative constructor
 
-        :param chore_as_json: string, JSON. Response of /api/v1/Chores('x')/Tasks?$expand=*
+        :param chore_as_json: string, JSON. Response of /Chores('x')/Tasks?$expand=*
         :return: Chore, an instance of this class
         """
         chore_as_dict = json.loads(chore_as_json)

--- a/TM1py/Objects/GitProject.py
+++ b/TM1py/Objects/GitProject.py
@@ -274,7 +274,7 @@ class TM1Project(TM1Object):
     @classmethod
     def from_json(cls, tm1project_as_json: str) -> 'TM1Project':
         """
-        :param tm1project_as_json: response of /api/v1/!tm1project
+        :param tm1project_as_json: response of /!tm1project
         :return: an instance of this class
         """
         tm1project_as_dict = json.loads(tm1project_as_json)

--- a/TM1py/Objects/Process.py
+++ b/TM1py/Objects/Process.py
@@ -123,7 +123,7 @@ class Process(TM1Object):
     @classmethod
     def from_json(cls, process_as_json: str) -> 'Process':
         """
-        :param process_as_json: response of /api/v1/Processes('x')?$expand=*
+        :param process_as_json: response of /Processes('x')?$expand=*
         :return: an instance of this class
         """
         process_as_dict = json.loads(process_as_json)

--- a/TM1py/Objects/Server.py
+++ b/TM1py/Objects/Server.py
@@ -6,7 +6,7 @@ class Server:
     """ Abstraction of the TM1 Server
 
         :Notes:
-            contains the information you get from http://localhost:5895/api/v1/Servers
+            contains the information you get from http://localhost:5895/Servers
             no methods so far
     """
     def __init__(self, server_as_dict: Dict):

--- a/TM1py/Objects/User.py
+++ b/TM1py/Objects/User.py
@@ -136,7 +136,7 @@ class User(TM1Object):
         """
         return cls(name=user_as_dict['Name'],
                    friendly_name=user_as_dict['FriendlyName'],
-                   enabled=user_as_dict["Enabled"],
+                   enabled=user_as_dict.get('Enabled', None),
                    user_type=user_as_dict["Type"],
                    groups=[group["Name"] for group in user_as_dict['Groups']])
 

--- a/TM1py/Services/AnnotationService.py
+++ b/TM1py/Services/AnnotationService.py
@@ -24,7 +24,7 @@ class AnnotationService(ObjectService):
 
         :param cube_name:
         """
-        url = format_url("/api/v1/Cubes('{}')/Annotations?$expand=DimensionalContext($select=Name)", cube_name)
+        url = format_url("/Cubes('{}')/Annotations?$expand=DimensionalContext($select=Name)", cube_name)
         response = self._rest.GET(url, **kwargs)
 
         annotations_as_dict = response.json()['value']
@@ -36,7 +36,7 @@ class AnnotationService(ObjectService):
 
         :param annotation: instance of TM1py.Annotation
         """
-        url = "/api/v1/Annotations"
+        url = "/Annotations"
 
         from TM1py import CubeService
         cube_dimensions = CubeService(self._rest).get_dimension_names(
@@ -65,7 +65,7 @@ class AnnotationService(ObjectService):
                 cube_dimensions[annotation.object_name] = dimension_names
             payload.append(annotation.construct_body_for_post(dimension_names))
 
-        response = self._rest.POST("/api/v1/Annotations", json.dumps(payload), **kwargs)
+        response = self._rest.POST("/Annotations", json.dumps(payload), **kwargs)
 
         return response
 
@@ -74,7 +74,7 @@ class AnnotationService(ObjectService):
 
         :param annotation_id: String, the id of the annotation
         """
-        request = format_url("/api/v1/Annotations('{}')?$expand=DimensionalContext($select=Name)", annotation_id)
+        request = format_url("/Annotations('{}')?$expand=DimensionalContext($select=Name)", annotation_id)
         response = self._rest.GET(url=request, **kwargs)
         return Annotation.from_json(response.text)
 
@@ -84,7 +84,7 @@ class AnnotationService(ObjectService):
 
         :param annotation: instance of TM1py.Annotation
         """
-        url = format_url("/api/v1/Annotations('{}')", annotation.id)
+        url = format_url("/Annotations('{}')", annotation.id)
         return self._rest.PATCH(url=url, data=annotation.body, **kwargs)
 
     def delete(self, annotation_id: str, **kwargs) -> Response:
@@ -92,5 +92,5 @@ class AnnotationService(ObjectService):
     
         :param annotation_id: string, the id of the annotation
         """
-        url = format_url("/api/v1/Annotations('{}')", annotation_id)
+        url = format_url("/Annotations('{}')", annotation_id)
         return self._rest.DELETE(url=url, **kwargs)

--- a/TM1py/Services/ApplicationService.py
+++ b/TM1py/Services/ApplicationService.py
@@ -9,7 +9,7 @@ from TM1py.Objects.Application import DocumentApplication, ApplicationTypes, Cub
     Application
 from TM1py.Services import RestService
 from TM1py.Services.ObjectService import ObjectService
-from TM1py.Utils import format_url
+from TM1py.Utils import format_url, verify_version
 
 
 class ApplicationService(ObjectService):
@@ -23,6 +23,21 @@ class ApplicationService(ObjectService):
         """
         super().__init__(tm1_rest)
         self._rest = tm1_rest
+
+    def get_all_public_root_names(self, **kwargs):
+
+        url = "/Contents('Applications')/Contents"
+        response = self._rest.GET(url, **kwargs)
+        applications = list(application['Name'] for application in response.json()['value'])
+        return applications
+
+    def get_all_private_root_names(self, **kwargs):
+
+        url = "/Contents('Applications')/PrivateContents"
+        response = self._rest.GET(url, **kwargs)
+        applications = list(application['Name'] for application in response.json()['value'])
+        return applications
+
 
     def get(self, path: str, application_type: Union[str, ApplicationTypes], name: str, private: bool = False,
             **kwargs) -> Application:
@@ -41,7 +56,7 @@ class ApplicationService(ObjectService):
         if application_type == ApplicationTypes.DOCUMENT:
             return self.get_document(path=path, name=name, private=private, **kwargs)
 
-        if not application_type == ApplicationTypes.FOLDER:
+        if not application_type == ApplicationTypes.FOLDER and not verify_version(required_version='12', version=self.version):
             name += application_type.suffix
 
         contents = 'PrivateContents' if private else 'Contents'
@@ -50,7 +65,7 @@ class ApplicationService(ObjectService):
             mid = "".join([format_url("/Contents('{}')", element) for element in path.split('/')])
 
         base_url = format_url(
-            "/api/v1/Contents('Applications')" + mid + "/" + contents + "('{application_name}')",
+            "/Contents('Applications')" + mid + "/" + contents + "('{application_name}')",
             application_name=name)
 
         if application_type == ApplicationTypes.CUBE:
@@ -112,19 +127,19 @@ class ApplicationService(ObjectService):
         :param private: boolean
         :return: Return DocumentApplication
         """
-        if not name.endswith(ApplicationTypes.DOCUMENT.suffix):
+        if not name.endswith(ApplicationTypes.DOCUMENT.suffix) and not verify_version(required_version='12', version=self.version):
             name += ApplicationTypes.DOCUMENT.suffix
 
         contents = 'PrivateContents' if private else 'Contents'
         mid = "".join([format_url("/Contents('{}')", element) for element in path.split('/')])
         url = format_url(
-            "/api/v1/Contents('Applications')" + mid + "/" + contents + "('{name}')/Document/Content",
+            "/Contents('Applications')" + mid + "/" + contents + "('{name}')/Document/Content",
             name=name)
 
         content = self._rest.GET(url, **kwargs).content
 
         url = format_url(
-            "/api/v1/Contents('Applications')" + mid + "/" + contents + "('{name}')/Document",
+            "/Contents('Applications')" + mid + "/" + contents + "('{name}')/Document",
             name=name)
         document_fields = self._rest.GET(url, **kwargs).json()
 
@@ -150,7 +165,7 @@ class ApplicationService(ObjectService):
         # raise ValueError if not a valid ApplicationType
         application_type = ApplicationTypes(application_type)
 
-        if not application_type == ApplicationTypes.FOLDER:
+        if not application_type == ApplicationTypes.FOLDER and not verify_version(required_version='12', version=self.version):
             application_name += application_type.suffix
 
         contents = 'PrivateContents' if private else 'Contents'
@@ -159,7 +174,7 @@ class ApplicationService(ObjectService):
             mid = "".join([format_url("/Contents('{}')", element) for element in path.split('/')])
 
         url = format_url(
-            "/api/v1/Contents('Applications')" + mid + "/" + contents + "('{application_name}')",
+            "/Contents('Applications')" + mid + "/" + contents + "('{application_name}')",
             application_name=application_name)
         return self._rest.DELETE(url, **kwargs)
 
@@ -168,7 +183,7 @@ class ApplicationService(ObjectService):
         # raise ValueError if not a valid ApplicationType
         application_type = ApplicationTypes(application_type)
 
-        if not application_type == ApplicationTypes.FOLDER:
+        if not application_type == ApplicationTypes.FOLDER and not verify_version(required_version='12', version=self.version):
             application_name += application_type.suffix
 
         contents = 'PrivateContents' if private else 'Contents'
@@ -177,7 +192,7 @@ class ApplicationService(ObjectService):
             mid = "".join([format_url("/Contents('{}')", element) for element in path.split('/')])
 
         url = format_url(
-            "/api/v1/Contents('Applications')" + mid + "/" + contents + "('{application_name}')/tm1.Move",
+            "/Contents('Applications')" + mid + "/" + contents + "('{application_name}')/tm1.Move",
             application_name=application_name)
         data = {"Name": new_application_name}
 
@@ -196,13 +211,14 @@ class ApplicationService(ObjectService):
         mid = ""
         if application.path.strip() != '':
             mid = "".join([format_url("/Contents('{}')", element) for element in application.path.split('/')])
-        url = "/api/v1/Contents('Applications')" + mid + "/" + contents
+        url = "/Contents('Applications')" + mid + "/" + contents
         response = self._rest.POST(url, application.body, **kwargs)
 
         if application.application_type == ApplicationTypes.DOCUMENT:
             url = format_url(
-                "/api/v1/Contents('Applications')" + mid + "/" + contents + "('{name}.blob')/Document/Content",
-                name=application.name)
+                "/Contents('Applications')" + mid + "/" + contents + "('{name}{suffix}')/Document/Content",
+                name=application.name,
+                suffix='.blob' if not verify_version(required_version='12', version=self.version) else '')
             response = self._rest.PUT(url, application.content, headers=self.BINARY_HTTP_HEADER, **kwargs)
 
         return response
@@ -223,11 +239,11 @@ class ApplicationService(ObjectService):
 
         if application.application_type == ApplicationTypes.DOCUMENT:
             url = format_url(
-                "/api/v1/Contents('Applications')" + mid + "/" + contents + "('{name}.blob')/Document/Content",
+                "/Contents('Applications')" + mid + "/" + contents + "('{name}.blob')/Document/Content",
                 name=application.name)
             response = self._rest.PATCH(url, application.content, headers=self.BINARY_HTTP_HEADER, **kwargs)
         else:
-            url = "/api/v1/Contents('Applications')" + mid + "/" + contents
+            url = "/Contents('Applications')" + mid + "/" + contents
             response = self._rest.POST(url, application.body, **kwargs)
 
         return response
@@ -265,7 +281,7 @@ class ApplicationService(ObjectService):
         # raise ValueError if not a valid ApplicationType
         application_type = ApplicationTypes(application_type)
 
-        if not application_type == ApplicationTypes.FOLDER:
+        if not application_type == ApplicationTypes.FOLDER and not verify_version(required_version='12', version=self.version):
             name += application_type.suffix
 
         contents = 'PrivateContents' if private else 'Contents'
@@ -274,7 +290,7 @@ class ApplicationService(ObjectService):
             mid = "".join(["/Contents('{}')".format(element) for element in path.split('/')])
 
         url = format_url(
-            "/api/v1/Contents('Applications')" + mid + "/" + contents + "('{application_name}')",
+            "/Contents('Applications')" + mid + "/" + contents + "('{application_name}')",
             application_name=name)
         return self._exists(url, **kwargs)
 

--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -843,7 +843,7 @@ class CellService(ObjectService):
               deactivate_transaction_log: bool = False, reactivate_transaction_log: bool = False,
               sandbox_name: str = None, use_ti: bool = False, use_blob: bool = False, use_changeset: bool = False,
               precision: int = None, skip_non_updateable: bool = False, measure_dimension_elements: Dict = None,
-              remove_blob: bool = True, allow_spread: bool=False, **kwargs) -> Optional[str]:
+              remove_blob: bool = True, allow_spread: bool = False, **kwargs) -> Optional[str]:
         """ Write values to a cube
 
         Same signature as `write_values` method, but faster since it uses `write_values_through_cellset`
@@ -1039,7 +1039,7 @@ class CellService(ObjectService):
     @require_pandas
     def write_through_blob(self, cube_name: str, cellset_as_dict: dict, increment: bool = False,
                            sandbox_name: str = None, skip_non_updateable: bool = False,
-                           remove_blob=True, dimensions: str = None, allow_spread: bool=False, **kwargs):
+                           remove_blob=True, dimensions: str = None, allow_spread: bool = False, **kwargs):
         """
         Writes data back to TM1 via an unbound TI process having an uploaded CSV as data source
         :param cube_name: str
@@ -2928,7 +2928,8 @@ class CellService(ObjectService):
             "/Cellsets('{}')?$expand=Cells($select=Value{})",
             cellset_id,
             f";$filter={filter_cells}" if filter_cells else "")
-        url = add_url_parameters(url, **{"!sandbox": sandbox_name})
+        if sandbox_name:
+            url = add_url_parameters(url, **{"!sandbox": sandbox_name})
         response = self._rest.GET(url=url, **kwargs)
 
         if not use_compact_json:

--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -35,7 +35,7 @@ from TM1py.Utils.Utils import build_pandas_dataframe_from_cellset, dimension_nam
     case_and_space_insensitive_equals, get_cube, resembles_mdx, require_admin, extract_compact_json_cellset, \
     cell_is_updateable, build_mdx_from_cellset, build_mdx_and_values_from_cellset, \
     dimension_names_from_element_unique_names, frame_to_significant_digits, build_dataframe_from_csv, \
-    drop_dimension_properties, decohints
+    drop_dimension_properties, decohints, verify_version
 
 try:
     import pandas as pd
@@ -343,7 +343,7 @@ class CellService(ObjectService):
                 component_fields = f'{component_depth}/Type, {component_depth}/Value, {component_depth}/Statements'
                 select_query = ','.join([select_query, component_fields])
 
-        url = format_url("/api/v1/Cubes('{}')/tm1.TraceCellCalculation?$select=Type,Value,Statements"
+        url = format_url("/Cubes('{}')/tm1.TraceCellCalculation?$select=Type,Value,Statements"
                          "{}&$expand=Tuple($select=Name, UniqueName, Type) {}", cube_name, select_query, expand_query)
 
         url = add_url_parameters(url, **{"!sandbox": sandbox_name})
@@ -388,7 +388,7 @@ class CellService(ObjectService):
         :return: feeder trace
         """
 
-        url = format_url("/api/v1/Cubes('{}')/tm1.TraceFeeders?$select=Statements,FedCells"
+        url = format_url("/Cubes('{}')/tm1.TraceFeeders?$select=Statements,FedCells"
                          "&$expand=FedCells/Tuple($select=Name,UniqueName,Type), "
                          "FedCells/Cube($select=Name)", cube_name)
 
@@ -434,7 +434,7 @@ class CellService(ObjectService):
         :return: fed cell descriptor
         """
 
-        url = format_url("/api/v1/Cubes('{}')/tm1.CheckFeeders"
+        url = format_url("/Cubes('{}')/tm1.CheckFeeders"
                          "?$select=Fed"
                          "&$expand=Tuple($select=Name,UniqueName,Type),Cube($select=Name)", cube_name)
 
@@ -608,7 +608,7 @@ class CellService(ObjectService):
         :param kwargs:
         :return:
         """
-        url = format_url("/api/v1/Cellsets('{}')/tm1.Update", cellset_id)
+        url = format_url("/Cellsets('{}')/tm1.Update", cellset_id)
         url = add_url_parameters(url, **{"!sandbox": sandbox_name})
         return self._rest.POST(url=url, data=json.dumps(payload), **kwargs)
 
@@ -829,7 +829,7 @@ class CellService(ObjectService):
         """
         if not dimensions:
             dimensions = self.get_dimension_names_for_writing(cube_name=cube_name)
-        url = format_url("/api/v1/Cubes('{}')/tm1.Update", cube_name)
+        url = format_url("/Cubes('{}')/tm1.Update", cube_name)
         url = add_url_parameters(url, **{"!sandbox": sandbox_name})
         body_as_dict = OrderedDict()
         body_as_dict["Cells"] = [{}]
@@ -1103,12 +1103,17 @@ class CellService(ObjectService):
     def _build_blob_to_cube_process(self, cube_name: str, process_name: str, blob_filename: str, dimensions: List[str],
                                     increment: bool, skip_non_updateable: bool, sandbox_name: str,
                                     allow_spread: bool) -> Process:
+
+        # v11 automatically adds blb file extensions to documents created via the contents api
+        if not verify_version(required_version="12", version=self.version):
+            blob_filename += ".blb"
+
         dataload_process = Process(
             name=process_name,
             datasource_type='ASCII',
             datasource_ascii_header_records=0,
-            datasource_data_source_name_for_server=f"{blob_filename}.blb",
-            datasource_data_source_name_for_client=f"{blob_filename}.blb",
+            datasource_data_source_name_for_server=f"{blob_filename}",
+            datasource_data_source_name_for_client=f"{blob_filename}",
             datasource_ascii_delimiter_char=',',
             datasource_ascii_decimal_separator='.',
             datasource_ascii_thousand_separator='',
@@ -1217,6 +1222,10 @@ class CellService(ObjectService):
             datasource_ascii_decimal_separator='.',
             datasource_ascii_thousand_separator='')
 
+        # v11 automatically adds blb file extensions to documents created via the contents api
+        if not verify_version(required_version="12", version=self.version):
+            file_name += ".blb"
+
         # Create variables in process data source as all String
         for variable in variables:
             process.add_variable(name=variable, variable_type='String')
@@ -1236,14 +1245,14 @@ class CellService(ObjectService):
         comma_sep_variables = ",".join(sorted(set(variables) - set(skip_variables), key=lambda v: int(v[1:])))
         data_procedure_pre = f"""
         IF (nRecord = 0);
-          SetOutputCharacterSet('{file_name}.blb','TM1CS_UTF8');
+          SetOutputCharacterSet('{file_name}','TM1CS_UTF8');
         ENDIF;
         nRecord = nRecord + 1;
         """
         if header_line:
             data_procedure_pre += f"""
             IF (nRecord = 1);
-              TextOutput('{file_name}.blb',{header_line});
+              TextOutput('{file_name}',{header_line});
             ENDIF;
             """
         if top:
@@ -1262,7 +1271,7 @@ class CellService(ObjectService):
             """
 
         data_procedure = f"""
-        TextOutput('{file_name}.blb',{comma_sep_variables},SVALUE);
+        TextOutput('{file_name}',{comma_sep_variables},SVALUE);
         """
         process.data_procedure = data_procedure_pre + data_procedure
 
@@ -1498,7 +1507,7 @@ class CellService(ObjectService):
         """
         if not dimensions:
             dimensions = self.get_dimension_names_for_writing(cube_name=cube_name, **kwargs)
-        url = format_url("/api/v1/Cubes('{}')/tm1.Update", cube_name)
+        url = format_url("/Cubes('{}')/tm1.Update", cube_name)
         url = add_url_parameters(url, **{"!sandbox": sandbox_name})
         url = add_url_parameters(url, **{"!ChangeSet": changeset})
 
@@ -1577,7 +1586,7 @@ class CellService(ObjectService):
         :return:
         """
 
-        url = format_url("/api/v1/Cellsets('{}')/Cells", cellset_id)
+        url = format_url("/Cellsets('{}')/Cells", cellset_id)
         url = add_url_parameters(url, **{"!sandbox": sandbox_name})
         url = add_url_parameters(url, **{"!ChangeSet": changeset})
         data = []
@@ -2693,7 +2702,7 @@ class CellService(ObjectService):
         # if top_cells is set to N => it will be sufficient to get only the first N tuples in Axes, top_tuples does this
         # if skip_cells is used => trick not applicable, all tuples must be extracted
 
-        url = "/api/v1/Cellsets('{cellset_id}')?$expand=" \
+        url = "/Cellsets('{cellset_id}')?$expand=" \
               "Cube($select=Name;$expand=Dimensions($select=Name))," \
               "Axes({filter_axis}$expand={hierarchies}Tuples($expand=Members({select_member_properties}" \
               "{expand_elem_properties}){top_tuples}))," \
@@ -2821,7 +2830,7 @@ class CellService(ObjectService):
         # if top_cells is set to N => it will be sufficient to get only the first N tuples in Axes, top_tuples does this
         # if skip_cells is used => trick not applicable, all tuples must be extracted
 
-        url = "/api/v1/Cellsets('{cellset_id}')?$expand=" \
+        url = "/Cellsets('{cellset_id}')?$expand=" \
               "Cube($select=Name;$expand=Dimensions($select=Name))," \
               "Axes({filter_axis}$expand={hierarchies}Tuples($expand=Members({select_member_properties}" \
               "{expand_elem_properties}){top_tuples}))" \
@@ -2875,7 +2884,7 @@ class CellService(ObjectService):
 
             filter_cells = " and ".join(filters)
 
-        url = "/api/v1/Cellsets('{cellset_id}')?$expand=" \
+        url = "/Cellsets('{cellset_id}')?$expand=" \
               "Cells($select={cell_properties}{top_cells}{skip_cells}{filter_cells})" \
             .format(cellset_id=cellset_id,
                     cell_properties=",".join(cell_properties),
@@ -2916,7 +2925,7 @@ class CellService(ObjectService):
             filter_cells = " and ".join(filters)
 
         url = format_url(
-            "/api/v1/Cellsets('{}')?$expand=Cells($select=Value{})",
+            "/Cellsets('{}')?$expand=Cells($select=Value{})",
             cellset_id,
             f";$filter={filter_cells}" if filter_cells else "")
         url = add_url_parameters(url, **{"!sandbox": sandbox_name})
@@ -2939,7 +2948,7 @@ class CellService(ObjectService):
         :param sandbox_name: str
         :return:
         """
-        url = "/api/v1/Cellsets('{}')?$expand=" \
+        url = "/Cellsets('{}')?$expand=" \
               "Axes($filter=Ordinal eq 1;$expand=Tuples(" \
               "$expand=Members($select=Element;$expand=Element($select={}))))," \
               "Cells($select=Value)".format(cellset_id, "UniqueName" if element_unique_names else "Name")
@@ -2983,7 +2992,7 @@ class CellService(ObjectService):
         :param sandbox_name: str
         :return:
         """
-        url = "/api/v1/Cellsets('{}')?$expand=" \
+        url = "/Cellsets('{}')?$expand=" \
               "Cube($select=Name)," \
               "Axes($expand=Hierarchies($select=UniqueName))".format(cellset_id)
         url = add_url_parameters(url, **{"!sandbox": sandbox_name})
@@ -3013,7 +3022,7 @@ class CellService(ObjectService):
         :param kwargs:
         :return:
         """
-        url = "/api/v1/Cellsets('{}')/Cells/$count".format(cellset_id)
+        url = "/Cellsets('{}')/Cells/$count".format(cellset_id)
         url = add_url_parameters(url, **{"!sandbox": sandbox_name})
         response = self._rest.GET(url, **kwargs)
         return int(response.content)
@@ -3309,7 +3318,7 @@ class CellService(ObjectService):
         :param infer_dtype: bool, if True, lets pandas infer dtypes, otherwise all columns will be of type str.
 
         """
-        url = "/api/v1/Cellsets('{}')?$expand=" \
+        url = "/Cellsets('{}')?$expand=" \
               "Axes($filter=Ordinal eq 0 or Ordinal eq 1;$expand=Tuples(" \
               "$expand=Members($select=Name{})),Hierarchies($select=Name))," \
               "Cells($select=Value)".format(cellset_id, ',Attributes' if display_attribute else '')
@@ -3476,7 +3485,7 @@ class CellService(ObjectService):
         :param sandbox_name: str
         :return:
         """
-        url = '/api/v1/ExecuteMDX'
+        url = '/ExecuteMDX'
         url = add_url_parameters(url, **{"!sandbox": sandbox_name})
         data = {
             'MDX': mdx.to_mdx() if isinstance(mdx, MdxBuilder) else mdx
@@ -3496,7 +3505,7 @@ class CellService(ObjectService):
         :param sandbox_name: str
         :return:
         """
-        url = format_url("/api/v1/Cubes('{cube_name}')/{views}('{view_name}')/tm1.Execute",
+        url = format_url("/Cubes('{cube_name}')/{views}('{view_name}')/tm1.Execute",
                          cube_name=cube_name,
                          views='PrivateViews' if private else 'Views',
                          view_name=view_name)
@@ -3537,7 +3546,7 @@ class CellService(ObjectService):
         :return: Change set ID
         """
 
-        url = "/api/v1/BeginChangeSet"
+        url = "/BeginChangeSet"
         return self._rest.POST(url).json()['value']
 
     def end_changeset(self, change_set: str) -> Response:
@@ -3546,7 +3555,7 @@ class CellService(ObjectService):
         :return: Change set ID
         """
 
-        url = "/api/v1/EndChangeSet"
+        url = "/EndChangeSet"
         data = {"ChangeSetID": change_set}
         return self._rest.POST(url, data=json.dumps(data, ensure_ascii=False))
 
@@ -3556,7 +3565,7 @@ class CellService(ObjectService):
         :return: Change set ID
         """
 
-        url = "/api/v1/UndoChangeSet"
+        url = "/UndoChangeSet"
         data = {"ChangeSetID": changeset}
         return self._rest.POST(url, data=json.dumps(data, ensure_ascii=False))
 
@@ -3567,7 +3576,7 @@ class CellService(ObjectService):
         :param sandbox_name: str
         :return:
         """
-        url = "/api/v1/Cellsets('{}')".format(cellset_id)
+        url = "/Cellsets('{}')".format(cellset_id)
         url = add_url_parameters(url, **{"!sandbox": sandbox_name})
         return self._rest.DELETE(url, **kwargs)
 

--- a/TM1py/Services/ChoreService.py
+++ b/TM1py/Services/ChoreService.py
@@ -76,7 +76,7 @@ class ChoreService(ObjectService):
         :return: instance of TM1py.Chore
         """
         url = format_url(
-            "/api/v1/Chores('{}')?$expand=Tasks($expand=*,Process($select=Name),Chore($select=Name))",
+            "/Chores('{}')?$expand=Tasks($expand=*,Process($select=Name),Chore($select=Name))",
             chore_name)
         response = self._rest.GET(url, **kwargs)
         return Chore.from_dict(response.json())
@@ -85,7 +85,7 @@ class ChoreService(ObjectService):
         """ get a List of all Chores
         :return: List of TM1py.Chore
         """
-        url = "/api/v1/Chores?$expand=Tasks($expand=*,Process($select=Name),Chore($select=Name))"
+        url = "/Chores?$expand=Tasks($expand=*,Process($select=Name),Chore($select=Name))"
         response = self._rest.GET(url, **kwargs)
         return [Chore.from_dict(chore_as_dict) for chore_as_dict in response.json()['value']]
 
@@ -93,7 +93,7 @@ class ChoreService(ObjectService):
         """ get a List of all Chores
         :return: List of TM1py.Chore
         """
-        url = "/api/v1/Chores?$select=Name"
+        url = "/Chores?$select=Name"
         response = self._rest.GET(url, **kwargs)
         return [chore['Name'] for chore in response.json()['value']]
 
@@ -102,7 +102,7 @@ class ChoreService(ObjectService):
         :param chore: instance of TM1py.Chore
         :return:
         """
-        url = "/api/v1/Chores"
+        url = "/Chores"
         response = self._rest.POST(url=url, data=chore.body, **kwargs)
 
         if chore.dst_sensitivity:
@@ -117,7 +117,7 @@ class ChoreService(ObjectService):
         :param chore_name:
         :return: response
         """
-        url = format_url("/api/v1/Chores('{}')", chore_name)
+        url = format_url("/Chores('{}')", chore_name)
         response = self._rest.DELETE(url, **kwargs)
         return response
 
@@ -127,7 +127,7 @@ class ChoreService(ObjectService):
         :param chore_name:
         :return:
         """
-        url = format_url("/api/v1/Chores('{}')", chore_name)
+        url = format_url("/Chores('{}')", chore_name)
         return self._exists(url, **kwargs)
 
     def search_for_process_name(self, process_name: str, **kwargs) -> List[Chore]:
@@ -136,7 +136,7 @@ class ChoreService(ObjectService):
         :param process_name: string, a valid ti process name; spaces will be elimniated
         """
         url = format_url(
-            "/api/v1/Chores?$filter=Tasks/any(t: replace(tolower(t/Process/Name), ' ', '') eq '{}')"
+            "/Chores?$filter=Tasks/any(t: replace(tolower(t/Process/Name), ' ', '') eq '{}')"
             "&$expand=Tasks($expand=*,Chore($select=Name),Process($select=Name))",
             process_name.lower().replace(' ', '')
         )
@@ -150,7 +150,7 @@ class ChoreService(ObjectService):
         :param parameter_value: string, will search wildcard for string in parameter value using Contains(string)
         """
         url = format_url(
-            "/api/v1/Chores?"
+            "/Chores?"
             "$filter=Tasks/any(t: t/Parameters/any(p: isof(p/Value, Edm.String) and contains(tolower(p/Value), '{}')))"
             "&$expand=Tasks($expand=*,Process($select=Name),Chore($select=Name))",
             parameter_value.lower()
@@ -166,7 +166,7 @@ class ChoreService(ObjectService):
         :return:
         """
         # Update StartTime, ExecutionMode, Frequency
-        url = format_url("/api/v1/Chores('{}')", chore.name)
+        url = format_url("/Chores('{}')", chore.name)
         # Remove Tasks from Body. Tasks to be managed individually
         chore_dict_without_tasks = chore.body_as_dict
         chore_dict_without_tasks.pop("Tasks")
@@ -198,7 +198,7 @@ class ChoreService(ObjectService):
         :param chore_name:
         :return: response
         """
-        url = format_url("/api/v1/Chores('{}')/tm1.Activate", chore_name)
+        url = format_url("/Chores('{}')/tm1.Activate", chore_name)
         return self._rest.POST(url, '', **kwargs)
 
     def deactivate(self, chore_name: str, **kwargs) -> Response:
@@ -206,7 +206,7 @@ class ChoreService(ObjectService):
         :param chore_name:
         :return: response
         """
-        url = format_url("/api/v1/Chores('{}')/tm1.Deactivate", chore_name)
+        url = format_url("/Chores('{}')/tm1.Deactivate", chore_name)
         return self._rest.POST(url, '', **kwargs)
 
     @deactivate_activate
@@ -216,7 +216,7 @@ class ChoreService(ObjectService):
         :param date_time:
         :return:
         """
-        url = format_url("/api/v1/Chores('{}')/tm1.SetServerLocalStartTime", chore_name)
+        url = format_url("/Chores('{}')/tm1.SetServerLocalStartTime", chore_name)
         data = {
             "StartDate": "{}-{}-{}".format(
                 date_time.year, date_time.month, date_time.day),
@@ -230,14 +230,14 @@ class ChoreService(ObjectService):
             :param chore_name: String, name of the chore to be executed
             :return: the response
         """
-        return self._rest.POST(format_url("/api/v1/Chores('{}')/tm1.Execute", chore_name), '', **kwargs)
+        return self._rest.POST(format_url("/Chores('{}')/tm1.Execute", chore_name), '', **kwargs)
 
     def _get_tasks_count(self, chore_name: str, **kwargs) -> int:
         """ Query Chore tasks count on TM1 Server
         :param chore_name: name of Chore to count tasks
         :return: int
         """
-        url = format_url("/api/v1/Chores('{}')/Tasks/$count", chore_name)
+        url = format_url("/Chores('{}')/Tasks/$count", chore_name)
         response = self._rest.GET(url, **kwargs)
         return int(response.text)
 
@@ -248,7 +248,7 @@ class ChoreService(ObjectService):
         :return: instance of TM1py.ChoreTask
         """
         url = format_url(
-            "/api/v1/Chores('{}')/Tasks({})?$expand=*,Process($select=Name),Chore($select=Name)", chore_name, str(step))
+            "/Chores('{}')/Tasks({})?$expand=*,Process($select=Name),Chore($select=Name)", chore_name, str(step))
         response = self._rest.GET(url, **kwargs)
         return ChoreTask.from_dict(response.json())
 
@@ -258,7 +258,7 @@ class ChoreService(ObjectService):
         :param step: integer
         :return: response
         """
-        url = format_url("/api/v1/Chores('{}')/Tasks({})", chore_name, str(step))
+        url = format_url("/Chores('{}')/Tasks({})", chore_name, str(step))
         response = self._rest.DELETE(url, **kwargs)
         return response
 
@@ -272,7 +272,7 @@ class ChoreService(ObjectService):
         if chore.active:
             self.deactivate(chore_name, **kwargs)
         try:
-            url = format_url("/api/v1/Chores('{}')/Tasks", chore_name)
+            url = format_url("/Chores('{}')/Tasks", chore_name)
             response = self._rest.POST(url, chore_task.body, **kwargs)
         except Exception as e:
             raise e
@@ -287,7 +287,7 @@ class ChoreService(ObjectService):
         :param chore_task: instance TM1py.ChoreTask
         :return: response
         """
-        url = format_url("/api/v1/Chores('{}')/Tasks({})", chore_name, str(chore_task.step))
+        url = format_url("/Chores('{}')/Tasks({})", chore_name, str(chore_task.step))
         return self._rest.PATCH(url, chore_task.body, **kwargs)
 
     @staticmethod

--- a/TM1py/Services/CubeService.py
+++ b/TM1py/Services/CubeService.py
@@ -32,7 +32,7 @@ class CubeService(ObjectService):
         :param cube: instance of TM1py.Cube
         :return: response
         """
-        url = "/api/v1/Cubes"
+        url = "/Cubes"
         return self._rest.POST(url=url, data=cube.body, **kwargs)
 
     def get(self, cube_name: str, **kwargs) -> Cube:
@@ -41,7 +41,7 @@ class CubeService(ObjectService):
         :param cube_name:
         :return: instance of TM1py.Cube
         """
-        url = format_url("/api/v1/Cubes('{}')?$expand=Dimensions($select=Name)", cube_name)
+        url = format_url("/Cubes('{}')?$expand=Dimensions($select=Name)", cube_name)
         response = self._rest.GET(url=url, **kwargs)
         cube = Cube.from_json(response.text)
         # cater for potential EnableSandboxDimension=T setup
@@ -50,7 +50,7 @@ class CubeService(ObjectService):
         return cube
 
     def get_last_data_update(self, cube_name: str, **kwargs) -> str:
-        url = format_url("/api/v1/Cubes('{}')/LastDataUpdate/$value", cube_name)
+        url = format_url("/Cubes('{}')/LastDataUpdate/$value", cube_name)
         response = self._rest.GET(url=url, **kwargs)
         return response.text
 
@@ -59,7 +59,7 @@ class CubeService(ObjectService):
 
         :return: List of TM1py.Cube instances
         """
-        url = "/api/v1/Cubes?$expand=Dimensions($select=Name)"
+        url = "/Cubes?$expand=Dimensions($select=Name)"
         response = self._rest.GET(url, **kwargs)
         cubes = [Cube.from_dict(cube_as_dict=cube) for cube in response.json()['value']]
         return cubes
@@ -69,7 +69,7 @@ class CubeService(ObjectService):
 
         :return: List of TM1py.Cube instances
         """
-        url = "/api/v1/ModelCubes()?$expand=Dimensions($select=Name)"
+        url = "/ModelCubes()?$expand=Dimensions($select=Name)"
         response = self._rest.GET(url, **kwargs)
         cubes = [Cube.from_dict(cube_as_dict=cube) for cube in response.json()['value']]
         return cubes
@@ -79,7 +79,7 @@ class CubeService(ObjectService):
 
         :return: List of TM1py.Cube instances
         """
-        url = "/api/v1/ControlCubes()?$expand=Dimensions($select=Name)"
+        url = "/ControlCubes()?$expand=Dimensions($select=Name)"
         response = self._rest.GET(url, **kwargs)
         cubes = [Cube.from_dict(cube_as_dict=cube) for cube in response.json()['value']]
         return cubes
@@ -91,14 +91,14 @@ class CubeService(ObjectService):
         :return: int, count
         """
         if skip_control_cubes:
-            response = self._rest.GET(url=format_url("/api/v1/ModelCubes()?$select=Name&$top=0&$count"), **kwargs)
+            response = self._rest.GET(url=format_url("/ModelCubes()?$select=Name&$top=0&$count"), **kwargs)
             return int(response.json()['@odata.count'])
 
-        return int(self._rest.GET(url=format_url("/api/v1/Cubes/$count"), **kwargs).text)
+        return int(self._rest.GET(url=format_url("/Cubes/$count"), **kwargs).text)
 
     def get_measure_dimension(self, cube_name: str, **kwargs) -> str:
         url = format_url(
-            "/api/v1/Cubes('{}')/Dimensions?$select=Name",
+            "/Cubes('{}')/Dimensions?$select=Name",
             cube_name)
         response = self._rest.GET(url, **kwargs)
         return response.json()['value'][-1]['Name']
@@ -109,7 +109,7 @@ class CubeService(ObjectService):
         :param cube: instance of TM1py.Cube
         :return: response
         """
-        url = format_url("/api/v1/Cubes('{}')", cube.name)
+        url = format_url("/Cubes('{}')", cube.name)
         return self._rest.PATCH(url, cube.body, **kwargs)
 
     def update_or_create(self, cube: Cube, **kwargs) -> Response:
@@ -129,7 +129,7 @@ class CubeService(ObjectService):
         :param cube_name: name of a cube
         :return: response
         """
-        url = format_url("/api/v1/Cubes('{}')/tm1.CheckRules", cube_name)
+        url = format_url("/Cubes('{}')/tm1.CheckRules", cube_name)
 
         response = self._rest.POST(url, **kwargs)
         errors = response.json()["value"]
@@ -142,7 +142,7 @@ class CubeService(ObjectService):
         :param cube_name:
         :return: response
         """
-        url = format_url("/api/v1/Cubes('{}')", cube_name)
+        url = format_url("/Cubes('{}')", cube_name)
         return self._rest.DELETE(url, **kwargs)
 
     def exists(self, cube_name: str, **kwargs) -> bool:
@@ -151,7 +151,7 @@ class CubeService(ObjectService):
         :param cube_name: 
         :return: Boolean 
         """
-        url = format_url("/api/v1/Cubes('{}')", cube_name)
+        url = format_url("/Cubes('{}')", cube_name)
         return self._exists(url, **kwargs)
 
     def get_all_names(self, skip_control_cubes: bool = False, **kwargs) -> List[str]:
@@ -161,7 +161,7 @@ class CubeService(ObjectService):
         :return: List of Strings
         """
         url = format_url(
-            "/api/v1/{}?$select=Name",
+            "/{}?$select=Name",
             'ModelCubes()' if skip_control_cubes else 'Cubes'
         )
 
@@ -176,7 +176,7 @@ class CubeService(ObjectService):
         :return: List of Strings
         """
         url = format_url(
-            "/api/v1/{}?$select=Name,Rules&$filter=Rules ne null",
+            "/{}?$select=Name,Rules&$filter=Rules ne null",
             'ModelCubes()' if skip_control_cubes else 'Cubes'
         )
 
@@ -191,7 +191,7 @@ class CubeService(ObjectService):
         """
 
         url = format_url(
-            "/api/v1/{}?$select=Name,Rules&$filter=Rules eq null",
+            "/{}?$select=Name,Rules&$filter=Rules eq null",
             'ModelCubes()' if skip_control_cubes else 'Cubes'
         )
 
@@ -206,7 +206,7 @@ class CubeService(ObjectService):
         :param skip_sandbox_dimension:
         :return:  List : [dim1, dim2, dim3, etc.]
         """
-        url = format_url("/api/v1/Cubes('{}')/Dimensions?$select=Name", cube_name)
+        url = format_url("/Cubes('{}')/Dimensions?$select=Name", cube_name)
         response = self._rest.GET(url, **kwargs)
         dimension_names = [element['Name'] for element in response.json()['value']]
         if skip_sandbox_dimension and dimension_names[0] == CellService.SANDBOX_DIMENSION:
@@ -221,7 +221,7 @@ class CubeService(ObjectService):
         :param skip_control_cubes: bool, True will exclude control cubes from result
         """
         url = format_url(
-            "/api/v1/{}?$select=Name&$filter=Dimensions/any(d: replace(tolower(d/Name), ' ', '') eq '{}')",
+            "/{}?$select=Name&$filter=Dimensions/any(d: replace(tolower(d/Name), ' ', '') eq '{}')",
             'ModelCubes()' if skip_control_cubes else 'Cubes',
             dimension_name.lower().replace(' ', '')
         )
@@ -239,7 +239,7 @@ class CubeService(ObjectService):
         substring = substring.lower().replace(' ', '')
 
         url = format_url(
-            "/api/v1/{}?$select=Name&$filter=Dimensions/any(d: contains(replace(tolower(d/Name), ' ', ''),'{}'))" +
+            "/{}?$select=Name&$filter=Dimensions/any(d: contains(replace(tolower(d/Name), ' ', ''),'{}'))" +
             "&$expand=Dimensions($select=Name;$filter=contains(replace(tolower(Name), ' ', ''), '{}'))",
             'ModelCubes()' if skip_control_cubes else 'Cubes',
             substring,
@@ -271,7 +271,7 @@ class CubeService(ObjectService):
         else:
             url_filter += format_url("Rules,'{}')", substring)
 
-        url = f"/api/v1/{'ModelCubes()' if skip_control_cubes else 'Cubes'}?$filter={url_filter}" \
+        url = f"/{'ModelCubes()' if skip_control_cubes else 'Cubes'}?$filter={url_filter}" \
               f"&$expand=Dimensions($select=Name)"
 
         response = self._rest.GET(url, **kwargs)
@@ -285,7 +285,7 @@ class CubeService(ObjectService):
         :param cube_name:
         :return: List of dimension names
         """
-        url = format_url("/api/v1/Cubes('{}')/tm1.DimensionsStorageOrder()?$select=Name", cube_name)
+        url = format_url("/Cubes('{}')/tm1.DimensionsStorageOrder()?$select=Name", cube_name)
         response = self._rest.GET(url, **kwargs)
         return [dimension["Name"] for dimension in response.json()["value"]]
 
@@ -298,7 +298,7 @@ class CubeService(ObjectService):
         :param dimension_names:
         :return:  Float: -23.076489699337078 (percent change in memory usage)
         """
-        url = format_url("/api/v1/Cubes('{}')/tm1.ReorderDimensions", cube_name)
+        url = format_url("/Cubes('{}')/tm1.ReorderDimensions", cube_name)
         payload = dict()
         payload['Dimensions@odata.bind'] = [format_url("Dimensions('{}')", dimension)
                                             for dimension
@@ -314,7 +314,7 @@ class CubeService(ObjectService):
         :param cube_name:
         :return:
         """
-        url = format_url("/api/v1/Cubes('{}')/tm1.Load", cube_name)
+        url = format_url("/Cubes('{}')/tm1.Load", cube_name)
         return self._rest.POST(url=url, **kwargs)
 
     @require_admin
@@ -325,7 +325,7 @@ class CubeService(ObjectService):
         :param cube_name:
         :return:
         """
-        url = format_url("/api/v1/Cubes('{}')/tm1.Unload", cube_name)
+        url = format_url("/Cubes('{}')/tm1.Unload", cube_name)
         return self._rest.POST(url=url, **kwargs)
 
     def lock(self, cube_name: str, **kwargs) -> Response:
@@ -334,7 +334,7 @@ class CubeService(ObjectService):
         :param cube_name:
         :return:
         """
-        url = format_url("/api/v1/Cubes('{}')/tm1.Lock", cube_name)
+        url = format_url("/Cubes('{}')/tm1.Lock", cube_name)
         return self._rest.POST(url=url, **kwargs)
 
     def unlock(self, cube_name: str, **kwargs) -> Response:
@@ -343,7 +343,7 @@ class CubeService(ObjectService):
         :param cube_name:
         :return:
         """
-        url = format_url("/api/v1/Cubes('{}')/tm1.Unlock", cube_name)
+        url = format_url("/Cubes('{}')/tm1.Unlock", cube_name)
         return self._rest.POST(url=url, **kwargs)
 
     @require_admin

--- a/TM1py/Services/DimensionService.py
+++ b/TM1py/Services/DimensionService.py
@@ -37,7 +37,7 @@ class DimensionService(ObjectService):
         # If not all subsequent calls successful -> undo everything that has been done in this function
         try:
             # Create Dimension, Hierarchies, Elements, Edges.
-            url = "/api/v1/Dimensions"
+            url = "/Dimensions"
             response = self._rest.POST(url, dimension.body, **kwargs)
             # Create ElementAttributes
             for hierarchy in dimension:
@@ -56,7 +56,7 @@ class DimensionService(ObjectService):
         :param dimension_name:
         :return:
         """
-        url = format_url("/api/v1/Dimensions('{}')?$expand=Hierarchies($expand=*)", dimension_name)
+        url = format_url("/Dimensions('{}')?$expand=Hierarchies($expand=*)", dimension_name)
         response = self._rest.GET(url, **kwargs)
         return Dimension.from_json(response.text)
 
@@ -118,7 +118,7 @@ class DimensionService(ObjectService):
         :param dimension_name: Name of the dimension
         :return:
         """
-        url = format_url("/api/v1/Dimensions('{}')", dimension_name)
+        url = format_url("/Dimensions('{}')", dimension_name)
         return self._rest.DELETE(url, **kwargs)
 
     def exists(self, dimension_name: str, **kwargs) -> bool:
@@ -126,7 +126,7 @@ class DimensionService(ObjectService):
         
         :return: 
         """
-        url = format_url("/api/v1/Dimensions('{}')", dimension_name)
+        url = format_url("/Dimensions('{}')", dimension_name)
         return self._exists(url, **kwargs)
 
     def get_all_names(self, skip_control_dims: bool = False, **kwargs) -> List[str]:
@@ -137,7 +137,7 @@ class DimensionService(ObjectService):
             List of Strings
         """
         url = format_url(
-            "/api/v1/{}?$select=Name",
+            "/{}?$select=Name",
             'ModelDimensions()' if skip_control_dims else 'Dimensions'
         )
 
@@ -154,10 +154,10 @@ class DimensionService(ObjectService):
         """
 
         if skip_control_dims:
-            response = self._rest.GET("/api/v1/ModelDimensions()?$select=Name&$top=0&$count", **kwargs)
+            response = self._rest.GET("/ModelDimensions()?$select=Name&$top=0&$count", **kwargs)
             return response.json()['@odata.count']
 
-        return int(self._rest.GET("/api/v1/Dimensions/$count", **kwargs).text)
+        return int(self._rest.GET("/Dimensions/$count", **kwargs).text)
 
     def execute_mdx(self, dimension_name: str, mdx: str, **kwargs) -> List:
         """ Execute MDX against Dimension. 
@@ -176,7 +176,7 @@ class DimensionService(ObjectService):
                        "{{ [}}ElementAttributes_{}].DefaultMember }} ON COLUMNS  " \
                        "FROM [}}ElementAttributes_{}]"
         mdx_full = mdx_skeleton.format(mdx, dimension_name, dimension_name)
-        request = '/api/v1/ExecuteMDX?$expand=Axes(' \
+        request = '/ExecuteMDX?$expand=Axes(' \
                   '$filter=Ordinal eq 1;' \
                   '$expand=Tuples($expand=Members($select=Ordinal;$expand=Element($select=Name))))'
         payload = {"MDX": mdx_full}

--- a/TM1py/Services/ElementService.py
+++ b/TM1py/Services/ElementService.py
@@ -37,21 +37,21 @@ class ElementService(ObjectService):
 
     def get(self, dimension_name: str, hierarchy_name: str, element_name: str, **kwargs) -> Element:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements('{}')?$expand=*",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements('{}')?$expand=*",
             dimension_name, hierarchy_name, element_name)
         response = self._rest.GET(url, **kwargs)
         return Element.from_dict(response.json())
 
     def create(self, dimension_name: str, hierarchy_name: str, element: Element, **kwargs) -> Response:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements",
             dimension_name,
             hierarchy_name)
         return self._rest.POST(url, element.body, **kwargs)
 
     def update(self, dimension_name: str, hierarchy_name: str, element: Element, **kwargs) -> Response:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements('{}')",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements('{}')",
             dimension_name,
             hierarchy_name,
             element.name)
@@ -59,7 +59,7 @@ class ElementService(ObjectService):
 
     def exists(self, dimension_name: str, hierarchy_name: str, element_name: str, **kwargs) -> bool:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements('{}')",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements('{}')",
             dimension_name,
             hierarchy_name,
             element_name)
@@ -67,7 +67,7 @@ class ElementService(ObjectService):
 
     def delete(self, dimension_name: str, hierarchy_name: str, element_name: str, **kwargs) -> Response:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements('{}')",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements('{}')",
             dimension_name,
             hierarchy_name,
             element_name)
@@ -75,7 +75,7 @@ class ElementService(ObjectService):
 
     def get_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[Element]:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?select=Name,Type",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?select=Name,Type",
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
@@ -247,7 +247,7 @@ class ElementService(ObjectService):
 
     def get_edges(self, dimension_name: str, hierarchy_name: str, **kwargs) -> Dict[Tuple[str, str], int]:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Edges?select=ParentName,ComponentName,Weight",
+            "/Dimensions('{}')/Hierarchies('{}')/Edges?select=ParentName,ComponentName,Weight",
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
@@ -256,14 +256,14 @@ class ElementService(ObjectService):
 
     def get_leaf_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[Element]:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type ne 3",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type ne 3",
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
         return [Element.from_dict(element) for element in response.json()["value"]]
 
     def get_leaf_element_names(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[str]:
-        url = format_url("/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type ne 3",
+        url = format_url("/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type ne 3",
                          dimension_name,
                          hierarchy_name)
         response = self._rest.GET(url, **kwargs)
@@ -271,14 +271,14 @@ class ElementService(ObjectService):
 
     def get_consolidated_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[Element]:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type eq 3",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type eq 3",
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
         return [Element.from_dict(element) for element in response.json()["value"]]
 
     def get_consolidated_element_names(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[str]:
-        url = format_url("/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type eq 3",
+        url = format_url("/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type eq 3",
                          dimension_name,
                          hierarchy_name)
         response = self._rest.GET(url, **kwargs)
@@ -286,14 +286,14 @@ class ElementService(ObjectService):
 
     def get_numeric_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[Element]:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type eq 1",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type eq 1",
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
         return [Element.from_dict(element) for element in response.json()["value"]]
 
     def get_numeric_element_names(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[str]:
-        url = format_url("/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type eq 1",
+        url = format_url("/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type eq 1",
                          dimension_name,
                          hierarchy_name)
         response = self._rest.GET(url, **kwargs)
@@ -301,14 +301,14 @@ class ElementService(ObjectService):
 
     def get_string_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[Element]:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type eq 2",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type eq 2",
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
         return [Element.from_dict(element) for element in response.json()["value"]]
 
     def get_string_element_names(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[str]:
-        url = format_url("/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type eq 2",
+        url = format_url("/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type eq 2",
                          dimension_name,
                          hierarchy_name)
         response = self._rest.GET(url, **kwargs)
@@ -322,7 +322,7 @@ class ElementService(ObjectService):
         :return: Generator of element-names
         """
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name",
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
@@ -330,7 +330,7 @@ class ElementService(ObjectService):
 
     def get_number_of_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> int:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements/$count",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements/$count",
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
@@ -338,7 +338,7 @@ class ElementService(ObjectService):
 
     def get_number_of_consolidated_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> int:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements/$count?$filter=Type eq 3",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements/$count?$filter=Type eq 3",
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
@@ -346,7 +346,7 @@ class ElementService(ObjectService):
 
     def get_number_of_leaf_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> int:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements/$count?$filter=Type ne 3",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements/$count?$filter=Type ne 3",
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
@@ -354,7 +354,7 @@ class ElementService(ObjectService):
 
     def get_number_of_numeric_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> int:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements/$count?$filter=Type eq 1",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements/$count?$filter=Type eq 1",
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
@@ -362,7 +362,7 @@ class ElementService(ObjectService):
 
     def get_number_of_string_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> int:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements/$count?$filter=Type eq 2",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements/$count?$filter=Type eq 2",
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
@@ -388,7 +388,7 @@ class ElementService(ObjectService):
         :return: List of element names
         """
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Level eq {}",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Level eq {}",
             dimension_name,
             hierarchy_name,
             str(level))
@@ -409,7 +409,7 @@ class ElementService(ObjectService):
         if level is not None:
             filter_elements = filter_elements + f" and Level eq {level}"
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=" + filter_elements,
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=" + filter_elements,
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
@@ -523,7 +523,7 @@ class ElementService(ObjectService):
 
     def get_level_names(self, dimension_name: str, hierarchy_name: str, descending: bool = True, **kwargs) -> List[str]:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Levels?$select=Name",
+            "/Dimensions('{}')/Hierarchies('{}')/Levels?$select=Name",
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
@@ -533,14 +533,14 @@ class ElementService(ObjectService):
             return [level["Name"] for level in response.json()["value"]]
 
     def get_levels_count(self, dimension_name: str, hierarchy_name: str, **kwargs) -> int:
-        url = format_url("/api/v1/Dimensions('{}')/Hierarchies('{}')/Levels/$count", dimension_name, hierarchy_name)
+        url = format_url("/Dimensions('{}')/Hierarchies('{}')/Levels/$count", dimension_name, hierarchy_name)
         response = self._rest.GET(url, **kwargs)
         return int(response.text)
 
     def get_element_types(self, dimension_name: str, hierarchy_name: str,
                           skip_consolidations: bool = False, **kwargs) -> CaseAndSpaceInsensitiveDict:
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name,Type",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name,Type",
             dimension_name,
             hierarchy_name)
         if skip_consolidations:
@@ -555,7 +555,7 @@ class ElementService(ObjectService):
     def get_element_types_from_all_hierarchies(
             self, dimension_name: str, skip_consolidations: bool = False, **kwargs) -> CaseAndSpaceInsensitiveDict:
         url = format_url(
-            "/api/v1/Dimensions('{}')?$expand=Hierarchies($select=Elements;$expand=Elements($select=Name,Type",
+            "/Dimensions('{}')?$expand=Hierarchies($select=Elements;$expand=Elements($select=Name,Type",
             dimension_name)
         url += ";$filter=Type ne 3))" if skip_consolidations else "))"
         response = self._rest.GET(url, **kwargs)
@@ -567,7 +567,7 @@ class ElementService(ObjectService):
         return result
 
     def attribute_cube_exists(self, dimension_name: str, **kwargs) -> bool:
-        url = format_url("/api/v1/Cubes('{}')", self.ELEMENT_ATTRIBUTES_PREFIX + dimension_name)
+        url = format_url("/Cubes('{}')", self.ELEMENT_ATTRIBUTES_PREFIX + dimension_name)
         return self._exists(url, **kwargs)
 
     def _retrieve_mdx_rows_and_cell_values_as_string_set(self, mdx: str, exclude_empty_cells=True, **kwargs):
@@ -598,7 +598,7 @@ class ElementService(ObjectService):
         :return:
         """
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/ElementAttributes",
+            "/Dimensions('{}')/Hierarchies('{}')/ElementAttributes",
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
@@ -613,7 +613,7 @@ class ElementService(ObjectService):
         :return:
         """
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/ElementAttributes?$select=Name",
+            "/Dimensions('{}')/Hierarchies('{}')/ElementAttributes?$select=Name",
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
@@ -660,7 +660,7 @@ class ElementService(ObjectService):
         :return:
         """
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/ElementAttributes",
+            "/Dimensions('{}')/Hierarchies('{}')/ElementAttributes",
             dimension_name,
             hierarchy_name)
         return self._rest.POST(url, element_attribute.body, **kwargs)
@@ -675,7 +675,7 @@ class ElementService(ObjectService):
         :return:
         """
         url = format_url(
-            "/api/v1/Dimensions('}}ElementAttributes_{}')/Hierarchies('}}ElementAttributes_{}')/Elements('{}')",
+            "/Dimensions('}}ElementAttributes_{}')/Hierarchies('}}ElementAttributes_{}')/Elements('{}')",
             dimension_name,
             hierarchy_name,
             element_attribute)
@@ -716,7 +716,7 @@ class ElementService(ObjectService):
         edges = CaseAndSpaceInsensitiveTuplesDict()
 
         # build url
-        bare_url = "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements('{}')?"
+        bare_url = "/Dimensions('{}')/Hierarchies('{}')/Elements('{}')?"
         url = format_url(bare_url, dimension_name, hierarchy_name, consolidation)
         for d in range(depth):
             if d == 0:
@@ -757,7 +757,7 @@ class ElementService(ObjectService):
         # members to return
         members = []
         # build url
-        bare_url = "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements('{}')?$select=Name,Type&$expand=Components("
+        bare_url = "/Dimensions('{}')/Hierarchies('{}')/Elements('{}')?$select=Name,Type&$expand=Components("
         url = format_url(bare_url, dimension_name, hierarchy_name, consolidation)
         for _ in range(depth):
             url += "$select=Name,Type;$expand=Components("
@@ -844,7 +844,7 @@ class ElementService(ObjectService):
         else:
             expand_properties = ""
 
-        url = f'/api/v1/ExecuteMDXSetExpression?$expand=Tuples({top}' \
+        url = f'/ExecuteMDXSetExpression?$expand=Tuples({top}' \
               f'$expand=Members({select_member_properties}' \
               f'{expand_properties}))'
 
@@ -864,7 +864,7 @@ class ElementService(ObjectService):
         """
 
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements('{}')/Edges(ParentName='{}',ComponentName='{}')",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements('{}')/Edges(ParentName='{}',ComponentName='{}')",
             dimension_name,
             hierarchy_name,
             parent,
@@ -885,7 +885,7 @@ class ElementService(ObjectService):
         if not hierarchy_name:
             hierarchy_name = dimension_name
 
-        url = format_url("/api/v1/Dimensions('{}')/Hierarchies('{}')/Edges", dimension_name, hierarchy_name)
+        url = format_url("/Dimensions('{}')/Hierarchies('{}')/Edges", dimension_name, hierarchy_name)
         body = [{"ParentName": parent, "ComponentName": component, "Weight": float(weight)}
                 for (parent, component), weight
                 in edges.items()]
@@ -900,7 +900,7 @@ class ElementService(ObjectService):
         :param elements:
         :return:
         """
-        url = format_url("/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements", dimension_name, hierarchy_name)
+        url = format_url("/Dimensions('{}')/Hierarchies('{}')/Elements", dimension_name, hierarchy_name)
         body = [element.body_as_dict for element in elements]
 
         return self._rest.POST(url=url, data=json.dumps(body), **kwargs)
@@ -914,14 +914,14 @@ class ElementService(ObjectService):
         :param element_attributes:
         :return:
         """
-        url = format_url("/api/v1/Dimensions('{}')/Hierarchies('{}')/ElementAttributes", dimension_name, hierarchy_name)
+        url = format_url("/Dimensions('{}')/Hierarchies('{}')/ElementAttributes", dimension_name, hierarchy_name)
         body = [element_attribute.body_as_dict for element_attribute in element_attributes]
 
         return self._rest.POST(url=url, data=json.dumps(body), **kwargs)
 
     def get_parents(self, dimension_name: str, hierarchy_name: str, element_name: str, **kwargs) -> List[str]:
         url = format_url(
-            "/api/v1/Dimensions('{dimension_name}')/Hierarchies('{hierarchy_name}')/Elements('{element_name}')/Parents"
+            "/Dimensions('{dimension_name}')/Hierarchies('{hierarchy_name}')/Elements('{element_name}')/Parents"
             f"?$select=Name",
             dimension_name=dimension_name,
             hierarchy_name=hierarchy_name,
@@ -933,7 +933,7 @@ class ElementService(ObjectService):
 
     def get_parents_of_all_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> Dict[str, List[str]]:
         url = format_url(
-            f"/api/v1/Dimensions('{dimension_name}')/Hierarchies('{hierarchy_name}')/Elements?$select=Name"
+            f"/Dimensions('{dimension_name}')/Hierarchies('{hierarchy_name}')/Elements?$select=Name"
             f"&$expand=Parents($select=Name)",
         )
         response = self._rest.GET(url=url, **kwargs)
@@ -945,7 +945,7 @@ class ElementService(ObjectService):
         return element.name
 
     def _get_mdx_set_cardinality(self, mdx: str) -> int:
-        url = format_url("/api/v1/ExecuteMDXSetExpression?$select=Cardinality")
+        url = format_url("/ExecuteMDXSetExpression?$select=Cardinality")
         payload = {"MDX": mdx}
         response = self._rest.POST(url, json.dumps(payload, ensure_ascii=False))
         return response.json()['Cardinality']

--- a/TM1py/Services/FileService.py
+++ b/TM1py/Services/FileService.py
@@ -4,6 +4,7 @@ import json
 from TM1py.Services import RestService
 from TM1py.Services.ObjectService import ObjectService
 from TM1py.Utils import format_url
+from TM1py.Utils.Utils import verify_version
 
 
 class FileService(ObjectService):
@@ -15,16 +16,33 @@ class FileService(ObjectService):
         """
         super().__init__(tm1_rest)
         self._rest = tm1_rest
+        if verify_version(required_version="12", version=self.version):
+            self.version_content_path = 'Files'
+        else:
+            self.version_content_path = 'Blobs'
+
+    def get_names(self, **kwargs) -> bytes:
+
+        url = format_url(
+            "/Contents('{version_content_path}')/Contents?$select=Name",
+            version_content_path=self.version_content_path)
+
+        return self._rest.GET(url, **kwargs).content
+
 
     def get(self, file_name: str, **kwargs) -> bytes:
+
         url = format_url(
-            "/api/v1/Contents('Blobs')/Contents('{name}')/Content",
-            name=file_name)
+            "/Contents('{version_content_path}')/Contents('{name}')/Content",
+            name=file_name,
+            version_content_path=self.version_content_path)
 
         return self._rest.GET(url, **kwargs).content
 
     def create(self, file_name: str, file_content: bytes, **kwargs):
-        url = "/api/v1/Contents('Blobs')/Contents"
+        url = format_url(
+            "/Contents('{version_content_path}')/Contents",
+            version_content_path=self.version_content_path)
         body = {
             "@odata.type": "#ibm.tm1.api.v1.Document",
             "ID": file_name,
@@ -33,15 +51,17 @@ class FileService(ObjectService):
         self._rest.POST(url, json.dumps(body), **kwargs)
 
         url = format_url(
-            "/api/v1/Contents('Blobs')/Contents('{name}')/Content",
-            name=file_name)
+            "/Contents('{version_content_path}')/Contents('{name}')/Content",
+            name=file_name,
+            version_content_path=self.version_content_path)
 
         return self._rest.PUT(url, file_content, headers=self.BINARY_HTTP_HEADER, **kwargs)
 
     def update(self, file_name: str, file_content: bytes, **kwargs):
         url = format_url(
-            "/api/v1/Contents('Blobs')/Contents('{name}')/Content",
-            name=file_name)
+            "/Contents('{version_content_path}')/Contents('{name}')/Content",
+            name=file_name,
+            version_content_path=self.version_content_path)
 
         return self._rest.PUT(url, file_content, headers=self.BINARY_HTTP_HEADER, **kwargs)
 
@@ -53,14 +73,16 @@ class FileService(ObjectService):
 
     def exists(self, file_name: str, **kwargs):
         url = format_url(
-            "/api/v1/Contents('Blobs')/Contents('{name}')",
-            name=file_name)
+            "/Contents('{version_content_path}')/Contents('{name}')",
+            name=file_name,
+            version_content_path=self.version_content_path)
 
         return self._exists(url, **kwargs)
 
     def delete(self, file_name: str, **kwargs):
         url = format_url(
-            "/api/v1/Contents('Blobs')/Contents('{name}')",
-            name=file_name)
+            "/Contents('{version_content_path}')/Contents('{name}')",
+            name=file_name,
+            version_content_path=self.version_content_path)
 
         return self._rest.DELETE(url, **kwargs)

--- a/TM1py/Services/GitService.py
+++ b/TM1py/Services/GitService.py
@@ -25,7 +25,7 @@ class GitService(ObjectService):
     def tm1project_get(self) -> TM1Project:
         """_summary_
         """
-        url = '/api/v1/!tm1project'
+        url = '/!tm1project'
         response = self._rest.GET(url)
         if not response.content:
             return None
@@ -33,7 +33,7 @@ class GitService(ObjectService):
         return TM1Project.from_dict(response.json())
     
     def tm1project_delete(self):
-        url = '/api/v1/!tm1project'
+        url = '/!tm1project'
         empty_dict = {}
         body_json = json.dumps(empty_dict)
         
@@ -41,7 +41,7 @@ class GitService(ObjectService):
         return TM1Project.from_dict(response.json())
         
     def tm1project_put(self, tm1_project: TM1Project) -> TM1Project:
-        url = '/api/v1/!tm1project'
+        url = '/!tm1project'
         body_json = tm1_project.body
 
         # we need to ensure that async_requests_mode=False for this specific request as the response will not include
@@ -63,7 +63,7 @@ class GitService(ObjectService):
         :param force: reset git context on True
         :param config: Dictionary containing git configuration parameters
         """
-        url = "/api/v1/GitInit"
+        url = "/GitInit"
         body = {'URL': git_url, 'Deployment': deployment}
 
         for key, value in locals().items():
@@ -80,7 +80,7 @@ class GitService(ObjectService):
 
         :param force: clean up git context when True
         """
-        url = "/api/v1/GitUninit"
+        url = "/GitUninit"
         body = json.dumps(force)
         return self._rest.POST(url=url, data=body, **kwargs)
 
@@ -93,7 +93,7 @@ class GitService(ObjectService):
         :param private_key: SSH private key, available from PAA V2.0.9.4
         :param passphrase: Passphrase for decrypting private key, if set
         """
-        url = "/api/v1/GitStatus"
+        url = "/GitStatus"
         body = {}
 
         for key, value in locals().items():
@@ -124,7 +124,7 @@ class GitService(ObjectService):
         :param execute: Executes the plan right away if True
 
         """
-        url = "/api/v1/GitPush"
+        url = "/GitPush"
         body = {}
 
         for key, value in locals().items():
@@ -152,7 +152,7 @@ class GitService(ObjectService):
         :param private_key: SSH private key, available from PAA V2.0.9.4
         :param passphrase: Passphrase for decrypting private key, if set
         """
-        url = "/api/v1/GitPull"
+        url = "/GitPull"
         body = {}
 
         for key, value in locals().items():
@@ -172,13 +172,13 @@ class GitService(ObjectService):
         """ Executes a plan based on the planid
         :param plan_id: GitPlan id
         """
-        url = format_url("/api/v1/GitPlans('{}')/tm1.Execute", plan_id)
+        url = format_url("/GitPlans('{}')/tm1.Execute", plan_id)
         return self._rest.POST(url=url, **kwargs)
 
     def git_get_plans(self, **kwargs) -> List[GitPlan]:
         """ Gets a list of currently available GIT plans
         """
-        url = "/api/v1/GitPlans"
+        url = "/GitPlans"
         plans = []
 
         response = self._rest.GET(url=url, **kwargs)

--- a/TM1py/Services/HierarchyService.py
+++ b/TM1py/Services/HierarchyService.py
@@ -10,7 +10,7 @@ from TM1py.Services.ObjectService import ObjectService
 from TM1py.Services.RestService import RestService
 from TM1py.Services.SubsetService import SubsetService
 from TM1py.Utils.Utils import case_and_space_insensitive_equals, format_url, CaseAndSpaceInsensitiveDict, \
-    CaseAndSpaceInsensitiveSet
+    CaseAndSpaceInsensitiveSet, verify_version
 
 
 class HierarchyService(ObjectService):
@@ -33,7 +33,7 @@ class HierarchyService(ObjectService):
         :param hierarchy:
         :return:
         """
-        url = format_url("/api/v1/Dimensions('{}')/Hierarchies", hierarchy.dimension_name)
+        url = format_url("/Dimensions('{}')/Hierarchies", hierarchy.dimension_name)
         response = self._rest.POST(url, hierarchy.body, **kwargs)
 
         self.update_element_attributes(hierarchy, **kwargs)
@@ -48,7 +48,7 @@ class HierarchyService(ObjectService):
         :return:
         """
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')?$expand=Edges,Elements,ElementAttributes,Subsets,DefaultMember",
+            "/Dimensions('{}')/Hierarchies('{}')?$expand=Edges,Elements,ElementAttributes,Subsets,DefaultMember",
             dimension_name,
             hierarchy_name)
         response = self._rest.GET(url, **kwargs)
@@ -60,7 +60,7 @@ class HierarchyService(ObjectService):
         :param dimension_name:
         :return:
         """
-        url = format_url("/api/v1/Dimensions('{}')/Hierarchies?$select=Name", dimension_name)
+        url = format_url("/Dimensions('{}')/Hierarchies?$select=Name", dimension_name)
         response = self._rest.GET(url, **kwargs)
         return [hierarchy["Name"] for hierarchy in response.json()["value"]]
 
@@ -79,7 +79,7 @@ class HierarchyService(ObjectService):
         # functions returns multiple responses
         responses = list()
         # 1. Update Hierarchy
-        url = format_url("/api/v1/Dimensions('{}')/Hierarchies('{}')", hierarchy.dimension_name, hierarchy.name)
+        url = format_url("/Dimensions('{}')/Hierarchies('{}')", hierarchy.dimension_name, hierarchy.name)
         # Workaround EDGES: Handle Issue, that Edges cant be created in one batch with the Hierarchy in certain versions
         hierarchy_body = hierarchy.body_as_dict
         if self.version[0:8] in self.EDGES_WORKAROUND_VERSIONS:
@@ -125,17 +125,17 @@ class HierarchyService(ObjectService):
         :param hierarchy_name: 
         :return: 
         """
-        url = format_url("/api/v1/Dimensions('{}')/Hierarchies('{}')", dimension_name, hierarchy_name)
+        url = format_url("/Dimensions('{}')/Hierarchies('{}')", dimension_name, hierarchy_name)
         return self._exists(url, **kwargs)
 
     def delete(self, dimension_name: str, hierarchy_name: str, **kwargs) -> Response:
-        url = format_url("/api/v1/Dimensions('{}')/Hierarchies('{}')", dimension_name, hierarchy_name)
+        url = format_url("/Dimensions('{}')/Hierarchies('{}')", dimension_name, hierarchy_name)
         return self._rest.DELETE(url, **kwargs)
 
     def get_hierarchy_summary(self, dimension_name: str, hierarchy_name: str, **kwargs) -> Dict[str, int]:
         hierarchy_properties = ("Elements", "Edges", "ElementAttributes", "Members", "Levels")
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')?$expand=Edges/$count,Elements/$count,"
+            "/Dimensions('{}')/Hierarchies('{}')?$expand=Edges/$count,Elements/$count,"
             "ElementAttributes/$count,Members/$count,Levels/$count&$select=Cardinality",
             dimension_name,
             hierarchy_name)
@@ -214,7 +214,7 @@ class HierarchyService(ObjectService):
         :return: String, name of Member
         """
         url = format_url(
-            "/api/v1/Dimensions('{dimension}')/Hierarchies('{hierarchy}')/DefaultMember",
+            "/Dimensions('{dimension}')/Hierarchies('{hierarchy}')/DefaultMember",
             dimension=dimension_name,
             hierarchy=hierarchy_name if hierarchy_name else dimension_name)
         response = self._rest.GET(url=url, **kwargs)
@@ -223,16 +223,9 @@ class HierarchyService(ObjectService):
             return None
         return response.json()["Name"]
 
-    def update_default_member(self, dimension_name: str, hierarchy_name: str = None, member_name: str = "",
-                              **kwargs) -> Response:
-        """ Update the default member of a hierarchy.
-        Currently implemented through TI, since TM1 API does not supports default member updates yet.
-
-        :param dimension_name:
-        :param hierarchy_name:
-        :param member_name:
-        :return:
-        """
+    def _update_default_member_via_props_cube(self, dimension_name: str, hierarchy_name: str = None,
+                                              member_name: str = "",
+                                              **kwargs) -> Response:
         from TM1py import ProcessService, CellService
         if hierarchy_name and not case_and_space_insensitive_equals(dimension_name, hierarchy_name):
             dimension = "{}:{}".format(dimension_name, hierarchy_name)
@@ -250,10 +243,35 @@ class HierarchyService(ObjectService):
             lines_prolog=format_url("RefreshMdxHierarchy('{}');", dimension_name),
             **kwargs)
 
+    def _update_default_member_via_api(self, dimension_name: str, hierarchy_name: str = None, member_name: str = "",
+                                       **kwargs) -> Response:
+
+        url = format_url("/Dimensions('{dimension}')/Hierarchies('{hierarchy}')",
+                         dimension=dimension_name,
+                         hierarchy=hierarchy_name if hierarchy_name else dimension_name)
+
+        payload = {"DefaultMemberName": member_name}
+
+        return self._rest.PATCH(url=url, data=json.dumps(payload))
+
+    def update_default_member(self, dimension_name: str, hierarchy_name: str = None, member_name: str = "",
+                              **kwargs) -> Response:
+        """ Update the default member of a hierarchy.
+
+        :param dimension_name:
+        :param hierarchy_name:
+        :param member_name:
+        :return:
+        """
+        if verify_version(required_version='12', version=self.version):
+            return self._update_default_member_via_api(dimension_name, hierarchy_name, member_name)
+        else:
+            return self._update_default_member_via_props_cube(dimension_name, hierarchy_name, member_name)
+
     def remove_all_edges(self, dimension_name: str, hierarchy_name: str = None, **kwargs) -> Response:
         if not hierarchy_name:
             hierarchy_name = dimension_name
-        url = format_url("/api/v1/Dimensions('{}')/Hierarchies('{}')", dimension_name, hierarchy_name)
+        url = format_url("/Dimensions('{}')/Hierarchies('{}')", dimension_name, hierarchy_name)
         body = {
             "Edges": []
         }
@@ -320,7 +338,7 @@ class HierarchyService(ObjectService):
         :return:
         """
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/Structure/$value",
+            "/Dimensions('{}')/Hierarchies('{}')/Structure/$value",
             dimension_name,
             hierarchy_name)
         structure = int(self._rest.GET(url, **kwargs).text)

--- a/TM1py/Services/ManageService.py
+++ b/TM1py/Services/ManageService.py
@@ -1,0 +1,161 @@
+import json
+import requests
+from requests.auth import HTTPBasicAuth
+
+
+class ManageService:
+    """ Manage service to interact with the manage endpoint.
+    The manage endpoint uses basic auth using the root client and secret
+
+    """
+
+    def __init__(self, domain, root_client, root_secret):
+        self._domain = domain
+        self._root_client = root_client
+        self._root_secret = root_secret
+        self._auth_header = HTTPBasicAuth(self._root_client, self._root_secret)
+        self._root_url = f"{self._domain}/manage/v1"
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exception_type, exception_value, traceback):
+        pass
+
+    def get_instances(self):
+        url = f"{self._root_url}/Instances"
+        response = requests.get(url=url, auth=self._auth_header)
+        return json.loads(response.content).get('value')
+
+    def get_instance(self, instance_name):
+        url = f"{self._root_url}/Instances('{instance_name}')"
+        response = requests.get(url=url, auth=self._auth_header)
+        return json.loads(response.content)
+
+    def create_instance(self, instance_name):
+        url = f"{self._root_url}/Instances"
+        payload = {"Name": instance_name}
+        response = requests.post(url=url, json=payload, auth=self._auth_header)
+        return response
+
+    def delete_instance(self, instance_name):
+        url = f"{self._root_url}/Instances('{instance_name}')"
+        response = requests.delete(url=url, auth=self._auth_header)
+        return response
+
+    def instance_exists(self, instance_name):
+        url = f"{self._root_url}/Instances('{instance_name}')"
+        response = requests.get(url=url, auth=self._auth_header)
+        if response.ok:
+            return True
+        else:
+            return False
+
+    def get_databases(self, instance_name):
+        url = f"{self._root_url}/Instances('{instance_name}')/Databases"
+        response = requests.get(url=url, auth=self._auth_header)
+        return json.loads(response.content).get('value')
+
+    def get_database(self, instance_name, database_name):
+        url = f"{self._root_url}/Instances('{instance_name}')/Databases('{database_name}')"
+        response = requests.get(url=url, auth=self._auth_header)
+        return json.loads(response.content)
+
+    def create_database(self,
+                        instance_name,
+                        database_name,
+                        number_replicas,
+                        product_version="12.0.0-alpha.1",
+                        cpu_requests="1000m",
+                        cpu_limits="2000m",
+                        memory_requests="1G",
+                        memory_limits="2G",
+                        storage_size="20Gi"):
+
+        url = f"{self._root_url}/Instances('{instance_name}')/Databases"
+
+        payload = {"Name": database_name,
+                   "Replicas": number_replicas,
+                   "ProductVersion": product_version,
+                   "Resources": {
+                       "Replica": {
+                           "CPU": {
+                               "Requests": cpu_requests,
+                               "Limits": cpu_limits
+                           },
+                           "Memory": {
+                               "Requests": memory_requests,
+                               "Limits": memory_limits
+                           }
+                       },
+                       "Storage": {
+                           "Size": storage_size
+                       }
+                   }
+                   }
+        response = requests.post(url=url, json=payload, auth=self._auth_header)
+
+        return response
+
+    def delete_database(self, instance_name, database_name):
+        url = f"{self._root_url}/Instances('{instance_name}')/Databases('{database_name}')"
+        response = requests.delete(url=url, auth=self._auth_header)
+        return response
+
+    def database_exists(self, instance_name, database_name):
+        url = f"{self._root_url}/Instances('{instance_name}')/Databases('{database_name}')"
+        response = requests.get(url=url, auth=self._auth_header)
+        if response.ok:
+            return True
+        else:
+            return False
+
+    def upgrade_database(self, instance_name: str, database_name: str, target_version: str = ""):
+        url = f"{self._root_url}/Instances('{instance_name}')/Databases('{database_name}')/tm1s.Upgrade"
+        payload = {"ProductVersion": target_version}
+        response = requests.post(url=url, json=payload, auth=self._auth_header)
+        return response
+
+    def create_database_backup(self, instance_name: str, database_name: str, backup_url: str):
+        url = f"{self._root_url}/Instances('{instance_name}')/Databases('{database_name}')/tm1s.Backup"
+        payload = {"URL": backup_url}
+        response = requests.post(url=url, json=payload, auth=self._auth_header)
+        return response
+
+    def create_and_upload_database_backup_set_file(self, instance_name: str, database_name: str, backup_set_name: str):
+        create_url = f"{self._root_url}/Instances('{instance_name}')/Databases('{database_name}')" \
+                     f"/Contents('Files')/Contents('.backupsets')/Contents"
+        payload = {"@odata.type": "#ibm.tm1.api.v1.Document", "Name": f"{backup_set_name}.tgz"}
+        requests.post(url=create_url, json=payload, auth=self._auth_header)
+
+        upload_url = f"{self._root_url}/Instances('{instance_name}')/Databases('{database_name}')" \
+                     f"/Contents('Files')/Contents('.backupsets')/Contents('{backup_set_name}.tgz')/Content"
+        response = requests.post(url=upload_url, json=payload, auth=self._auth_header)
+        return response
+
+    def restore_database(self, instance_name: str, database_name: str, backup_url: str):
+        url = f"{self._root_url}/Instances('{instance_name}')/Databases('{database_name}')/tm1s.Restore"
+        payload = {"URL": backup_url}
+        response = requests.post(url=url, json=payload, auth=self._auth_header)
+        return response
+
+    def scale_database(self, instance_name: str, database_name: str, replicas: int):
+        url = f"{self._root_url}/Instances('{instance_name}')/Databases('{database_name}')"
+        payload = {"Replicas": replicas}
+        response = requests.patch(url=url, json=payload, auth=self._auth_header)
+        return response
+
+    def get_applications(self, instance_name):
+        url = f"{self._root_url}/Instances('{instance_name}')/Applications"
+        response = requests.get(url=url, auth=self._auth_header)
+        return json.loads(response.content)
+
+    def create_application(self, instance_name, application_name):
+        url = f"{self._root_url}/Instances('{instance_name}')/Applications"
+        payload = {"Name": application_name}
+        response = requests.post(url=url, json=payload, auth=self._auth_header)
+        response_json = json.loads(response.content)
+        return response_json['ClientID'], response_json['ClientSecret']
+
+
+

--- a/TM1py/Services/MonitoringService.py
+++ b/TM1py/Services/MonitoringService.py
@@ -23,7 +23,7 @@ class MonitoringService(ObjectService):
             :return:
                 dict: the response
         """
-        url = '/api/v1/Threads'
+        url = '/Threads'
         response = self._rest.GET(url, **kwargs)
         return response.json()['value']
 
@@ -33,7 +33,7 @@ class MonitoringService(ObjectService):
             :return:
                 list: TM1 threads as dict
         """
-        url = "/api/v1/Threads?$filter=Function ne 'GET /api/v1/Threads' and State ne 'Idle'"
+        url = "/Threads?$filter=Function ne 'GET /Threads' and State ne 'Idle'"
         response = self._rest.GET(url, **kwargs)
         return response.json()['value']
 
@@ -43,7 +43,7 @@ class MonitoringService(ObjectService):
         :param thread_id: 
         :return: 
         """
-        url = format_url("/api/v1/Threads('{}')/tm1.CancelOperation", str(thread_id))
+        url = format_url("/Threads('{}')/tm1.CancelOperation", str(thread_id))
         response = self._rest.POST(url, **kwargs)
         return response
 
@@ -57,7 +57,7 @@ class MonitoringService(ObjectService):
                 continue
             if thread["Name"] == "Pseudo":
                 continue
-            if thread["Function"] == "GET /api/v1/Threads":
+            if thread["Function"] == "GET /Threads":
                 continue
             self.cancel_thread(thread["ID"], **kwargs)
             canceled_threads.append(thread)
@@ -68,7 +68,7 @@ class MonitoringService(ObjectService):
 
         :return: List of TM1py.User instances
         """
-        url = '/api/v1/Users?$filter=IsActive eq true&$expand=Groups'
+        url = '/Users?$filter=IsActive eq true&$expand=Groups'
         response = self._rest.GET(url, **kwargs)
         users = [User.from_dict(user) for user in response.json()['value']]
         return users
@@ -79,7 +79,7 @@ class MonitoringService(ObjectService):
         :param user_name:
         :return: Boolean
         """
-        url = format_url("/api/v1/Users('{}')/IsActive", user_name)
+        url = format_url("/Users('{}')/IsActive", user_name)
         response = self._rest.GET(url, **kwargs)
         return bool(response.json()['value'])
 
@@ -89,12 +89,12 @@ class MonitoringService(ObjectService):
         :param user_name: 
         :return: 
         """
-        url = format_url("/api/v1/Users('{}')/tm1.Disconnect", user_name)
+        url = format_url("/Users('{}')/tm1.Disconnect", user_name)
         response = self._rest.POST(url, **kwargs)
         return response
 
     def get_active_session_threads(self, exclude_idle: bool = True, **kwargs):
-        url = "/api/v1/ActiveSession/Threads?$filter=Function ne 'GET /api/v1/ActiveSession/Threads'"
+        url = "/ActiveSession/Threads?$filter=Function ne 'GET /ActiveSession/Threads'"
         if exclude_idle:
             url += " and State ne 'Idle'"
 
@@ -102,7 +102,7 @@ class MonitoringService(ObjectService):
         return response.json()['value']
 
     def get_sessions(self, include_user: bool = True, include_threads: bool = True, **kwargs) -> List:
-        url = "/api/v1/Sessions"
+        url = "/Sessions"
         if include_user or include_threads:
             expands = list()
             if include_user:
@@ -126,7 +126,7 @@ class MonitoringService(ObjectService):
         return disconnected_users
 
     def close_session(self, session_id, **kwargs) -> Response:
-        url = format_url(f"/api/v1/Sessions('{session_id}')/tm1.Close")
+        url = format_url(f"/Sessions('{session_id}')/tm1.Close")
         return self._rest.POST(url, **kwargs)
 
     @require_admin

--- a/TM1py/Services/ObjectService.py
+++ b/TM1py/Services/ObjectService.py
@@ -38,7 +38,7 @@ class ObjectService:
 
     def determine_actual_object_name(self, object_class: str, object_name: str, **kwargs) -> str:
         url = format_url(
-            "/api/v1/{}?$filter=tolower(replace(Name, ' ', '')) eq '{}'",
+            "/{}?$filter=tolower(replace(Name, ' ', '')) eq '{}'",
             object_class,
             object_name.replace(" ", "").lower())
         response = self._rest.GET(url, **kwargs)

--- a/TM1py/Services/ProcessService.py
+++ b/TM1py/Services/ProcessService.py
@@ -14,7 +14,7 @@ from TM1py.Objects.ProcessDebugBreakpoint import ProcessDebugBreakpoint
 from TM1py.Services.ObjectService import ObjectService
 from TM1py.Services.RestService import RestService
 from TM1py.Utils import format_url, require_admin
-from TM1py.Utils.Utils import require_version
+from TM1py.Utils.Utils import require_version, deprecated_in_version
 
 
 class ProcessService(ObjectService):
@@ -32,7 +32,7 @@ class ProcessService(ObjectService):
         :return: Instance of the TM1py.Process
         """
         url = format_url(
-            "/api/v1/Processes('{}')?$select=*,UIData,VariablesUIData,"
+            "/Processes('{}')?$select=*,UIData,VariablesUIData,"
             "DataSource/dataSourceNameForServer,"
             "DataSource/dataSourceNameForClient,"
             "DataSource/asciiDecimalSeparator,"
@@ -58,7 +58,7 @@ class ProcessService(ObjectService):
         """
         model_process_filter = "&$filter=startswith(Name,'}') eq false and startswith(Name,'{') eq false"
 
-        url = "/api/v1/Processes?$select=*,UIData,VariablesUIData," \
+        url = "/Processes?$select=*,UIData,VariablesUIData," \
               "DataSource/dataSourceNameForServer," \
               "DataSource/dataSourceNameForClient," \
               "DataSource/asciiDecimalSeparator," \
@@ -86,7 +86,7 @@ class ProcessService(ObjectService):
             List of Strings
         """
         model_process_filter = "&$filter=startswith(Name,'}') eq false and startswith(Name,'{') eq false"
-        url = "/api/v1/Processes?$select=Name{}".format(model_process_filter if skip_control_processes else "")
+        url = "/Processes?$select=Name{}".format(model_process_filter if skip_control_processes else "")
 
         response = self._rest.GET(url, **kwargs)
         processes = list(process['Name'] for process in response.json()['value'])
@@ -103,7 +103,7 @@ class ProcessService(ObjectService):
         """
         search_string = search_string.lower().replace(' ', '')
         model_process_filter = "and (startswith(Name,'}') eq false and startswith(Name,'{') eq false)"
-        url = format_url("/api/v1/Processes?$select=Name&$filter="
+        url = format_url("/Processes?$select=Name&$filter="
                          "contains(tolower(replace(PrologProcedure, ' ', '')),'{}') "
                          "or contains(tolower(replace(MetadataProcedure, ' ', '')),'{}') "
                          "or contains(tolower(replace(DataProcedure, ' ', '')),'{}') "
@@ -130,7 +130,7 @@ class ProcessService(ObjectService):
         if name_contains_operator not in ("and", "or"):
             raise ValueError("'name_contains_operator' must be either 'AND' or 'OR'")
 
-        url = "/api/v1/Processes?$select=Name"
+        url = "/Processes?$select=Name"
         name_filters = []
 
         if name_startswith:
@@ -159,7 +159,7 @@ class ProcessService(ObjectService):
         :param process: Instance of TM1py.Process class
         :return: Response
         """
-        url = "/api/v1/Processes"
+        url = "/Processes"
         # Adjust process body if TM1 version is lower than 11 due to change in Process Parameters structure
         # https://www.ibm.com/developerworks/community/forums/html/topic?id=9188d139-8905-4895-9229-eaaf0e7fa683
         if int(self.version[0:2]) < 11:
@@ -173,7 +173,7 @@ class ProcessService(ObjectService):
         :param process: Instance of TM1py.Process class
         :return: Response
         """
-        url = format_url("/api/v1/Processes('{}')", process.name)
+        url = format_url("/Processes('{}')", process.name)
         # Adjust process body if TM1 version is lower than 11 due to change in Process Parameters structure
         # https://www.ibm.com/developerworks/community/forums/html/topic?id=9188d139-8905-4895-9229-eaaf0e7fa683
         if int(self.version[0:2]) < 11:
@@ -198,7 +198,7 @@ class ProcessService(ObjectService):
         :param name: 
         :return: Response
         """
-        url = format_url("/api/v1/Processes('{}')", name)
+        url = format_url("/Processes('{}')", name)
         response = self._rest.DELETE(url, **kwargs)
         return response
 
@@ -208,7 +208,7 @@ class ProcessService(ObjectService):
         :param name: 
         :return: 
         """
-        url = format_url("/api/v1/Processes('{}')", name)
+        url = format_url("/Processes('{}')", name)
         return self._exists(url, **kwargs)
 
     def compile(self, name: str, **kwargs) -> List:
@@ -217,7 +217,7 @@ class ProcessService(ObjectService):
         :param name: 
         :return: 
         """
-        url = format_url("/api/v1/Processes('{}')/tm1.Compile", name)
+        url = format_url("/Processes('{}')/tm1.Compile", name)
         response = self._rest.POST(url, **kwargs)
         syntax_errors = response.json()["value"]
         return syntax_errors
@@ -228,7 +228,7 @@ class ProcessService(ObjectService):
         :param process:
         :return:
         """
-        url = "/api/v1/CompileProcess"
+        url = "/CompileProcess"
 
         payload = json.loads('{"Process":' + process.body + '}')
 
@@ -251,7 +251,7 @@ class ProcessService(ObjectService):
         :param cancel_at_timeout: Abort operation in TM1 when timeout is reached
         :return:
         """
-        url = format_url("/api/v1/Processes('{}')/tm1.Execute", process_name)
+        url = format_url("/Processes('{}')/tm1.Execute", process_name)
         if not parameters:
             if kwargs:
                 parameters = {"Parameters": []}
@@ -273,7 +273,7 @@ class ProcessService(ObjectService):
         :param kwargs: dictionary of process parameters and values
         :return: success (boolean), status (String), error_log_file (String)
         """
-        url = "/api/v1/ExecuteProcessWithReturn?$expand=*"
+        url = "/ExecuteProcessWithReturn?$expand=*"
         if kwargs:
             for parameter_name, parameter_value in kwargs.items():
                 process.remove_parameter(name=parameter_name)
@@ -313,7 +313,7 @@ class ProcessService(ObjectService):
         :param kwargs: dictionary of process parameters and values
         :return: success (boolean), status (String), error_log_file (String)
         """
-        url = format_url("/api/v1/Processes('{}')/tm1.ExecuteWithReturn?$expand=*", process_name)
+        url = format_url("/Processes('{}')/tm1.ExecuteWithReturn?$expand=*", process_name)
         parameters = dict()
         if kwargs:
             parameters = {"Parameters": []}
@@ -359,20 +359,22 @@ class ProcessService(ObjectService):
         :param file_name: name of the error log file in the TM1 log directory
         :return: String, content of the file
         """
-        url = format_url("/api/v1/ErrorLogFiles('{}')/Content", file_name)
+        url = format_url("/ErrorLogFiles('{}')/Content", file_name)
         response = self._rest.GET(url=url, **kwargs)
         return response.text
 
+    @deprecated_in_version(version="12")
     def get_processerrorlogs(self, process_name: str, **kwargs) -> List:
         """ Get all ProcessErrorLog entries for a process
 
         :param process_name: name of the process
         :return: list - Collection of ProcessErrorLogs
         """
-        url = format_url("/api/v1/Processes('{}')/ErrorLogs", process_name)
+        url = format_url("/Processes('{}')/ErrorLogs", process_name)
         response = self._rest.GET(url=url, **kwargs)
         return response.json()['value']
 
+    @deprecated_in_version(version="12")
     def get_last_message_from_processerrorlog(self, process_name: str, **kwargs) -> str:
         """ Get the latest ProcessErrorLog from a process entity
 
@@ -383,7 +385,7 @@ class ProcessService(ObjectService):
         logs_as_list = self.get_processerrorlogs(process_name, **kwargs)
         if len(logs_as_list) > 0:
             timestamp = logs_as_list[-1]['Timestamp']
-            url = format_url("/api/v1/Processes('{}')/ErrorLogs('{}')/Content", process_name, timestamp)
+            url = format_url("/Processes('{}')/ErrorLogs('{}')/Content", process_name, timestamp)
             # response is plain text - due to entity type Edm.Stream
             response = self._rest.GET(url=url, **kwargs)
             return response.text
@@ -392,7 +394,7 @@ class ProcessService(ObjectService):
         """ 
         Start debug session for specified process; debug session id is returned in response        
         """
-        raw_url = "/api/v1/Processes('{}')/tm1.Debug?$expand=Breakpoints," \
+        raw_url = "/Processes('{}')/tm1.Debug?$expand=Breakpoints," \
                   "Thread,CallStack($expand=Variables,Process($select=Name))"
         url = format_url(raw_url, process_name)
 
@@ -414,14 +416,14 @@ class ProcessService(ObjectService):
         Runs a single statement in the process
         If ExecuteProcess is next function, will NOT debug child process
         """
-        url = format_url("/api/v1/ProcessDebugContexts('{}')/tm1.StepOver", debug_id)
+        url = format_url("/ProcessDebugContexts('{}')/tm1.StepOver", debug_id)
         self._rest.POST(url, **kwargs)
 
         # digest time  necessary for TM1 <= 11.8
         # ToDo: remove in later versions of TM1 once issue in TM1 server is resolved
         time.sleep(0.1)
 
-        raw_url = "/api/v1/ProcessDebugContexts('{}')?$expand=Breakpoints," \
+        raw_url = "/ProcessDebugContexts('{}')?$expand=Breakpoints," \
                   "Thread,CallStack($expand=Variables,Process($select=Name))"
         url = format_url(raw_url, debug_id)
         response = self._rest.GET(url, **kwargs)
@@ -433,14 +435,14 @@ class ProcessService(ObjectService):
         Runs a single statement in the process
         If ExecuteProcess is next function, will pause at first statement inside child process
         """
-        url = format_url("/api/v1/ProcessDebugContexts('{}')/tm1.StepIn", debug_id)
+        url = format_url("/ProcessDebugContexts('{}')/tm1.StepIn", debug_id)
         self._rest.POST(url, **kwargs)
 
         # digest time  necessary for TM1 <= 11.8
         # ToDo: remove in later versions of TM1 once issue in TM1 server is resolved
         time.sleep(0.1)
 
-        raw_url = "/api/v1/ProcessDebugContexts('{}')?$expand=Breakpoints," \
+        raw_url = "/ProcessDebugContexts('{}')?$expand=Breakpoints," \
                   "Thread,CallStack($expand=Variables,Process($select=Name))"
         url = format_url(raw_url, debug_id)
         response = self._rest.GET(url, **kwargs)
@@ -451,14 +453,14 @@ class ProcessService(ObjectService):
         """
         Resumes execution and runs until current process has finished.
         """
-        url = format_url("/api/v1/ProcessDebugContexts('{}')/tm1.StepOut", debug_id)
+        url = format_url("/ProcessDebugContexts('{}')/tm1.StepOut", debug_id)
         self._rest.POST(url, **kwargs)
 
         # digest time  necessary for TM1 <= 11.8
         # ToDo: remove in later versions of TM1 once issue in TM1 server is resolved
         time.sleep(0.1)
 
-        raw_url = "/api/v1/ProcessDebugContexts('{}')?$expand=Breakpoints," \
+        raw_url = "/ProcessDebugContexts('{}')?$expand=Breakpoints," \
                   "Thread,CallStack($expand=Variables,Process($select=Name))"
         url = format_url(raw_url, debug_id)
         response = self._rest.GET(url, **kwargs)
@@ -470,14 +472,14 @@ class ProcessService(ObjectService):
         Resumes execution until next breakpoint
         
         """
-        url = format_url("/api/v1/ProcessDebugContexts('{}')/tm1.Continue", debug_id)
+        url = format_url("/ProcessDebugContexts('{}')/tm1.Continue", debug_id)
         self._rest.POST(url, **kwargs)
 
         # digest time  necessary for TM1 <= 11.8
         # ToDo: remove in later versions of TM1 once issue in TM1 server is resolved
         time.sleep(0.1)
 
-        raw_url = "/api/v1/ProcessDebugContexts('{}')?$expand=Breakpoints," \
+        raw_url = "/ProcessDebugContexts('{}')?$expand=Breakpoints," \
                   "Thread,CallStack($expand=Variables,Process($select=Name))"
         url = format_url(raw_url, debug_id)
         response = self._rest.GET(url, **kwargs)
@@ -485,7 +487,7 @@ class ProcessService(ObjectService):
         return response.json()
 
     def debug_get_breakpoints(self, debug_id: str, **kwargs) -> List[ProcessDebugBreakpoint]:
-        url = format_url("/api/v1/ProcessDebugContexts('{}')/Breakpoints", debug_id)
+        url = format_url("/ProcessDebugContexts('{}')/Breakpoints", debug_id)
 
         response = self._rest.GET(url, **kwargs)
         return [ProcessDebugBreakpoint.from_dict(b) for b in response.json()['value']]
@@ -495,7 +497,7 @@ class ProcessService(ObjectService):
 
     def debug_add_breakpoints(self, debug_id: str, break_points: Iterable[ProcessDebugBreakpoint] = None,
                               **kwargs) -> Response:
-        url = format_url("/api/v1/ProcessDebugContexts('{}')/Breakpoints", debug_id)
+        url = format_url("/ProcessDebugContexts('{}')/Breakpoints", debug_id)
 
         body = json.dumps([break_point.body_as_dict for break_point in break_points])
 
@@ -503,14 +505,14 @@ class ProcessService(ObjectService):
         return response
 
     def debug_remove_breakpoint(self, debug_id: str, breakpoint_id: int, **kwargs) -> Response:
-        url = format_url("/api/v1/ProcessDebugContexts('{}')/Breakpoints('{}')", debug_id, str(breakpoint_id))
+        url = format_url("/ProcessDebugContexts('{}')/Breakpoints('{}')", debug_id, str(breakpoint_id))
 
         response = self._rest.DELETE(url, **kwargs)
         return response
 
     def debug_update_breakpoint(self, debug_id: str, break_point: ProcessDebugBreakpoint, **kwargs) -> Response:
         url = format_url(
-            "/api/v1/ProcessDebugContexts('{}')/Breakpoints('{}')",
+            "/ProcessDebugContexts('{}')/Breakpoints('{}')",
             debug_id,
             str(break_point.breakpoint_id))
 
@@ -518,7 +520,7 @@ class ProcessService(ObjectService):
         return response
 
     def debug_get_variable_values(self, debug_id: str, **kwargs) -> CaseInsensitiveDict:
-        raw_url = "/api/v1/ProcessDebugContexts('{}')?$expand=" \
+        raw_url = "/ProcessDebugContexts('{}')?$expand=" \
                   "CallStack($expand=Variables)"
         url = format_url(raw_url, debug_id)
 
@@ -529,7 +531,7 @@ class ProcessService(ObjectService):
         return CaseInsensitiveDict({entry["Name"]: entry["Value"] for entry in call_stack})
 
     def debug_get_single_variable_value(self, debug_id: str, variable_name: str, **kwargs) -> str:
-        raw_url = "/api/v1/ProcessDebugContexts('{}')?$expand=" \
+        raw_url = "/ProcessDebugContexts('{}')?$expand=" \
                   "CallStack($expand=Variables($filter=tolower(Name) eq '{}';$select=Value))"
         url = format_url(raw_url, debug_id, variable_name.lower())
 
@@ -541,7 +543,7 @@ class ProcessService(ObjectService):
             raise ValueError(f"'{variable_name}' not found in collection")
 
     def debug_get_process_procedure(self, debug_id: str, **kwargs) -> str:
-        raw_url = "/api/v1/ProcessDebugContexts('{}')?$expand=" \
+        raw_url = "/ProcessDebugContexts('{}')?$expand=" \
                   "CallStack($select=Procedure)"
         url = format_url(raw_url, debug_id)
 
@@ -549,7 +551,7 @@ class ProcessService(ObjectService):
         return response.json()['CallStack'][0]['Procedure']
 
     def debug_get_process_line_number(self, debug_id: str, **kwargs) -> str:
-        raw_url = "/api/v1/ProcessDebugContexts('{}')?$expand=" \
+        raw_url = "/ProcessDebugContexts('{}')?$expand=" \
                   "CallStack($select=LineNumber)"
         url = format_url(raw_url, debug_id)
 
@@ -557,7 +559,7 @@ class ProcessService(ObjectService):
         return response.json()['CallStack'][0]['LineNumber']
 
     def debug_get_record_number(self, debug_id: str, **kwargs) -> str:
-        raw_url = "/api/v1/ProcessDebugContexts('{}')?$expand=" \
+        raw_url = "/ProcessDebugContexts('{}')?$expand=" \
                   "CallStack($select=RecordNumber)"
         url = format_url(raw_url, debug_id)
 
@@ -565,7 +567,7 @@ class ProcessService(ObjectService):
         return response.json()['CallStack'][0]['RecordNumber']
 
     def debug_get_current_breakpoint(self, debug_id: str, **kwargs) -> ProcessDebugBreakpoint:
-        raw_url = "/api/v1/ProcessDebugContexts('{}')?$expand=CurrentBreakpoint"
+        raw_url = "/ProcessDebugContexts('{}')?$expand=CurrentBreakpoint"
 
         url = format_url(raw_url, debug_id)
 

--- a/TM1py/Services/RestService.py
+++ b/TM1py/Services/RestService.py
@@ -348,7 +348,6 @@ class RestService:
         else:
             self._construct_v12_service_and_auth_root()
 
-
     def _manage_http_adapter(self):
         if self._tcp_keepalive:
             # SO_KEEPALIVE: set 1 to enable TCP keepalive
@@ -525,10 +524,11 @@ class RestService:
                                             json=payload)
                     self.verify_response(response)
                     if 'TM1SessionId' not in self._s.cookies:
-                        warnings.warn(f"TM1SessionId has failed to be added to the session cookies, future requests "
-                                      "using this TM1Service instance will fail due to authentication. "
-                                      "Check the tm1-gateway domain settings are correct "
-                                      "in the container orchestrator ")
+                        raise TM1pyException(
+                            f"TM1SessionId has failed to be added to the session cookies, future requests "
+                            "using this TM1Service instance will fail due to authentication. "
+                            "Check the tm1-gateway domain settings are correct "
+                            "in the container orchestrator ")
 
 
                 else:

--- a/TM1py/Services/RestService.py
+++ b/TM1py/Services/RestService.py
@@ -5,6 +5,7 @@ import re
 import socket
 import time
 import warnings
+from http.cookies import SimpleCookie
 from base64 import b64encode, b64decode
 from http.client import HTTPResponse
 from io import BytesIO
@@ -472,6 +473,19 @@ class RestService:
         finally:
             self._s.close()
 
+    @staticmethod
+    def _extract_tm1_session_id_from_set_cookie_header(auth_response_headers: object) -> str:
+        if auth_response_headers["set-cookie"]:
+            cookie = SimpleCookie()
+            #remove invalid domain from cookie
+            cookie.load(auth_response_headers["set-cookie"].split(";")[0])
+            tm1_session_id = cookie['TM1SessionId'].value
+            return tm1_session_id
+        else:
+            return None
+
+
+
     def _start_session(self, user: str, password: str, decode_b64: bool = False, namespace: str = None,
                        gateway: str = None, cam_passport: str = None, integrated_login: bool = None,
                        integrated_login_domain: str = None, integrated_login_service: str = None,
@@ -524,13 +538,12 @@ class RestService:
                                             json=payload)
                     self.verify_response(response)
                     if 'TM1SessionId' not in self._s.cookies:
-                        raise TM1pyException(
-                            f"TM1SessionId has failed to be added to the session cookies, future requests "
-                            "using this TM1Service instance will fail due to authentication. "
-                            "Check the tm1-gateway domain settings are correct "
-                            "in the container orchestrator ")
-
-
+                        warnings.warn("TM1SessionId has failed to be automatically added to the session cookies, future requests ")
+                        warnings.warn("Check the tm1-gateway domain settings are correct in the container orchestrator ")
+                          
+                        #if session had incorrect domain due to CP4D extract it and add it to cookie jar
+                        self._s.cookies.set("TM1SessionId",
+                                            self._extract_tm1_session_id_from_set_cookie_header(auth_response_headers=response.headers))
                 else:
                     response = self._s.get(url=self._auth_url,
                                            headers=self._headers,

--- a/TM1py/Services/RestService.py
+++ b/TM1py/Services/RestService.py
@@ -22,7 +22,6 @@ from urllib3._collections import HTTPHeaderDict
 from TM1py.Exceptions.Exceptions import TM1pyTimeout, TM1pyVersionDeprecationException
 from TM1py.Utils import case_and_space_insensitive_equals, CaseAndSpaceInsensitiveSet, HTTPAdapterWithSocketOptions, \
     decohints
-from Utils import verify_version
 
 try:
     from requests_negotiate_sspi import HttpNegotiateAuth

--- a/TM1py/Services/SandboxService.py
+++ b/TM1py/Services/SandboxService.py
@@ -23,7 +23,7 @@ class SandboxService(ObjectService):
         :param sandbox_name: str
         :return: instance of TM1py.Sandbox
         """
-        url = format_url("/api/v1/Sandboxes('{}')", sandbox_name)
+        url = format_url("/Sandboxes('{}')", sandbox_name)
         response = self._rest.GET(url=url, **kwargs)
         sandbox = Sandbox.from_json(response.text)
         return sandbox
@@ -33,7 +33,7 @@ class SandboxService(ObjectService):
 
         :return: List of TM1py.Sandbox instances
         """
-        url = "/api/v1/Sandboxes?$select=Name,IncludeInSandboxDimension,IsLoaded,IsActive,IsQueued"
+        url = "/Sandboxes?$select=Name,IncludeInSandboxDimension,IsLoaded,IsActive,IsQueued"
         response = self._rest.GET(url, **kwargs)
         sandboxes = [
             Sandbox.from_dict(sandbox_as_dict=sandbox)
@@ -47,7 +47,7 @@ class SandboxService(ObjectService):
         :param kwargs:
         :return:
         """
-        url = "/api/v1/Sandboxes?$select=Name"
+        url = "/Sandboxes?$select=Name"
         response = self._rest.GET(url, **kwargs)
         return [entry["Name"] for entry in response.json()["value"]]
 
@@ -57,7 +57,7 @@ class SandboxService(ObjectService):
         :param sandbox: Sandbox
         :return: response
         """
-        url = "/api/v1/Sandboxes"
+        url = "/Sandboxes"
         return self._rest.POST(url=url, data=sandbox.body, **kwargs)
 
     def update(self, sandbox: Sandbox, **kwargs) -> Response:
@@ -66,7 +66,7 @@ class SandboxService(ObjectService):
         :param sandbox:
         :return: response
         """
-        url = format_url("/api/v1/Sandboxes('{}')", sandbox.name)
+        url = format_url("/Sandboxes('{}')", sandbox.name)
         return self._rest.PATCH(url=url, data=sandbox.body, **kwargs)
 
     def delete(self, sandbox_name: str, **kwargs) -> Response:
@@ -75,7 +75,7 @@ class SandboxService(ObjectService):
         :param sandbox_name:
         :return: response
         """
-        url = format_url("/api/v1/Sandboxes('{}')", sandbox_name)
+        url = format_url("/Sandboxes('{}')", sandbox_name)
         return self._rest.DELETE(url, **kwargs)
 
     def publish(self, sandbox_name: str, **kwargs) -> Response:
@@ -84,7 +84,7 @@ class SandboxService(ObjectService):
         :param sandbox_name: str
         :return: response
         """
-        url = format_url("/api/v1/Sandboxes('{}')/tm1.Publish", sandbox_name)
+        url = format_url("/Sandboxes('{}')/tm1.Publish", sandbox_name)
         return self._rest.POST(url=url, **kwargs)
 
     def reset(self, sandbox_name: str, **kwargs) -> Response:
@@ -93,7 +93,7 @@ class SandboxService(ObjectService):
         :param sandbox_name: str
         :return: response
         """
-        url = format_url("/api/v1/Sandboxes('{}')/tm1.DiscardChanges", sandbox_name)
+        url = format_url("/Sandboxes('{}')/tm1.DiscardChanges", sandbox_name)
         return self._rest.POST(url=url, **kwargs)
 
     def merge(
@@ -110,7 +110,7 @@ class SandboxService(ObjectService):
         :param clean_after: bool: Reset source sandbox after merging
         :return: response
         """
-        url = format_url("/api/v1/Sandboxes('{}')/tm1.Merge", source_sandbox_name)
+        url = format_url("/Sandboxes('{}')/tm1.Merge", source_sandbox_name)
         payload = dict()
         payload["Target@odata.bind"] = format_url(
             "Sandboxes('{}')", target_sandbox_name
@@ -124,7 +124,7 @@ class SandboxService(ObjectService):
         :param sandbox_name: String
         :return: bool
         """
-        url = format_url("/api/v1/Sandboxes('{}')", sandbox_name)
+        url = format_url("/Sandboxes('{}')", sandbox_name)
         return self._exists(url, **kwargs)
     
     def load(self, sandbox_name: str, **kwargs) -> Response:
@@ -133,7 +133,7 @@ class SandboxService(ObjectService):
         :param sandbox_name: str
         :return: response
         """
-        url = format_url("/api/v1/Sandboxes('{}')/tm1.Load", sandbox_name)
+        url = format_url("/Sandboxes('{}')/tm1.Load", sandbox_name)
         return self._rest.POST(url=url, **kwargs)
     
     def unload(self, sandbox_name: str, **kwargs) -> Response:
@@ -142,5 +142,5 @@ class SandboxService(ObjectService):
         :param sandbox_name: str
         :return: response
         """
-        url = format_url("/api/v1/Sandboxes('{}')/tm1.Unload", sandbox_name)
+        url = format_url("/Sandboxes('{}')/tm1.Unload", sandbox_name)
         return self._rest.POST(url=url, **kwargs)

--- a/TM1py/Services/SecurityService.py
+++ b/TM1py/Services/SecurityService.py
@@ -32,7 +32,7 @@ class SecurityService(ObjectService):
         :param user: instance of TM1py.User
         :return: response
         """
-        url = '/api/v1/Users'
+        url = '/Users'
         return self._rest.POST(url, user.body, **kwargs)
 
     @require_admin
@@ -42,7 +42,7 @@ class SecurityService(ObjectService):
         :param group_name:
         :return:
         """
-        url = '/api/v1/Groups'
+        url = '/Groups'
         return self._rest.POST(url, json.dumps({"Name": group_name}), **kwargs)
 
     def get_user(self, user_name: str, **kwargs) -> User:
@@ -53,7 +53,7 @@ class SecurityService(ObjectService):
         """
         user_name = self.determine_actual_user_name(user_name, **kwargs)
         url = format_url(
-            "/api/v1/Users('{}')?$select=Name,FriendlyName,Password,Type,Enabled&$expand=Groups",
+            "/Users('{}')?$select=Name,FriendlyName,Password,Type,Enabled&$expand=Groups",
             user_name)
         response = self._rest.GET(url, **kwargs)
         return User.from_dict(response.json())
@@ -63,7 +63,7 @@ class SecurityService(ObjectService):
 
         :return: instance of TM1py.User
         """
-        url = "/api/v1/ActiveUser?$select=Name,FriendlyName,Password,Type,Enabled&$expand=Groups"
+        url = "/ActiveUser?$select=Name,FriendlyName,Password,Type,Enabled&$expand=Groups"
         response = self._rest.GET(url, **kwargs)
         return User.from_dict(response.json())
 
@@ -78,11 +78,11 @@ class SecurityService(ObjectService):
         for current_group in self.get_groups(user.name, **kwargs):
             if current_group not in user.groups:
                 self.remove_user_from_group(current_group, user.name, **kwargs)
-        url = format_url("/api/v1/Users('{}')", user.name)
+        url = format_url("/Users('{}')", user.name)
         return self._rest.PATCH(url, user.body, **kwargs)
 
     def update_user_password(self, user_name: str, password: str, **kwargs) -> Response:
-        url = format_url("/api/v1/Users('{}')", user_name)
+        url = format_url("/Users('{}')", user_name)
         body = {"Password": password}
         return self._rest.PATCH(url, json.dumps(body), **kwargs)
 
@@ -94,7 +94,7 @@ class SecurityService(ObjectService):
         :return: response
         """
         user_name = self.determine_actual_user_name(user_name, **kwargs)
-        url = format_url("/api/v1/Users('{}')", user_name)
+        url = format_url("/Users('{}')", user_name)
         return self._rest.DELETE(url, **kwargs)
 
     @require_admin
@@ -105,7 +105,7 @@ class SecurityService(ObjectService):
         :return:
         """
         group_name = self.determine_actual_group_name(group_name, **kwargs)
-        url = format_url("/api/v1/Groups('{}')", group_name)
+        url = format_url("/Groups('{}')", group_name)
         return self._rest.DELETE(url, **kwargs)
 
     def get_all_users(self, **kwargs):
@@ -113,7 +113,7 @@ class SecurityService(ObjectService):
 
         :return: List of TM1py.User instances
         """
-        url = '/api/v1/Users?$select=Name,FriendlyName,Password,Type,Enabled&$expand=Groups'
+        url = '/Users?$select=Name,FriendlyName,Password,Type,Enabled&$expand=Groups'
         response = self._rest.GET(url, **kwargs)
         users = [User.from_dict(user) for user in response.json()['value']]
         return users
@@ -123,7 +123,7 @@ class SecurityService(ObjectService):
 
         :return: List of TM1py.User instances
         """
-        url = '/api/v1/Users?select=Name'
+        url = '/Users?select=Name'
         response = self._rest.GET(url, **kwargs)
         users = [user["Name"] for user in response.json()['value']]
         return users
@@ -135,7 +135,7 @@ class SecurityService(ObjectService):
         :return: List of TM1py.User instances
         """
         url = format_url(
-            "/api/v1/Groups('{}')?$expand=Users($select=Name,FriendlyName,Password,Type,Enabled;$expand=Groups)",
+            "/Groups('{}')?$expand=Users($select=Name,FriendlyName,Password,Type,Enabled;$expand=Groups)",
             group_name)
         response = self._rest.GET(url, **kwargs)
         users = [User.from_dict(user) for user in response.json()['Users']]
@@ -147,7 +147,7 @@ class SecurityService(ObjectService):
         :param group_name:
         :return: List of strings
         """
-        url = format_url("/api/v1/Groups('{}')?$expand=Users($expand=Groups)", group_name)
+        url = format_url("/Groups('{}')?$expand=Users($expand=Groups)", group_name)
         response = self._rest.GET(url, **kwargs)
         users = [user["Name"] for user in response.json()['Users']]
         return users
@@ -159,7 +159,7 @@ class SecurityService(ObjectService):
         :return: List of strings
         """
         user_name = self.determine_actual_user_name(user_name, **kwargs)
-        url = format_url("/api/v1/Users('{}')/Groups", user_name)
+        url = format_url("/Users('{}')/Groups", user_name)
         response = self._rest.GET(url, **kwargs)
         return [group['Name'] for group in response.json()['value']]
 
@@ -172,7 +172,7 @@ class SecurityService(ObjectService):
         :return: response
         """
         user_name = self.determine_actual_user_name(user_name, **kwargs)
-        url = format_url("/api/v1/Users('{}')", user_name)
+        url = format_url("/Users('{}')", user_name)
         body = {
             "Name": user_name,
             "Groups@odata.bind": [
@@ -192,7 +192,7 @@ class SecurityService(ObjectService):
         """
         user_name = self.determine_actual_user_name(user_name, **kwargs)
         group_name = self.determine_actual_group_name(group_name, **kwargs)
-        url = format_url("/api/v1/Users('{}')/Groups?$id=Groups('{}')", user_name, group_name)
+        url = format_url("/Users('{}')/Groups?$id=Groups('{}')", user_name, group_name)
         return self._rest.DELETE(url, **kwargs)
 
     def get_all_groups(self, **kwargs) -> List[str]:
@@ -200,7 +200,7 @@ class SecurityService(ObjectService):
 
         :return: List of strings
         """
-        url = '/api/v1/Groups?$select=Name'
+        url = '/Groups?$select=Name'
         response = self._rest.GET(url, **kwargs)
         groups = [entry['Name'] for entry in response.json()['value']]
         return groups
@@ -213,11 +213,11 @@ class SecurityService(ObjectService):
         return process_service.execute_ti_code(ti, **kwargs)
 
     def user_exists(self, user_name: str, **kwargs) -> bool:
-        url = format_url("/api/v1/Users('{}')", user_name)
+        url = format_url("/Users('{}')", user_name)
         return self._exists(url, **kwargs)
 
     def group_exists(self, group_name: str, **kwargs) -> bool:
-        url = format_url("/api/v1/Groups('{}')", group_name)
+        url = format_url("/Groups('{}')", group_name)
         return self._exists(url, **kwargs)
 
     def get_custom_security_groups(self, **kwargs) -> List[str]:

--- a/TM1py/Services/SubsetService.py
+++ b/TM1py/Services/SubsetService.py
@@ -30,7 +30,7 @@ class SubsetService(ObjectService):
         """
         subsets = "PrivateSubsets" if private else "Subsets"
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/{}",
+            "/Dimensions('{}')/Hierarchies('{}')/{}",
             subset.dimension_name,
             subset.hierarchy_name,
             subsets)
@@ -52,7 +52,7 @@ class SubsetService(ObjectService):
             hierarchy_name = dimension_name
         subsets = "PrivateSubsets" if private else "Subsets"
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/{}('{}')?$expand=Hierarchy($select=Dimension,Name),"
+            "/Dimensions('{}')/Hierarchies('{}')/{}('{}')?$expand=Hierarchy($select=Dimension,Name),"
             "Elements($select=Name)&$select=*,Alias", dimension_name, hierarchy_name, subsets, subset_name)
         response = self._rest.GET(url=url, **kwargs)
         return Subset.from_dict(response.json())
@@ -70,7 +70,7 @@ class SubsetService(ObjectService):
 
         subsets = "PrivateSubsets" if private else "Subsets"
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/{}?$select=Name",
+            "/Dimensions('{}')/Hierarchies('{}')/{}?$select=Name",
             dimension_name, hierarchy_name, subsets)
         response = self._rest.GET(url=url, **kwargs)
         subsets = response.json()['value']
@@ -92,7 +92,7 @@ class SubsetService(ObjectService):
                 **kwargs)
         subsets = "PrivateSubsets" if private else "Subsets"
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/{}('{}')",
+            "/Dimensions('{}')/Hierarchies('{}')/{}('{}')",
             subset.dimension_name, subset.hierarchy_name, subsets, subset.name)
         return self._rest.PATCH(url=url, data=subset.body, **kwargs)
 
@@ -113,7 +113,7 @@ class SubsetService(ObjectService):
         payload['MakePrivate'] = True if private else False
         payload['MakeStatic'] = True
         subsets = "PrivateSubsets" if private else "Subsets"
-        url = format_url("/api/v1/Dimensions('{}')/Hierarchies('{}')/{}('{}')/tm1.SaveAs", dimension_name,
+        url = format_url("/Dimensions('{}')/Hierarchies('{}')/{}('{}')/tm1.SaveAs", dimension_name,
                          hierarchy_name, subsets, subset_name)
         return self._rest.POST(url=url, data=json.dumps(payload))
 
@@ -147,7 +147,7 @@ class SubsetService(ObjectService):
         hierarchy_name = hierarchy_name if hierarchy_name else dimension_name
         subsets = "PrivateSubsets" if private else "Subsets"
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/{}('{}')",
+            "/Dimensions('{}')/Hierarchies('{}')/{}('{}')",
             dimension_name, hierarchy_name, subsets, subset_name)
         response = self._rest.DELETE(url=url, **kwargs)
         return response
@@ -165,7 +165,7 @@ class SubsetService(ObjectService):
         hierarchy_name = hierarchy_name if hierarchy_name else dimension_name
         subset_type = 'PrivateSubsets' if private else "Subsets"
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/{}('{}')",
+            "/Dimensions('{}')/Hierarchies('{}')/{}('{}')",
             dimension_name, hierarchy_name, subset_type, subset_name)
         return self._exists(url, **kwargs)
 
@@ -173,7 +173,7 @@ class SubsetService(ObjectService):
                                            private: bool, **kwargs) -> Response:
         subsets = "PrivateSubsets" if private else "Subsets"
         url = format_url(
-            "/api/v1/Dimensions('{}')/Hierarchies('{}')/{}('{}')/Elements/$ref",
+            "/Dimensions('{}')/Hierarchies('{}')/{}('{}')/Elements/$ref",
             dimension_name, hierarchy_name, subsets, subset_name)
         return self._rest.DELETE(url=url, **kwargs)
 

--- a/TM1py/Services/ViewService.py
+++ b/TM1py/Services/ViewService.py
@@ -31,7 +31,7 @@ class ViewService(ObjectService):
         :return: Response
         """
         view_type = "PrivateViews" if private else "Views"
-        url = format_url("/api/v1/Cubes('{}')/{}", view.cube, view_type)
+        url = format_url("/Cubes('{}')/{}", view.cube, view_type)
         return self._rest.POST(url, view.body, **kwargs)
 
     def exists(self, cube_name: str, view_name: str, private: bool = None, **kwargs):
@@ -43,7 +43,7 @@ class ViewService(ObjectService):
 
         :return boolean tuple
         """
-        url_template = "/api/v1/Cubes('{}')/{}('{}')"
+        url_template = "/Cubes('{}')/{}('{}')"
         if private is not None:
             url = format_url(url_template, cube_name, "PrivateViews" if private else "Views", view_name)
             return self._exists(url, **kwargs)
@@ -63,7 +63,7 @@ class ViewService(ObjectService):
 
     def get(self, cube_name: str, view_name: str, private: bool = False, **kwargs) -> View:
         view_type = "PrivateViews" if private else "Views"
-        url = format_url("/api/v1/Cubes('{}')/{}('{}')?$expand=*", cube_name, view_type, view_name)
+        url = format_url("/Cubes('{}')/{}('{}')?$expand=*", cube_name, view_type, view_name)
         response = self._rest.GET(url, **kwargs)
         view_as_dict = response.json()
         if "MDX" in view_as_dict:
@@ -82,7 +82,7 @@ class ViewService(ObjectService):
         """
         view_type = "PrivateViews" if private else "Views"
         url = format_url(
-            "/api/v1/Cubes('{}')/{}('{}')?$expand="
+            "/Cubes('{}')/{}('{}')?$expand="
             "tm1.NativeView/Rows/Subset($expand=Hierarchy($select=Name;"
             "$expand=Dimension($select=Name)),Elements($select=Name);"
             "$select=Expression,UniqueName,Name, Alias),  "
@@ -108,7 +108,7 @@ class ViewService(ObjectService):
         :return: instance of TM1py.MDXView
         """
         view_type = 'PrivateViews' if private else 'Views'
-        url = format_url("/api/v1/Cubes('{}')/{}('{}')?$expand=*", cube_name, view_type, view_name)
+        url = format_url("/Cubes('{}')/{}('{}')?$expand=*", cube_name, view_type, view_name)
         response = self._rest.GET(url, **kwargs)
         mdx_view = MDXView.from_json(view_as_json=response.text)
         return mdx_view
@@ -125,7 +125,7 @@ class ViewService(ObjectService):
         private_views, public_views = [], []
         for view_type in ('PrivateViews', 'Views'):
             url = format_url(
-                "/api/v1/Cubes('{}')/{}?$expand="
+                "/Cubes('{}')/{}?$expand="
                 "tm1.NativeView/Rows/Subset($expand=Hierarchy($select=Name;"
                 "$expand=Dimension($select=Name)),Elements($select=Name{});"
                 "$select=Expression,UniqueName,Name, Alias),  "
@@ -158,7 +158,7 @@ class ViewService(ObjectService):
         """
         private_views, public_views = [], []
         for view_type in ('PrivateViews', 'Views'):
-            url = format_url("/api/v1/Cubes('{}')/{}?$select=Name", cube_name, view_type)
+            url = format_url("/Cubes('{}')/{}?$select=Name", cube_name, view_type)
             response = self._rest.GET(url, **kwargs)
             response_as_list = response.json()['value']
 
@@ -178,7 +178,7 @@ class ViewService(ObjectService):
         :return: response
         """
         view_type = 'PrivateViews' if private else 'Views'
-        url = format_url("/api/v1/Cubes('{}')/{}('{}')", view.cube, view_type, view.name)
+        url = format_url("/Cubes('{}')/{}('{}')", view.cube, view_type, view.name)
         response = self._rest.PATCH(url, view.body, **kwargs)
         return response
 
@@ -205,7 +205,7 @@ class ViewService(ObjectService):
         :return: String, the response
         """
         view_type = 'PrivateViews' if private else 'Views'
-        url = format_url("/api/v1/Cubes('{}')/{}('{}')", cube_name, view_type, view_name)
+        url = format_url("/Cubes('{}')/{}('{}')", cube_name, view_type, view_name)
         response = self._rest.DELETE(url, **kwargs)
         return response
 
@@ -226,10 +226,10 @@ class ViewService(ObjectService):
         element_filter = ";$top=0" if not include_elements else ""
         if cube_name:
             base_url = format_url(
-                "/api/v1/Cubes?$select=Name&$filter=replace(tolower(Name),' ', '') eq '{}'",
+                "/Cubes?$select=Name&$filter=replace(tolower(Name),' ', '') eq '{}'",
                 cube_name.lower().replace(' ', ''))
         else:
-            base_url = "/api/v1/Cubes?$select=Name"
+            base_url = "/Cubes?$select=Name"
 
         private_views, public_views = [], []
         for view_type in ('PrivateViews', 'Views'):
@@ -272,7 +272,7 @@ class ViewService(ObjectService):
         return private_views, public_views
 
     def is_mdx_view(self, cube_name: str, view_name: str, private=False, **kwargs):
-        url_template = "/api/v1/Cubes('{}')/{}('{}')?select=Name"
+        url_template = "/Cubes('{}')/{}('{}')?select=Name"
         if private is not None:
             url = format_url(url_template, cube_name, "PrivateViews" if private else "Views", view_name)
 

--- a/TM1py/Services/__init__.py
+++ b/TM1py/Services/__init__.py
@@ -18,3 +18,4 @@ from TM1py.Services.SubsetService import SubsetService
 from TM1py.Services.ViewService import ViewService
 from TM1py.Services.GitService import GitService
 from TM1py.Services.TM1Service import TM1Service
+from TM1py.Services.ManageService import ManageService

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -876,6 +876,10 @@ def extract_compact_json_cellset(context: str, response: Dict, return_as_dict: b
     if len(props) == 1:
         return [value[0] for value in cells_data]
 
+    if props == ['Ordinal', 'Value']:
+        return [value[1] for value in cells_data]
+
+
     return cells_data
 
 

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -16,7 +16,7 @@ import requests
 from mdxpy import MdxBuilder, Member
 from requests.adapters import HTTPAdapter
 
-from TM1py.Exceptions.Exceptions import TM1pyVersionException, TM1pyNotAdminException
+from TM1py.Exceptions.Exceptions import TM1pyVersionException, TM1pyNotAdminException, TM1pyVersionDeprecationException
 
 try:
     import pandas as pd
@@ -63,6 +63,22 @@ def require_version(version):
 
     return wrap
 
+@decohints
+def deprecated_in_version(version):
+    """ Higher order function to check required version for TM1py function
+    """
+
+    def wrap(func):
+        @functools.wraps(func)
+        def wrapper(self, *args, **kwargs):
+            if verify_version(required_version=version, version=self.version):
+                raise TM1pyVersionDeprecationException(func.__name__, version)
+            return func(self, *args, **kwargs)
+
+        return wrapper
+
+    return wrap
+
 
 @decohints
 def require_pandas(func):
@@ -90,7 +106,7 @@ def get_all_servers_from_adminhost(adminhost='localhost', port=None, use_ssl=Fal
         conn = http_client.HTTPConnection(adminhost, port or 5895)
     else:
         conn = http_client.HTTPSConnection(adminhost, port or 5898, context=ssl._create_unverified_context())
-    request = '/api/v1/Servers'
+    request = '/Servers'
     conn.request('GET', request, body='')
     response = conn.getresponse().read().decode('utf-8')
     response_as_dict = json.loads(response)
@@ -126,7 +142,7 @@ def create_server_on_adminhost(adminhost: str = 'localhost', server_as_dict: Dic
     if not adminhost:
         adminhost = 'localhost'
 
-    url = f"http://{adminhost}:5895/api/v1/Servers"
+    url = f"http://{adminhost}:5895/Servers"
     response = requests.post(url, data=json.dumps(server_as_dict), headers={'Content-Type': 'application/json'})
     response.raise_for_status()
 
@@ -140,7 +156,7 @@ def delete_server_on_adminhost(adminhost: str = None, server_name: str = None):
     if not adminhost:
         adminhost = 'localhost'
 
-    url = f"http://{adminhost}:5895/api/v1/Servers('{server_name}')"
+    url = f"http://{adminhost}:5895/Servers('{server_name}')"
     response = requests.delete(url, headers={'Content-Type': 'application/json'})
     response.raise_for_status()
 
@@ -170,7 +186,7 @@ def update_server_on_adminhost(adminhost: str = 'localhost', server_as_dict: Dic
     if not adminhost:
         adminhost = 'localhost'
 
-    url = f"http://{adminhost}:5895/api/v1/Servers"
+    url = f"http://{adminhost}:5895/Servers"
     response = requests.patch(url, body=json.dumps(server_as_dict), headers={'Content-Type': 'application/json'})
     response.raise_for_status()
 

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -11,7 +11,6 @@ from contextlib import suppress
 from enum import Enum, unique
 from io import StringIO
 from typing import Any, Dict, List, Tuple, Iterable, Optional, Generator, Union, Callable
-
 import requests
 from mdxpy import MdxBuilder, Member
 from requests.adapters import HTTPAdapter
@@ -93,6 +92,7 @@ def require_pandas(func):
     return wrapper
 
 
+
 def get_all_servers_from_adminhost(adminhost='localhost', port=None, use_ssl=False) -> List:
     from TM1py.Objects import Server
     """ Ask Adminhost for TM1 Servers
@@ -106,7 +106,7 @@ def get_all_servers_from_adminhost(adminhost='localhost', port=None, use_ssl=Fal
         conn = http_client.HTTPConnection(adminhost, port or 5895)
     else:
         conn = http_client.HTTPSConnection(adminhost, port or 5898, context=ssl._create_unverified_context())
-    request = '/Servers'
+    request = '/api/v1/Servers'
     conn.request('GET', request, body='')
     response = conn.getresponse().read().decode('utf-8')
     response_as_dict = json.loads(response)
@@ -222,7 +222,7 @@ def abbreviate_mdx(mdx: str, size=100) -> str:
 
 
 def integerize_version(version: str, precision: int = 4) -> int:
-    return int(version[:precision].replace(".", ""))
+    return int(version[:precision].replace(".", "").ljust(precision, "0"))
 
 
 def verify_version(required_version: str, version: str) -> bool:

--- a/TM1py/__init__.py
+++ b/TM1py/__init__.py
@@ -60,6 +60,7 @@ from TM1py.Services.ServerService import ServerService
 from TM1py.Services.SubsetService import SubsetService
 from TM1py.Services.TM1Service import TM1Service
 from TM1py.Services.ViewService import ViewService
+from TM1py.Services.ManageService import ManageService
 from TM1py.Utils import Utils
 
 __version__ = "1.11.2"

--- a/Tests/CellService_test.py
+++ b/Tests/CellService_test.py
@@ -2796,7 +2796,7 @@ class TestCellService(unittest.TestCase):
 
         df = self.tm1.cubes.cells.execute_mdx_dataframe(query, use_blob=True)
         self.assertEqual(
-            [["NA", "Element 1", 4.0]],
+            [["Element 1", "NA", 4.0]],
             df.values.tolist())
 
     @skip_if_no_pandas

--- a/Tests/CellService_test.py
+++ b/Tests/CellService_test.py
@@ -3995,7 +3995,7 @@ class TestCellService(unittest.TestCase):
             cube_name=self.cube_with_rules_name,
             elements=["Element1", "Element1", "Element1"])
 
-        self.assertEqual(result['@odata.context'], '../$metadata#ibm.tm1.api.v1.CalculationComponent')
+        self.assertIn('../$metadata#ibm.tm1.api.v1.CalculationComponent', result['@odata.context'])
 
     def test_trace_cell_calculation_shallow_depth_iterable(self):
         shallow_depth = 1
@@ -4004,7 +4004,7 @@ class TestCellService(unittest.TestCase):
             elements=["Element3", "Element1", "Element1"],
             depth=shallow_depth)
 
-        self.assertEqual(result['@odata.context'], '../$metadata#ibm.tm1.api.v1.CalculationComponent')
+        self.assertIn('../$metadata#ibm.tm1.api.v1.CalculationComponent', result['@odata.context'])
         components = result["Components"]
 
         self.assertNotIn("Components", components)
@@ -4016,7 +4016,7 @@ class TestCellService(unittest.TestCase):
             elements=["Element3", "Element1", "Element1"],
             depth=shallow_depth)
 
-        self.assertEqual(result['@odata.context'], '../$metadata#ibm.tm1.api.v1.CalculationComponent')
+        self.assertIn('../$metadata#ibm.tm1.api.v1.CalculationComponent', result['@odata.context'])
         components = result["Components"]
         for _ in range(shallow_depth - 1):
             components = components[0]["Components"]
@@ -4029,14 +4029,14 @@ class TestCellService(unittest.TestCase):
             elements=["Element1", "Element1", "Element1"],
             dimensions=["TM1py_Tests_Cell_Dimension1", "TM1py_Tests_Cell_Dimension2", "TM1py_Tests_Cell_Dimension3"])
 
-        self.assertEqual(result['@odata.context'], '../$metadata#ibm.tm1.api.v1.CalculationComponent')
+        self.assertIn('../$metadata#ibm.tm1.api.v1.CalculationComponent', result['@odata.context'])
 
     def test_trace_cell_calculation_no_depth_string(self):
         result = self.tm1.cells.trace_cell_calculation(
             cube_name=self.cube_with_rules_name,
             elements="Element1,Element1,Element1")
 
-        self.assertEqual(result['@odata.context'], '../$metadata#ibm.tm1.api.v1.CalculationComponent')
+        self.assertIn('../$metadata#ibm.tm1.api.v1.CalculationComponent', result['@odata.context'])
 
     def test_trace_cell_calculation_shallow_depth_string(self):
         shallow_depth = 2
@@ -4046,7 +4046,7 @@ class TestCellService(unittest.TestCase):
             elements="Element3,Element1,Element1",
             depth=shallow_depth)
 
-        self.assertEqual(result['@odata.context'], '../$metadata#ibm.tm1.api.v1.CalculationComponent')
+        self.assertIn('../$metadata#ibm.tm1.api.v1.CalculationComponent', result['@odata.context'])
         components = result["Components"]
         for _ in range(shallow_depth - 1):
             components = components[0]["Components"]
@@ -4059,7 +4059,7 @@ class TestCellService(unittest.TestCase):
             elements="Element1,Element1,Element1",
             depth=25)
 
-        self.assertEqual(result['@odata.context'], '../$metadata#ibm.tm1.api.v1.CalculationComponent')
+        self.assertIn('../$metadata#ibm.tm1.api.v1.CalculationComponent', result['@odata.context'])
 
     def test_trace_cell_calculation_dimensions_string(self):
         result = self.tm1.cells.trace_cell_calculation(
@@ -4067,7 +4067,7 @@ class TestCellService(unittest.TestCase):
             elements="Element1,Element1,Element1",
             dimensions=["TM1py_Tests_Cell_Dimension1", "TM1py_Tests_Cell_Dimension2", "TM1py_Tests_Cell_Dimension3"])
 
-        self.assertEqual(result['@odata.context'], '../$metadata#ibm.tm1.api.v1.CalculationComponent')
+        self.assertIn('../$metadata#ibm.tm1.api.v1.CalculationComponent', result['@odata.context'])
 
     def test_trace_cell_calculation_dimensions_string_hierarchy(self):
         result = self.tm1.cells.trace_cell_calculation(
@@ -4077,7 +4077,7 @@ class TestCellService(unittest.TestCase):
                      "TM1py_Tests_Cell_Dimension3::Element1",
             dimensions=["TM1py_Tests_Cell_Dimension1", "TM1py_Tests_Cell_Dimension2", "TM1py_Tests_Cell_Dimension3"])
 
-        self.assertEqual(result['@odata.context'], '../$metadata#ibm.tm1.api.v1.CalculationComponent')
+        self.assertIn('../$metadata#ibm.tm1.api.v1.CalculationComponent', result['@odata.context'])
 
     def test_trace_cell_calculation_dimensions_string_multi_hierarchy(self):
         result = self.tm1.cells.trace_cell_calculation(
@@ -4087,14 +4087,14 @@ class TestCellService(unittest.TestCase):
                      "TM1py_Tests_Cell_Dimension3::Element1",
             dimensions=["TM1py_Tests_Cell_Dimension1", "TM1py_Tests_Cell_Dimension2", "TM1py_Tests_Cell_Dimension3"])
 
-        self.assertEqual(result['@odata.context'], '../$metadata#ibm.tm1.api.v1.CalculationComponent')
+        self.assertIn('../$metadata#ibm.tm1.api.v1.CalculationComponent', result['@odata.context'])
 
     def test_trace_feeders_string(self):
         result = self.tm1.cells.trace_cell_feeders(
             cube_name=self.cube_with_rules_name,
             elements="Element1,Element1,Element1")
 
-        self.assertEqual(result['@odata.context'], '../$metadata#ibm.tm1.api.v1.FeederTrace')
+        self.assertIn('../$metadata#ibm.tm1.api.v1.FeederTrace', result['@odata.context'])
 
     def test_trace_feeders_dimensions_string(self):
         result = self.tm1.cells.trace_cell_feeders(
@@ -4102,7 +4102,7 @@ class TestCellService(unittest.TestCase):
             elements="Element1,Element1,Element1",
             dimensions=["TM1py_Tests_Cell_Dimension1", "TM1py_Tests_Cell_Dimension2", "TM1py_Tests_Cell_Dimension3"])
 
-        self.assertEqual(result['@odata.context'], '../$metadata#ibm.tm1.api.v1.FeederTrace')
+        self.assertIn('../$metadata#ibm.tm1.api.v1.FeederTrace', result['@odata.context'])
 
     def test_trace_feeders_dimensions_string_hierarchy(self):
         result = self.tm1.cells.trace_cell_feeders(
@@ -4112,7 +4112,7 @@ class TestCellService(unittest.TestCase):
                      "TM1py_Tests_Cell_Dimension3::Element1",
             dimensions=["TM1py_Tests_Cell_Dimension1", "TM1py_Tests_Cell_Dimension2", "TM1py_Tests_Cell_Dimension3"])
 
-        self.assertEqual(result['@odata.context'], '../$metadata#ibm.tm1.api.v1.FeederTrace')
+        self.assertIn('../$metadata#ibm.tm1.api.v1.FeederTrace', result['@odata.context'])
 
     def test_trace_feeders_dimensions_string_multi_hierarchy(self):
         result = self.tm1.cells.trace_cell_feeders(
@@ -4122,14 +4122,14 @@ class TestCellService(unittest.TestCase):
                      "TM1py_Tests_Cell_Dimension3::Element1",
             dimensions=["TM1py_Tests_Cell_Dimension1", "TM1py_Tests_Cell_Dimension2", "TM1py_Tests_Cell_Dimension3"])
 
-        self.assertEqual(result['@odata.context'], '../$metadata#ibm.tm1.api.v1.FeederTrace')
+        self.assertIn('../$metadata#ibm.tm1.api.v1.FeederTrace', result['@odata.context'])
 
     def test_check_feeders_string(self):
         result = self.tm1.cells.check_cell_feeders(
             cube_name=self.cube_with_rules_name,
             elements="Element1,Element1,Element1")
 
-        self.assertEqual(result['@odata.context'], '../$metadata#Collection(ibm.tm1.api.v1.FedCellDescriptor)')
+        self.assertIn('../$metadata#Collection(ibm.tm1.api.v1.FedCellDescriptor)', result['@odata.context'])
 
     def test_check_feeders_dimensions_string(self):
         result = self.tm1.cells.check_cell_feeders(
@@ -4137,7 +4137,7 @@ class TestCellService(unittest.TestCase):
             elements="Element1,Element1,Element1",
             dimensions=["TM1py_Tests_Cell_Dimension1", "TM1py_Tests_Cell_Dimension2", "TM1py_Tests_Cell_Dimension3"])
 
-        self.assertEqual(result['@odata.context'], '../$metadata#Collection(ibm.tm1.api.v1.FedCellDescriptor)')
+        self.assertIn('../$metadata#Collection(ibm.tm1.api.v1.FedCellDescriptor)', result['@odata.context'])
 
     def test_check_feeders_dimensions_string_hierarchy(self):
         result = self.tm1.cells.check_cell_feeders(
@@ -4147,7 +4147,7 @@ class TestCellService(unittest.TestCase):
                      "TM1py_Tests_Cell_Dimension3::Element1",
             dimensions=["TM1py_Tests_Cell_Dimension1", "TM1py_Tests_Cell_Dimension2", "TM1py_Tests_Cell_Dimension3"])
 
-        self.assertEqual(result['@odata.context'], '../$metadata#Collection(ibm.tm1.api.v1.FedCellDescriptor)')
+        self.assertIn('../$metadata#Collection(ibm.tm1.api.v1.FedCellDescriptor)', result['@odata.context'])
 
     def test_check_feeders_dimensions_string_multi_hierarchy(self):
         result = self.tm1.cells.check_cell_feeders(
@@ -4157,7 +4157,7 @@ class TestCellService(unittest.TestCase):
                      "TM1py_Tests_Cell_Dimension3::Element1",
             dimensions=["TM1py_Tests_Cell_Dimension1", "TM1py_Tests_Cell_Dimension2", "TM1py_Tests_Cell_Dimension3"])
 
-        self.assertEqual(result['@odata.context'], '../$metadata#Collection(ibm.tm1.api.v1.FedCellDescriptor)')
+        self.assertIn('../$metadata#Collection(ibm.tm1.api.v1.FedCellDescriptor)', result['@odata.context'])
 
     # Delete Cube and Dimensions
     @classmethod

--- a/Tests/CellService_test.py
+++ b/Tests/CellService_test.py
@@ -12,7 +12,7 @@ from TM1py.Objects import (AnonymousSubset, Cube, Dimension, Element,
 from TM1py.Services import TM1Service
 from TM1py.Utils import Utils, element_names_from_element_unique_names, CaseAndSpaceInsensitiveDict, \
     CaseAndSpaceInsensitiveTuplesDict
-from .Utils import skip_if_insufficient_version, skip_if_no_pandas
+from .Utils import skip_if_insufficient_version, skip_if_no_pandas, skip_if_deprecated_in_version
 
 try:
     import pandas as pd
@@ -2796,7 +2796,7 @@ class TestCellService(unittest.TestCase):
 
         df = self.tm1.cubes.cells.execute_mdx_dataframe(query, use_blob=True)
         self.assertEqual(
-            [["Element 1", "NA", 4.0]],
+          [["Element 1", "NA", 4.0]],
             df.values.tolist())
 
     @skip_if_no_pandas
@@ -3631,6 +3631,7 @@ class TestCellService(unittest.TestCase):
         values = self.tm1.cubes.cells.execute_mdx_values(mdx)
         self.assertEqual(values[0], 1.5)
 
+    @skip_if_deprecated_in_version(version='12')
     def test_write_values_through_cellset_deactivate_transaction_log(self):
         query = MdxBuilder.from_cube(self.cube_name)
         query = query.add_hierarchy_set_to_row_axis(
@@ -3647,6 +3648,7 @@ class TestCellService(unittest.TestCase):
 
         self.assertFalse(self.tm1.cells.transaction_log_is_active(self.cube_name))
 
+    @skip_if_deprecated_in_version(version='12')
     def test_write_values_through_cellset_deactivate_transaction_log_reactivate_transaction_log(self):
         mdx = MdxBuilder.from_cube(self.cube_name) \
             .add_hierarchy_set_to_row_axis(MdxHierarchySet.member(Member.of(self.dimension_names[0], "element2"))) \
@@ -3666,6 +3668,7 @@ class TestCellService(unittest.TestCase):
         self.assertEqual(values[0], 1.5)
         self.assertTrue(self.tm1.cells.transaction_log_is_active(self.cube_name))
 
+    @skip_if_deprecated_in_version(version='12')
     def test_deactivate_transaction_log(self):
         self.tm1.cubes.cells.write_value(value="YES",
                                          cube_name="}CubeProperties",
@@ -3674,6 +3677,7 @@ class TestCellService(unittest.TestCase):
         value = self.tm1.cubes.cells.get_value("}CubeProperties", "{},LOGGING".format(self.cube_name))
         self.assertEqual("NO", value.upper())
 
+    @skip_if_deprecated_in_version(version='12')
     def test_activate_transaction_log(self):
         self.tm1.cubes.cells.write_value(value="NO",
                                          cube_name="}CubeProperties",
@@ -3864,16 +3868,19 @@ class TestCellService(unittest.TestCase):
         elements = element_names_from_element_unique_names(list(cells.keys())[0])
         self.assertEqual(elements, ("Element 2", "Element 1", "Element 1"))
 
+    @skip_if_deprecated_in_version(version='12')
     def test_transaction_log_is_active_false(self):
         self.tm1.cells.deactivate_transactionlog(self.cube_name)
 
         self.assertFalse(self.tm1.cells.transaction_log_is_active(self.cube_name))
 
+    @skip_if_deprecated_in_version(version='12')
     def test_transaction_log_is_active_true(self):
         self.tm1.cells.activate_transactionlog(self.cube_name)
 
         self.assertTrue(self.tm1.cells.transaction_log_is_active(self.cube_name))
 
+    @skip_if_deprecated_in_version(version='12')
     def test_manage_transaction_log_deactivate_reactivate(self):
         self.tm1.cubes.cells.write_values(
             self.cube_name,
@@ -3883,6 +3890,7 @@ class TestCellService(unittest.TestCase):
 
         self.assertTrue(self.tm1.cells.transaction_log_is_active(self.cube_name))
 
+    @skip_if_deprecated_in_version(version='12')
     def test_manage_transaction_log_not_deactivate_not_reactivate(self):
         pre_state = self.tm1.cells.transaction_log_is_active(self.cube_name)
 
@@ -3894,6 +3902,7 @@ class TestCellService(unittest.TestCase):
 
         self.assertEqual(pre_state, self.tm1.cells.transaction_log_is_active(self.cube_name))
 
+    @skip_if_deprecated_in_version(version='12')
     def test_manage_transaction_log_deactivate_not_reactivate(self):
         self.tm1.cubes.cells.write_values(
             self.cube_name,

--- a/Tests/CubeService_test.py
+++ b/Tests/CubeService_test.py
@@ -7,7 +7,7 @@ from TM1py import Element, Hierarchy, Dimension
 from TM1py.Objects import Cube
 from TM1py.Objects import Rules
 from TM1py.Services import TM1Service
-from .Utils import skip_if_insufficient_version
+from .Utils import skip_if_insufficient_version, skip_if_deprecated_in_version
 
 
 class TestCubeService(unittest.TestCase):
@@ -149,7 +149,7 @@ class TestCubeService(unittest.TestCase):
         self.tm1.cubes.delete(cube_name)
 
         cube = self.tm1.cubes.get(self.control_cube_name)
-        cube.rules = "#find_control_comment"
+        cube.rules = "SKIPCHECK"
         self.tm1.cubes.update(cube)
         self.assertNotEqual(self.tm1.cubes.get_all_names_with_rules(),
                             self.tm1.cubes.get_all_names_with_rules(skip_control_cubes=True))
@@ -203,9 +203,15 @@ class TestCubeService(unittest.TestCase):
         cubes = self.tm1.cubes.search_for_dimension_substring(substring="}cubes", skip_control_cubes=True)
         self.assertEqual({}, cubes)
 
-    def test_search_for_dimension_substring_skip_control_cubes_false(self):
+    @skip_if_deprecated_in_version(version="12")
+    def test_search_for_dimension_substring_skip_control_cubes_false_v11(self):
         cubes = self.tm1.cubes.search_for_dimension_substring(substring="}cubes", skip_control_cubes=False)
         self.assertEqual(cubes['}CubeProperties'], ['}Cubes'])
+
+    @skip_if_insufficient_version(version="12")
+    def test_search_for_dimension_substring_skip_control_cubes_false_v12(self):
+        cubes = self.tm1.cubes.search_for_dimension_substring(substring="}cubes", skip_control_cubes=False)
+        self.assertEqual(cubes['}CubeSecurity'], ['}Cubes'])
 
     def test_get_number_of_cubes(self):
         number_of_cubes = self.tm1.cubes.get_number_of_cubes()
@@ -222,11 +228,13 @@ class TestCubeService(unittest.TestCase):
             self.dimension_names)
 
     @skip_if_insufficient_version(version="11.6")
+    @skip_if_deprecated_in_version(version="12")
     def test_load(self):
         response = self.tm1.cubes.load(cube_name=self.cube_name)
         self.assertTrue(response.ok)
 
     @skip_if_insufficient_version(version="11.6")
+    @skip_if_deprecated_in_version(version="12")
     def test_unload(self):
         response = self.tm1.cubes.unload(cube_name=self.cube_name)
         self.assertTrue(response.ok)

--- a/Tests/HierarchyService_test.py
+++ b/Tests/HierarchyService_test.py
@@ -31,6 +31,7 @@ class TestHierarchyService(unittest.TestCase):
 
     @classmethod
     def setUp(cls):
+        cls.delete_dimension()
         cls.create_dimension()
         cls.create_subset()
 
@@ -55,7 +56,8 @@ class TestHierarchyService(unittest.TestCase):
 
     @classmethod
     def delete_dimension(cls):
-        cls.tm1.dimensions.delete(cls.dimension_name)
+        if cls.tm1.dimensions.exists(cls.dimension_name):
+            cls.tm1.dimensions.delete(cls.dimension_name)
 
     @classmethod
     def create_subset(cls):

--- a/Tests/MonitoringService_test.py
+++ b/Tests/MonitoringService_test.py
@@ -22,7 +22,9 @@ class TestMonitoringService(unittest.TestCase):
 
     def test_get_threads(self):
         threads = self.tm1.monitoring.get_threads()
-        self.assertTrue(any(thread["Function"] == "GET /api/v1/Threads" for thread in threads))
+        self.assertTrue(any(thread["Function"] == "GET /api/v1/Threads" for thread in threads)
+                        or
+                        any(thread["Function"] == "GET /Threads" for thread in threads))
 
     def test_get_active_users(self):
         current_user = self.tm1.security.get_current_user()

--- a/Tests/ProcessService_test.py
+++ b/Tests/ProcessService_test.py
@@ -29,10 +29,10 @@ class TestProcessService(unittest.TestCase):
                       datasource_ascii_header_records=2,
                       datasource_ascii_quote_character='^',
                       datasource_ascii_thousand_separator='~',
-                      prolog_procedure="sTestProlog = 'test prolog procedure'",
-                      metadata_procedure="sTestMeta = 'test metadata procedure'",
-                      data_procedure="sTestData =  'test data procedure'",
-                      epilog_procedure="sTestEpilog = 'test epilog procedure'",
+                      prolog_procedure="sTestProlog = 'test prolog procedure';",
+                      metadata_procedure="sTestMeta = 'test metadata procedure';",
+                      data_procedure="sTestData =  'test data procedure';",
+                      epilog_procedure="sTestEpilog = 'test epilog procedure';",
                       datasource_data_source_name_for_server=r'C:\Data\file.csv',
                       datasource_data_source_name_for_client=r'C:\Data\file.csv')
     p_ascii.add_variable('v_1', 'Numeric')

--- a/Tests/SandboxService_test.py
+++ b/Tests/SandboxService_test.py
@@ -194,8 +194,8 @@ class TestSandboxService(unittest.TestCase):
         self.tm1.sandboxes.create(sandbox3)
         time.sleep(1)
         self.tm1.sandboxes.unload(sandbox3.name)
-
-        loaded = (self.tm1.sandboxes.get(self.sandbox_name3)).loaded
+        sandbox = self.tm1.sandboxes.get(self.sandbox_name3)
+        loaded = sandbox.loaded
         self.assertFalse(loaded)
 
     def test_load_sandbox(self):

--- a/Tests/SecurityService_test.py
+++ b/Tests/SecurityService_test.py
@@ -7,23 +7,24 @@ from TM1py.Exceptions import TM1pyRestException
 from TM1py.Objects import User
 from TM1py.Objects.User import UserType
 from TM1py.Services import TM1Service
-from TM1py.Utils.Utils import CaseAndSpaceInsensitiveSet, case_and_space_insensitive_equals
+from TM1py.Utils.Utils import CaseAndSpaceInsensitiveSet, case_and_space_insensitive_equals, verify_version
+from .Utils import skip_if_deprecated_in_version, skip_if_insufficient_version
 
 
 class TestSecurityService(unittest.TestCase):
     tm1: TM1Service
 
     prefix = "TM1py_Tests_"
-    user_name = prefix + "Us'er1"
+    user_name = prefix + "User1"
     read_only_user_name = prefix + "Read_Only_user"
     user_name_exotic_password = "UserWithExoticPassword"
     enabled = True
     user = User(name=user_name, groups=[], password='TM1py', enabled=enabled)
     read_only_user = User(name=read_only_user_name, groups=[], password="TM1py", enabled=True)
-    group_name1 = prefix + "Gro'up1"
+    group_name1 = prefix + "Group1"
     group_name2 = prefix + "Group2"
     user.add_group(group_name1)
-    
+
     @classmethod
     def setUpClass(cls):
         """
@@ -51,9 +52,10 @@ class TestSecurityService(unittest.TestCase):
             self.tm1.security.create_user(self.user)
         if not self.tm1.security.user_exists(self.read_only_user.name):
             self.tm1.security.create_user(self.read_only_user)
-        self.tm1.cells.write_values(
-            cube_name="}ClientProperties",
-            cellset_as_dict={(self.read_only_user_name, "ReadOnlyUser"): 1})
+        if not verify_version(required_version='12', version=self.tm1.version):
+            self.tm1.cells.write_values(
+                cube_name="}ClientProperties",
+                cellset_as_dict={(self.read_only_user_name, "ReadOnlyUser"): 1})
 
     def tearDown(self):
         self.tm1.security.delete_user(self.user_name)
@@ -121,6 +123,7 @@ class TestSecurityService(unittest.TestCase):
         user = User("not_relevant", groups=["OperationsAdmin"], user_type=None)
         self.assertEqual(user.user_type, UserType.OperationsAdmin)
 
+    @skip_if_deprecated_in_version(version='12')
     def test_update_user_properties(self):
         # get user
         u = self.tm1.security.get_user(self.user_name)
@@ -141,6 +144,7 @@ class TestSecurityService(unittest.TestCase):
         self.assertEqual(u.user_type, UserType.DataAdmin)
         self.assertIn("DataAdmin", u.groups)
 
+    @skip_if_deprecated_in_version(version='12')
     def test_update_user_properties_with_type_as_str(self):
         # get user
         u = self.tm1.security.get_user(self.user_name)
@@ -263,6 +267,7 @@ class TestSecurityService(unittest.TestCase):
         self.assertIn(group, groups_before_delete)
         self.assertNotIn(group, groups_after_delete)
 
+    @skip_if_deprecated_in_version(version='12')
     def test_tm1service_with_encrypted_password_decode_b64_as_string(self):
         user_name = "TM1py user name"
         user = User(name=user_name, groups=["ADMIN"], password="apple")
@@ -281,6 +286,7 @@ class TestSecurityService(unittest.TestCase):
 
         self.tm1.security.delete_user(user.name)
 
+    @skip_if_deprecated_in_version(version='12')
     def test_tm1service_without_encrypted_password(self):
         user_name = "TM1py user name"
         user = User(name=user_name, groups=["ADMIN"], password="apple")
@@ -299,6 +305,7 @@ class TestSecurityService(unittest.TestCase):
 
         self.tm1.security.delete_user(user.name)
 
+    @skip_if_deprecated_in_version(version='12')
     def test_tm1service_with_encrypted_password(self):
         user_name = "TM1py user name"
         user = User(name=user_name, groups=["ADMIN"], password="apple")
@@ -317,6 +324,7 @@ class TestSecurityService(unittest.TestCase):
 
         self.tm1.security.delete_user(user.name)
 
+    @skip_if_deprecated_in_version(version='12')
     def test_tm1service_with_encrypted_password_fail(self):
         user_name = "TM1py user name"
         user = User(name=user_name, groups=["ADMIN"], password="apple")
@@ -333,6 +341,7 @@ class TestSecurityService(unittest.TestCase):
 
         self.tm1.security.delete_user(user.name)
 
+    @skip_if_deprecated_in_version(version='12')
     def test_tm1service_with_plain_password(self):
         user_name = "TM1py user name"
         user = User(name=user_name, groups=["ADMIN"], password="apple")
@@ -349,6 +358,7 @@ class TestSecurityService(unittest.TestCase):
             pass
         self.tm1.security.delete_user(user.name)
 
+    @skip_if_deprecated_in_version(version='12')
     def test_tm1service_with_plain_password_fail(self):
         user_name = "TM1py user name"
         user = User(name=user_name, groups=["ADMIN"], password="apple")
@@ -376,6 +386,7 @@ class TestSecurityService(unittest.TestCase):
     def test_group_exists_false(self):
         self.assertFalse(self.tm1.security.group_exists(group_name="NotAValidName"))
 
+    @skip_if_deprecated_in_version(version='12')
     def test_impersonate(self):
         tm1 = TM1Service(**self.config['tm1srv01'])
         self.assertNotEqual(self.user_name, tm1.whoami.name)
@@ -397,12 +408,14 @@ class TestSecurityService(unittest.TestCase):
 
         self.assertNotIn("NotExistingGroup", CaseAndSpaceInsensitiveSet(*custom_groups))
 
+    @skip_if_deprecated_in_version(version='12')
     def test_get_read_only_users(self):
         read_only_users = self.tm1.security.get_read_only_users()
 
         self.assertEqual(1, len(read_only_users))
         self.assertEqual(self.read_only_user_name, read_only_users[0])
 
+    @skip_if_deprecated_in_version(version='12')
     def test_update_user_password(self):
         self.tm1.security.update_user_password(user_name=self.user.name, password="new_password123")
 

--- a/Tests/ServerService_test.py
+++ b/Tests/ServerService_test.py
@@ -427,7 +427,7 @@ class TestServerService(unittest.TestCase):
     def test_session_context_default(self):
         threads = self.tm1.monitoring.get_threads()
         for thread in threads:
-            if "GET /api/v1/Threads" in thread["Function"] and thread["Name"] == self.config['tm1srv01']['user']:
+            if "GET /Threads" in thread["Function"] and thread["Name"] == self.config['tm1srv01']['user']:
                 self.assertTrue(thread["Context"] == "TM1py")
                 return
         raise Exception("Did not find my own Thread")
@@ -437,7 +437,7 @@ class TestServerService(unittest.TestCase):
         with TM1Service(**self.config['tm1srv01'], session_context=app_name) as tm1:
             threads = tm1.monitoring.get_threads()
             for thread in threads:
-                if "GET /api/v1/Threads" in thread["Function"] and thread["Name"] == self.config['tm1srv01']['user']:
+                if "GET /Threads" in thread["Function"] and thread["Name"] == self.config['tm1srv01']['user']:
                     self.assertTrue(thread["Context"] == app_name)
                     return
         raise Exception("Did not find my own Thread")

--- a/Tests/Utils.py
+++ b/Tests/Utils.py
@@ -30,7 +30,27 @@ def skip_if_insufficient_version(version):
         def wrapper(self, *args, **kwargs):
             if not verify_version(required_version=version, version=self.tm1.version):
                 return self.skipTest(
-                    f"Function '{ func.__name__, }' requires TM1 server version >= '{ version }'"
+                    f"Function '{func.__name__,}' requires TM1 server version >= '{version}'"
+                )
+            else:
+                return func(self, *args, **kwargs)
+
+        return wrapper
+
+    return wrap
+
+
+def skip_if_deprecated_in_version(version):
+    """
+    Checks whether TM1 Function Has Been Deprecated
+    """
+
+    def wrap(func):
+        @functools.wraps(func)
+        def wrapper(self, *args, **kwargs):
+            if verify_version(required_version=version, version=self.tm1.version):
+                return self.skipTest(
+                    f"Function '{func.__name__,}' requires TM1 server version < '{version}'"
                 )
             else:
                 return func(self, *args, **kwargs)

--- a/Tests/Utils_test.py
+++ b/Tests/Utils_test.py
@@ -38,35 +38,35 @@ class TestUtilsMethods(unittest.TestCase):
     def test_integerize_version(self):
         version = "11.0.00000.918"
         integerized_version = integerize_version(version)
-        self.assertEqual(110, integerized_version)
+        self.assertEqual(1100, integerized_version)
 
         version = "11.0.00100.927-0"
         integerized_version = integerize_version(version)
-        self.assertEqual(110, integerized_version)
+        self.assertEqual(1100, integerized_version)
 
         version = "11.1.00004.2"
         integerized_version = integerize_version(version)
-        self.assertEqual(111, integerized_version)
+        self.assertEqual(1110, integerized_version)
 
         version = "11.2.00000.27"
         integerized_version = integerize_version(version)
-        self.assertEqual(112, integerized_version)
+        self.assertEqual(1120, integerized_version)
 
         version = "11.3.00003.1"
         integerized_version = integerize_version(version)
-        self.assertEqual(113, integerized_version)
+        self.assertEqual(1130, integerized_version)
 
         version = "11.4.00003.8"
         integerized_version = integerize_version(version)
-        self.assertEqual(114, integerized_version)
+        self.assertEqual(1140, integerized_version)
 
         version = "11.7.00002.1"
         integerized_version = integerize_version(version)
-        self.assertEqual(117, integerized_version)
+        self.assertEqual(1170, integerized_version)
 
         version = "11.8.00000.33"
         integerized_version = integerize_version(version)
-        self.assertEqual(118, integerized_version)
+        self.assertEqual(1180, integerized_version)
 
     def test_verify_version_true(self):
         required_version = "11.7.00002.1"

--- a/Tests/Utils_test.py
+++ b/Tests/Utils_test.py
@@ -12,6 +12,7 @@ from TM1py.Utils import (
     map_cell_properties_to_compact_json_response, frame_to_significant_digits, drop_dimension_properties
 )
 
+from .Utils import skip_if_deprecated_in_version
 
 class TestUtilsMethods(unittest.TestCase):
     tm1: TM1Service
@@ -27,6 +28,7 @@ class TestUtilsMethods(unittest.TestCase):
         cls.config.read(Path(__file__).parent.joinpath("config.ini"))
         cls.tm1 = TM1Service(**cls.config["tm1srv01"])
 
+    @skip_if_deprecated_in_version(version="12")
     def test_get_instances_from_adminhost(self):
         servers = Utils.get_all_servers_from_adminhost(
             self.config["tm1srv01"]["address"]
@@ -229,71 +231,71 @@ class TestUtilsMethods(unittest.TestCase):
         self.assertTrue(resembles_mdx(mdx))
 
     def test_format_url_args_no_single_quote(self):
-        url = "/api/v1/Processes('{}')/tm1.ExecuteWithReturn?$expand=*"
+        url = "/Processes('{}')/tm1.ExecuteWithReturn?$expand=*"
         process_name = "process"
         escaped_url = format_url(url, process_name)
         self.assertEqual(
-            "/api/v1/Processes('process')/tm1.ExecuteWithReturn?$expand=*", escaped_url
+            "/Processes('process')/tm1.ExecuteWithReturn?$expand=*", escaped_url
         )
 
     def test_format_url_args_one_single_quote(self):
-        url = "/api/v1/Processes('{}')/tm1.ExecuteWithReturn?$expand=*"
+        url = "/Processes('{}')/tm1.ExecuteWithReturn?$expand=*"
         process_name = "pro'cess"
         escaped_url = format_url(url, process_name)
         self.assertEqual(
-            "/api/v1/Processes('pro''cess')/tm1.ExecuteWithReturn?$expand=*",
+            "/Processes('pro''cess')/tm1.ExecuteWithReturn?$expand=*",
             escaped_url,
         )
 
     def test_format_url_args_multi_single_quote(self):
-        url = "/api/v1/Processes('{}')/tm1.ExecuteWithReturn?$expand=*"
+        url = "/Processes('{}')/tm1.ExecuteWithReturn?$expand=*"
         process_name = "pro'ces's"
         escaped_url = format_url(url, process_name)
         self.assertEqual(
-            "/api/v1/Processes('pro''ces''s')/tm1.ExecuteWithReturn?$expand=*",
+            "/Processes('pro''ces''s')/tm1.ExecuteWithReturn?$expand=*",
             escaped_url,
         )
 
     def test_format_url_kwargs_no_single_quote(self):
-        url = "/api/v1/Processes('{process_name}')/tm1.ExecuteWithReturn?$expand=*"
+        url = "/Processes('{process_name}')/tm1.ExecuteWithReturn?$expand=*"
         process_name = "process"
         escaped_url = format_url(url, process_name=process_name)
         self.assertEqual(
-            "/api/v1/Processes('process')/tm1.ExecuteWithReturn?$expand=*", escaped_url
+            "/Processes('process')/tm1.ExecuteWithReturn?$expand=*", escaped_url
         )
 
     def test_format_url_kwargs_one_single_quote(self):
-        url = "/api/v1/Processes('{process_name}')/tm1.ExecuteWithReturn?$expand=*"
+        url = "/Processes('{process_name}')/tm1.ExecuteWithReturn?$expand=*"
         process_name = "pro'cess"
         escaped_url = format_url(url, process_name=process_name)
         self.assertEqual(
-            "/api/v1/Processes('pro''cess')/tm1.ExecuteWithReturn?$expand=*",
+            "/Processes('pro''cess')/tm1.ExecuteWithReturn?$expand=*",
             escaped_url,
         )
 
     def test_format_url_kwargs_multi_single_quote(self):
-        url = "/api/v1/Processes('{process_name}')/tm1.ExecuteWithReturn?$expand=*"
+        url = "/Processes('{process_name}')/tm1.ExecuteWithReturn?$expand=*"
         process_name = "pro'ces's"
         escaped_url = format_url(url, process_name=process_name)
         self.assertEqual(
-            "/api/v1/Processes('pro''ces''s')/tm1.ExecuteWithReturn?$expand=*",
+            "/Processes('pro''ces''s')/tm1.ExecuteWithReturn?$expand=*",
             escaped_url,
         )
 
     def test_url_parameters_add(self):
-        url = "/api/v1/Cubes('cube')/tm1.Update"
+        url = "/Cubes('cube')/tm1.Update"
         url = add_url_parameters(url, **{"!sandbox": "sandbox1"})
 
         self.assertEqual(
-            "/api/v1/Cubes('cube')/tm1.Update?!sandbox=sandbox1",
+            "/Cubes('cube')/tm1.Update?!sandbox=sandbox1",
             url)
 
     def test_url_parameters_add_with_query_options(self):
-        url = "/api/v1/Cellsets('abcd')?$expand=Cells($select=Value)"
+        url = "/Cellsets('abcd')?$expand=Cells($select=Value)"
         url = add_url_parameters(url, **{"!sandbox": "sandbox1"})
 
         self.assertEqual(
-            "/api/v1/Cellsets('abcd')?$expand=Cells($select=Value)&!sandbox=sandbox1",
+            "/Cellsets('abcd')?$expand=Cells($select=Value)&!sandbox=sandbox1",
             url)
 
     def test_get_seconds_from_duration(self):

--- a/Tests/config.ini
+++ b/Tests/config.ini
@@ -1,13 +1,13 @@
-[tm1srv01]
+[tm1srv02]
 address=localhost
 port=12354
 user=admin
 password=apple
 ssl=True
 
-[tm1srv02]
-address=10.77.19.60
-port=9699
+[tm1srv01]
+address=awstm1-ux-d01
+port=8010
 user=Admin
 password=apple
-ssl=False
+ssl=True

--- a/Tests/config.ini
+++ b/Tests/config.ini
@@ -6,8 +6,9 @@ password=apple
 ssl=True
 
 [tm1srv01]
-address=awstm1-ux-d01
+address=
 port=8010
 user=Admin
 password=apple
 ssl=True
+


### PR DESCRIPTION
Approved to contribute.

These changes enable TM1py to support TM1v12. Changes include

• Changes to all service URL definitions
• New methods to define the service root url
• Support for service-to-service auth model
• Expanded support for new endpoints like setting default members
• Updates to all unit tests to ensure backwards compatibility
• Added error checking for poorly configured OpenShift Networking domains which can lead to mal formed cookies and an invalid session
• Updates to the FileService to support new resource path standards
• New ManagerService to wrap the control plane API

Enjoy!