### PR TITLE
Add method to delete elements

### DIFF
--- a/TM1py/Services/ElementService.py
+++ b/TM1py/Services/ElementService.py
@@ -73,6 +73,13 @@ class ElementService(ObjectService):
             element_name)
         return self._rest.DELETE(url, **kwargs)
 
+    def delete_elements(self, dimension_name: str, hierarchy_name: str, elements: str= None, **kwargs):
+        h_service = self._get_hierarchy_service()
+        h = h_service.get(dimension_name, hierarchy_name)
+        for ele in elements:
+            h.remove_element(ele)
+        h_service.update(h)
+
     def get_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[Element]:
         url = format_url(
             "/api/v1/Dimensions('{}')/Hierarchies('{}')/Elements?select=Name,Type",


### PR DESCRIPTION
Currently only a element by element delete method exists in the element service. This is really slow when iterating over. 

The Odata v4 rest api does not support deleting multiple elements at once, so this implementation uses a workaround suggested by Hubert Heijkers (https://community.ibm.com/community/user/businessanalytics/communities/community-home/digestviewer/viewthread?GroupId=3067&MessageKey=43fd0611-5665-4367-b250-f4278dba6ac6&CommunityKey=8fde0600-e22b-4178-acf5-bf4eda43146b&tab=digestviewer). The hierarchy object is patched instead of trying to delete a collection of entities.

