### PR TITLE
Add `update_or_create_hierarchy_from_dataframe` Function

### DIFF
--- a/TM1py/Services/ElementService.py
+++ b/TM1py/Services/ElementService.py
@@ -899,7 +899,7 @@ class ElementService(ObjectService):
 
         return self._rest.POST(url=url, data=json.dumps(body), **kwargs)
 
-    def add_elements(self, dimension_name: str, hierarchy_name: str, elements: List[Element], **kwargs):
+    def add_elements(self, dimension_name: str, hierarchy_name: str, elements: Iterable[Element], **kwargs):
         """ Add elements to hierarchy. Fails if one element already exists.
 
         :param dimension_name:

--- a/TM1py/Services/HierarchyService.py
+++ b/TM1py/Services/HierarchyService.py
@@ -1,16 +1,26 @@
 # -*- coding: utf-8 -*-
+
+try:
+    import pandas as pd
+
+    _has_pandas = True
+except ImportError:
+    _has_pandas = False
+
 import json
+import math
 from typing import Dict, Tuple, List, Optional
 
 from requests import Response
 
-from TM1py.Objects import Hierarchy, Element, ElementAttribute
+from TM1py.Exceptions import TM1pyRestException
+from TM1py.Objects import Hierarchy, Element, ElementAttribute, Dimension
 from TM1py.Services.ElementService import ElementService
 from TM1py.Services.ObjectService import ObjectService
 from TM1py.Services.RestService import RestService
 from TM1py.Services.SubsetService import SubsetService
 from TM1py.Utils.Utils import case_and_space_insensitive_equals, format_url, CaseAndSpaceInsensitiveDict, \
-    CaseAndSpaceInsensitiveSet
+    CaseAndSpaceInsensitiveSet, CaseAndSpaceInsensitiveTuplesDict, require_pandas, require_admin
 
 
 class HierarchyService(ObjectService):
@@ -26,6 +36,30 @@ class HierarchyService(ObjectService):
         super().__init__(rest)
         self.subsets = SubsetService(rest)
         self.elements = ElementService(rest)
+
+    @staticmethod
+    def _validate_alias_uniqueness(df: 'pd.DataFrame'):
+        # map alias values against their principal element name
+        seen_values = CaseAndSpaceInsensitiveDict()
+
+        for row in df.itertuples(index=False):
+            normalized_row = tuple(col.strip().lower() for col in row)
+            element_name, *alias_values = normalized_row
+            # Register e.g. 'Deutschand' -> 'Deutschand'
+            seen_values[element_name] = element_name
+
+            for value in alias_values:
+                if not value:
+                    continue
+
+                if value in seen_values:
+                    # Duplicate entries
+                    if case_and_space_insensitive_equals(element_name, seen_values[value]):
+                        continue
+
+                    raise ValueError(f"Invalid alias value found in record {tuple(row)}")
+                # Register e.g. 'Deutschand' -> 'Germany'
+                seen_values[value] = element_name
 
     def create(self, hierarchy: Hierarchy, **kwargs):
         """ Create a hierarchy in an existing dimension
@@ -110,7 +144,7 @@ class HierarchyService(ObjectService):
     def update_or_create(self, hierarchy: Hierarchy, **kwargs):
         """ update if exists else create
 
-        :param Hierarchy:
+        :param hierarchy:
         :return:
         """
         if self.exists(dimension_name=hierarchy.dimension_name, hierarchy_name=hierarchy.name, **kwargs):
@@ -331,3 +365,248 @@ class HierarchyService(ObjectService):
             return False
         else:
             raise RuntimeError(f"Unexpected return value from TM1 API request: {str(structure)}")
+
+    @require_pandas
+    @require_admin
+    def update_or_create_hierarchy_from_dataframe(
+            self,
+            dimension_name: str,
+            hierarchy_name: str,
+            df: pd.DataFrame,
+            element_column: str = None,
+            verify_unique_elements: bool = False,
+            element_types_column: str = 'ElementType',
+            unwind: bool = False):
+        """
+
+        :param dimension_name:
+        :param hierarchy_name:
+        :param df: pd.DataFrame
+        :param element_types_column: str
+            The column name in the df which specifies which element is which type. If None, all will be considered N level.
+        :param element_column: str
+            The column name of the element ID. If None, assumes first column is the element ID.
+        :param unwind: bool
+            Unwind hierarch before creating new edges
+        :return:
+
+        """
+        # element ID is in first column if not specified.
+        element_column = df.columns[0] if not element_column else element_column
+        df[element_column] = df[element_column].astype(str)
+
+        # assume all Numeric if no type is provided
+        if element_types_column not in df.columns:
+            df[element_types_column] = "Numeric"
+
+        # verify uniqueness of element names
+        if verify_unique_elements:
+            unique_element_names = len(set(df[element_column].str.lower().str.replace(' ', '')))
+            if df.shape[0] != unique_element_names:
+                raise ValueError("There must be no duplicates in the element column")
+
+        # verify alias uniqueness
+        alias_columns = tuple([col for col in df.columns if col.lower().endswith((":a", ":alias"))])
+        if len(alias_columns) > 0:
+            self._validate_alias_uniqueness(df=df[[element_column, *alias_columns]])
+
+        # identify level columns
+        level_columns = []
+        level_weight_columns = []
+        # sort to assure right order of levels
+        for column in sorted(df.columns, reverse=True):
+            if column.lower().startswith('level') and column[5:8].isdigit():
+                if len(column) == 8:
+                    level_columns.append(column)
+                elif len(column) == 15 and column.lower().endswith('_weight'):
+                    level_weight_columns.append(column)
+
+        if not len(level_columns) == len(level_weight_columns):
+            raise ValueError("Number of level columns must be equal to number of level weight columns")
+
+        hierarchy_exists = self.exists(dimension_name, hierarchy_name)
+
+        if not hierarchy_exists:
+            existing_element_identifiers = set()
+        else:
+            existing_element_identifiers = self.elements.get_all_element_identifiers(
+                dimension_name=dimension_name,
+                hierarchy_name=hierarchy_name)
+
+        if not hierarchy_exists:
+            hierarchy = Hierarchy(name=hierarchy_name, dimension_name=dimension_name)
+            dimension_service = self.get_dimension_service()
+            if not dimension_service.exists(dimension_name):
+                dimension = Dimension(name=dimension_name, hierarchies=[hierarchy])
+                dimension_service.create(dimension)
+            else:
+                hierarchy = Hierarchy(name=hierarchy_name, dimension_name=dimension_name)
+                self.create(hierarchy)
+
+        # determine new elements based on Element Name column
+        elements_to_create = CaseAndSpaceInsensitiveDict({
+            element_name: Element.Types(element_type)
+            for element_name, element_type
+            in df.loc[
+                ~df[element_column].isin(existing_element_identifiers),
+                (element_column, element_types_column)
+            ].itertuples(index=False)
+        })
+
+        # determine new consolidations based on level columns
+        for element_name in df[[*level_columns]].stack().unique():
+            if not element_name:
+                continue
+            if element_name in existing_element_identifiers:
+                continue
+            if element_name in elements_to_create and elements_to_create[element_name] != Element.Types.CONSOLIDATED:
+                raise ValueError(f"Inconsistent Type for element: '{element_name}' in hierarchy '{hierarchy_name}'")
+            elements_to_create[element_name] = Element.Types.CONSOLIDATED
+
+        if elements_to_create:
+            # add these elements to hierarchy in tm1
+            self.elements.add_elements(
+                dimension_name=dimension_name,
+                hierarchy_name=hierarchy_name,
+                elements=(
+                    Element(element_name, element_type)
+                    for element_name, element_type in
+                    elements_to_create.items()))
+
+        # identify level columns
+        level_columns = []
+        level_weight_columns = []
+        # sort to assure right order of levels
+        for column in sorted(df.columns, reverse=True):
+            if column.lower().startswith('level') and column[5:8].isdigit():
+                if len(column) == 8:
+                    level_columns.append(column)
+                elif len(column) == 15 and column.lower().endswith('_weight'):
+                    level_weight_columns.append(column)
+
+        if not len(level_columns) == len(level_weight_columns):
+            raise ValueError("Number of level columns must be equal to number of level weight columns")
+
+        # define the attribute columns in df. Applies to all elements in df, not only new ones.
+        attribute_columns = df.columns.drop(
+            labels=[element_column] + [element_types_column] + level_columns + level_weight_columns,
+            errors='ignore')
+
+        # new attributes are created as strings if no type is provided
+        try:
+            existing_attributes = self.elements.get_all_element_identifiers(
+                dimension_name='}ElementAttributes_' + dimension_name,
+                hierarchy_name='}ElementAttributes_' + hierarchy_name)
+        except TM1pyRestException as ex:
+            if ex.status_code == 404:
+                existing_attributes = set()
+            else:
+                raise ex
+
+        new_attributes = []
+        for attribute_column in attribute_columns:
+            if ':' in attribute_column:
+                attribute_name, attribute_type = attribute_column.rsplit(":", maxsplit=1)
+                attribute_type = self._attribute_type_from_code(attribute_type)
+
+            else:
+                attribute_name = attribute_column
+                attribute_type = ElementAttribute.Types.STRING
+
+            if attribute_name not in existing_attributes:
+                new_attributes.append(ElementAttribute(attribute_name, attribute_type))
+
+        self.elements.add_element_attributes(
+            dimension_name=dimension_name,
+            hierarchy_name=hierarchy_name,
+            element_attributes=new_attributes)
+
+        # define attributes df with ID + attribute columns.
+        id_attribute_cols = [element_column] + list(attribute_columns.values)
+        attributes_df: pd.DataFrame = df.loc[:, id_attribute_cols]
+
+        # melt for write structure (ID, Attribute) : Attribute_value
+        attributes_df = attributes_df.melt(
+            id_vars=element_column,
+            value_vars=attribute_columns,
+            var_name='}ElementAttributes_' + dimension_name,
+            value_name='attribute_value',)
+        attributes_df.fillna('', inplace=True)
+
+        # drop ':' suffix in attribute column
+        attribute_column = '}ElementAttributes_' + dimension_name
+        attributes_df[attribute_column] = attributes_df[attribute_column].apply(lambda x: x.rsplit(':', 1)[0])
+
+        # write attributes to cube
+        cell_service = self.get_cell_service()
+        cell_service.write_dataframe(
+            cube_name='}ElementAttributes_' + dimension_name,
+            data=attributes_df,
+            sum_numeric_duplicates=False,
+            use_blob=True)
+
+        if unwind:
+            self.remove_all_edges(dimension_name, hierarchy_name)
+
+        edges = CaseAndSpaceInsensitiveTuplesDict()
+        for element_name, *record in df[[element_column, *level_columns, *level_weight_columns]].itertuples(
+                index=False):
+            levels = record[:len(level_columns)]
+            level_weights = record[len(level_columns):]
+
+            previous_level = element_name
+            for level, weight in zip(levels, level_weights):
+                if not level:
+                    continue
+                if not isinstance(level, str) and math.isnan(level):
+                    continue
+                if level == previous_level:
+                    continue
+
+                edges[level, previous_level] = weight
+                previous_level = level
+
+        if edges:
+            try:
+                current_edges = self.elements.get_edges(
+                    dimension_name=dimension_name,
+                    hierarchy_name=hierarchy_name)
+            except TM1pyRestException as ex:
+                if ex.status_code == 404:
+                    current_edges = CaseAndSpaceInsensitiveTuplesDict()
+                else:
+                    raise ex
+
+            new_edges = {
+                (k, v): w
+                for (k, v), w
+                in edges.items()
+                if (k, v) not in current_edges or w != current_edges[(k, v)]}
+            self.elements.add_edges(dimension_name=dimension_name, hierarchy_name=hierarchy_name, edges=new_edges)
+
+    def get_dimension_service(self):
+        from TM1py import DimensionService
+        return DimensionService(self._rest)
+
+    def get_cell_service(self):
+        from TM1py import CellService
+        return CellService(self._rest)
+
+    @staticmethod
+    def _attribute_type_from_code(attribute_type: str) -> ElementAttribute.Types:
+        attribute_type = attribute_type.lower()
+        if attribute_type not in ["a", "s", "n"] and attribute_type not in ElementAttribute.Types:
+            raise ValueError(f"Attribute Type '{attribute_type}' is not a valid "
+                             f"value: 'a', 's', 'n', 'alias', 'string', 'numeric'")
+
+        if attribute_type == 'a':
+            return ElementAttribute.Types.ALIAS
+
+        if attribute_type == 's':
+            return ElementAttribute.Types.STRING
+
+        if attribute_type == 'n':
+            return ElementAttribute.Types.NUMERIC
+
+        else:
+            return ElementAttribute.Types(attribute_type)

--- a/Tests/HierarchyService_test.py
+++ b/Tests/HierarchyService_test.py
@@ -554,7 +554,7 @@ class TestHierarchyService(unittest.TestCase):
             hierarchy_name=self.region_dimension_name,
             df=df,
             element_column=self.region_dimension_name,
-            element_types_column="ElementType",
+            element_type_column="ElementType",
             unwind=True
         )
         hierarchy = self.tm1.hierarchies.get(self.region_dimension_name, self.region_dimension_name)
@@ -597,7 +597,7 @@ class TestHierarchyService(unittest.TestCase):
             hierarchy_name=self.region_dimension_name,
             df=df,
             element_column=self.region_dimension_name,
-            element_types_column="ElementType",
+            element_type_column="ElementType",
             unwind=True
         )
 
@@ -623,7 +623,7 @@ class TestHierarchyService(unittest.TestCase):
             hierarchy_name=self.region_dimension_name,
             df=df,
             element_column=self.region_dimension_name,
-            element_types_column="ElementType",
+            element_type_column="ElementType",
             unwind=True
         )
 
@@ -721,7 +721,7 @@ class TestHierarchyService(unittest.TestCase):
                 hierarchy_name=self.region_dimension_name,
                 df=df,
                 element_column=self.region_dimension_name,
-                element_types_column="ElementType",
+                element_type_column="ElementType",
                 unwind=True)
 
     def test_update_or_create_hierarchy_from_dataframe_duplicate_records(self):
@@ -740,7 +740,7 @@ class TestHierarchyService(unittest.TestCase):
             hierarchy_name=self.region_dimension_name,
             df=df,
             element_column=self.region_dimension_name,
-            element_types_column="ElementType",
+            element_type_column="ElementType",
             unwind=True)
 
         hierarchy = self.tm1.hierarchies.get(
@@ -766,7 +766,7 @@ class TestHierarchyService(unittest.TestCase):
             hierarchy_name=self.region_dimension_name,
             df=df,
             element_column=self.region_dimension_name,
-            element_types_column="ElementType",
+            element_type_column="ElementType",
             unwind=True)
 
         hierarchy = self.tm1.hierarchies.get(
@@ -793,7 +793,7 @@ class TestHierarchyService(unittest.TestCase):
                 hierarchy_name=self.region_dimension_name,
                 df=df,
                 element_column=self.region_dimension_name,
-                element_types_column="ElementType",
+                element_type_column="ElementType",
                 unwind=True)
 
     def test_update_or_create_hierarchy_from_dataframe_circular_reference(self):
@@ -814,7 +814,7 @@ class TestHierarchyService(unittest.TestCase):
                 hierarchy_name=self.region_dimension_name,
                 df=df,
                 element_column=self.region_dimension_name,
-                element_types_column="ElementType",
+                element_type_column="ElementType",
                 unwind=True
             )
 
@@ -836,7 +836,7 @@ class TestHierarchyService(unittest.TestCase):
                 hierarchy_name=self.region_dimension_name,
                 df=df,
                 element_column=self.region_dimension_name,
-                element_types_column="ElementType",
+                element_type_column="ElementType",
                 unwind=True
             )
 

--- a/Tests/HierarchyService_test.py
+++ b/Tests/HierarchyService_test.py
@@ -1,9 +1,13 @@
 import configparser
 import unittest
+from contextlib import suppress
 from pathlib import Path
 
+from mdxpy import MdxBuilder, MdxHierarchySet
+from pandas import DataFrame
+
 from TM1py import Element, ElementAttribute
-from TM1py.Exceptions import TM1pyException
+from TM1py.Exceptions import TM1pyException, TM1pyRestException
 from TM1py.Objects import Dimension, Hierarchy, Subset
 from TM1py.Services import TM1Service
 
@@ -13,6 +17,8 @@ class TestHierarchyService(unittest.TestCase):
     prefix = 'TM1py_Tests_Hierarchy_'
     dimension_name = prefix + "Some_Name"
     subset_name = prefix + "Some_Subset"
+
+    region_dimension_name = prefix + "Region"
 
     @classmethod
     def setUpClass(cls):
@@ -36,7 +42,7 @@ class TestHierarchyService(unittest.TestCase):
 
     @classmethod
     def tearDown(cls):
-        cls.delete_dimension()
+        cls.delete_dimensions()
 
     @classmethod
     def create_dimension(cls):
@@ -51,17 +57,20 @@ class TestHierarchyService(unittest.TestCase):
         hierarchy.add_element_attribute('Updateable Attribute', 'String')
         hierarchy.add_edge('Total Years', '1989', 2)
         dimension.add_hierarchy(hierarchy)
-        cls.tm1.dimensions.create(dimension)
+        cls.tm1.dimensions.update_or_create(dimension)
 
     @classmethod
-    def delete_dimension(cls):
-        cls.tm1.dimensions.delete(cls.dimension_name)
+    def delete_dimensions(cls):
+        with suppress(TM1pyRestException):
+            cls.tm1.dimensions.delete(cls.dimension_name)
+        with suppress(TM1pyRestException):
+            cls.tm1.dimensions.delete(cls.region_dimension_name)
 
     @classmethod
     def create_subset(cls):
         s = Subset(cls.subset_name, cls.dimension_name, cls.dimension_name,
                    expression="{{[{}].Members}}".format(cls.dimension_name))
-        cls.tm1.dimensions.subsets.create(s, False)
+        cls.tm1.subsets.update_or_create(s, False)
 
     def add_other_hierarchy(self):
         dimension = self.tm1.dimensions.get(self.dimension_name)
@@ -427,6 +436,365 @@ class TestHierarchyService(unittest.TestCase):
         hierarchy = self.tm1.hierarchies.get(self.dimension_name, self.dimension_name)
         self.assertGreater(len(hierarchy.elements), 0)
         self.assertEqual(len(hierarchy.edges), 0)
+
+    def _verify_region_dimension(self, hierarchy):
+        self._verify_region_elements(hierarchy)
+        self._verify_region_edges(hierarchy)
+        self._verify_region_attributes(hierarchy)
+
+    def _verify_region_edges(self, hierarchy):
+        self.assertEqual(1, hierarchy.edges["Europe", "France"])
+        self.assertEqual(1, hierarchy.edges["Europe", "Switzerland"])
+        self.assertEqual(1, hierarchy.edges["Europe", "Germany"])
+
+    def _verify_region_elements(self, hierarchy):
+        self.assertIn(Element("France", "Numeric"), hierarchy.elements.values())
+        self.assertIn(Element("Switzerland", "Numeric"), hierarchy.elements.values())
+        self.assertIn(Element("Germany", "Numeric"), hierarchy.elements.values())
+
+    def _verify_region_attributes(self, hierarchy, ignore_type_differences: bool = False):
+        self.assertIn(ElementAttribute("Currency", "String"), hierarchy.element_attributes)
+        self.assertIn(ElementAttribute("Population", "Numeric"), hierarchy.element_attributes)
+        self.assertIn(ElementAttribute("Alias", "Alias"), hierarchy.element_attributes)
+
+        q = MdxBuilder.from_cube("}ElementAttributes_" + self.region_dimension_name)
+        q.add_hierarchy_set_to_column_axis(MdxHierarchySet.tm1_subset_all(
+            self.region_dimension_name,
+            self.region_dimension_name))
+        q.add_hierarchy_set_to_column_axis(MdxHierarchySet.tm1_subset_all(
+            "}ElementAttributes_" + self.region_dimension_name,
+            "}ElementAttributes_" + self.region_dimension_name))
+        attribute_values = self.tm1.cells.execute_mdx(
+            mdx=q.to_mdx(),
+            skip_cell_properties=True,
+            element_unique_names=False)
+
+        self.assertEqual("Frankreich", attribute_values["France", "Alias"])
+        self.assertEqual("Schweiz", attribute_values["Switzerland", "Alias"])
+        self.assertEqual("Deutschland", attribute_values["Germany", "Alias"])
+        self.assertEqual("EUR", attribute_values["France", "Currency"])
+        self.assertEqual("CHF", attribute_values["Switzerland", "Currency"])
+        self.assertEqual("EUR", attribute_values["Germany", "Currency"])
+
+        if ignore_type_differences:
+            self.assertEqual(60_000_000, attribute_values["France", "Population"])
+            self.assertEqual(9_000_000, attribute_values["Switzerland", "Population"])
+            self.assertEqual(84_000_000, attribute_values["Germany", "Population"])
+        else:
+            self.assertEqual('60000000', str(attribute_values["France", "Population"]))
+            self.assertEqual('9000000', str(attribute_values["Switzerland", "Population"]))
+            self.assertEqual('84000000', str(attribute_values["Germany", "Population"]))
+
+    def test_update_or_create_hierarchy_from_dataframe_with_attributes_without_suffix(self):
+        columns = [self.region_dimension_name, "Alias", "Currency", "population"]
+        data = [
+            ['France', "Frankreich", "EUR", 60_000_000],
+            ['Switzerland', "Schweiz", "CHF", 9_000_000],
+            ['Germany', "Deutschland", "EUR", 84_000_000],
+        ]
+        df = DataFrame(data=data, columns=columns)
+
+        self.tm1.hierarchies.update_or_create_hierarchy_from_dataframe(
+            dimension_name=self.region_dimension_name,
+            hierarchy_name=self.region_dimension_name,
+            df=df,
+            element_column=self.region_dimension_name,
+            unwind=True
+        )
+
+        hierarchy = self.tm1.hierarchies.get(self.region_dimension_name, self.region_dimension_name)
+        self._verify_region_attributes(hierarchy)
+
+    def test_update_or_create_hierarchy_from_dataframe_on_preexisting_hierarchy(self):
+        columns = [self.region_dimension_name, "Alias"]
+        data = [
+            ['France', "Frankreich"],
+            ['Switzerland', "Schweiz"],
+            ['Germany', "Deutschland"],
+        ]
+        df = DataFrame(data=data, columns=columns)
+        self.tm1.hierarchies.update_or_create_hierarchy_from_dataframe(
+            dimension_name=self.region_dimension_name,
+            hierarchy_name=self.region_dimension_name,
+            df=df,
+            element_column=self.region_dimension_name,
+            unwind=True
+        )
+
+        columns = [self.region_dimension_name, "Currency", "population"]
+        data = [
+            ['France', "EUR", 60_000_000],
+            ['Switzerland', "CHF", 9_000_000],
+            ['Germany', "EUR", 84_000_000],
+        ]
+        df = DataFrame(data=data, columns=columns)
+        self.tm1.hierarchies.update_or_create_hierarchy_from_dataframe(
+            dimension_name=self.region_dimension_name,
+            hierarchy_name=self.region_dimension_name,
+            df=df,
+            element_column=self.region_dimension_name,
+            unwind=True
+        )
+
+        hierarchy = self.tm1.hierarchies.get(self.region_dimension_name, self.region_dimension_name)
+        self._verify_region_attributes(hierarchy)
+
+    def test_update_or_create_hierarchy_from_dataframe_on_preexisting_hierarchy_with_unwind(self):
+        columns = [self.region_dimension_name, "ElementType", "Alias:a", "Currency:s", "population:n", "level001",
+                   "level000", "level001_weight", "level000_weight"]
+        data = [
+            ['France', "Numeric", "Frankreich", "EUR", 60_000_000, "Europe", "World", 1, 1],
+            ['Switzerland', 'Numeric', "Schweiz", "CHF", 9_000_000, "Europe", "World", 1, 1],
+            ['Germany', 'Numeric', "Deutschland", "EUR", 84_000_000, "Europe", "World", 1, 1],
+        ]
+        df = DataFrame(data=data, columns=columns)
+
+        self.tm1.hierarchies.update_or_create_hierarchy_from_dataframe(
+            dimension_name=self.region_dimension_name,
+            hierarchy_name=self.region_dimension_name,
+            df=df,
+            element_column=self.region_dimension_name,
+            element_types_column="ElementType",
+            unwind=True
+        )
+        hierarchy = self.tm1.hierarchies.get(self.region_dimension_name, self.region_dimension_name)
+        # Assert that edges exist
+        self._verify_region_dimension(hierarchy)
+
+        columns = [self.region_dimension_name, "Alias"]
+        data = [
+            ['France', "Frankreich"],
+            ['Switzerland', "Schweiz"],
+            ['Germany', "Deutschland"],
+        ]
+        df = DataFrame(data=data, columns=columns)
+        self.tm1.hierarchies.update_or_create_hierarchy_from_dataframe(
+            dimension_name=self.region_dimension_name,
+            hierarchy_name=self.region_dimension_name,
+            df=df,
+            element_column=self.region_dimension_name,
+            unwind=True
+        )
+
+        hierarchy = self.tm1.hierarchies.get(self.region_dimension_name, self.region_dimension_name)
+        self._verify_region_attributes(hierarchy)
+
+        # assert that no edges exist
+        self.assertEqual(dict(), hierarchy.edges)
+
+    def test_update_or_create_hierarchy_from_dataframe(self):
+        columns = [self.region_dimension_name, "ElementType", "Alias:a", "Currency:s", "population:n", "level001",
+                   "level000", "level001_weight", "level000_weight"]
+        data = [
+            ['France', "Numeric", "Frankreich", "EUR", 60_000_000, "Europe", "World", 1, 1],
+            ['Switzerland', 'Numeric', "Schweiz", "CHF", 9_000_000, "Europe", "World", 1, 1],
+            ['Germany', 'Numeric', "Deutschland", "EUR", 84_000_000, "Europe", "World", 1, 1],
+        ]
+        df = DataFrame(data=data, columns=columns)
+
+        self.tm1.hierarchies.update_or_create_hierarchy_from_dataframe(
+            dimension_name=self.region_dimension_name,
+            hierarchy_name=self.region_dimension_name,
+            df=df,
+            element_column=self.region_dimension_name,
+            element_types_column="ElementType",
+            unwind=True
+        )
+
+        hierarchy = self.tm1.hierarchies.get(
+            dimension_name=self.region_dimension_name,
+            hierarchy_name=self.region_dimension_name)
+        self._verify_region_dimension(hierarchy)
+
+    def test_update_or_create_hierarchy_from_dataframe_with_consolidations(self):
+        columns = [self.region_dimension_name, "ElementType", "Alias:a", "Currency:s", "population:n", "level001",
+                   "level000", "level001_weight", "level000_weight"]
+        data = [
+            ['France', "Numeric", "Frankreich", "EUR", 60_000_000, "Europe", "World", 1, 1],
+            ['Switzerland', 'Numeric', "Schweiz", "CHF", 9_000_000, "Europe", "World", 1, 1],
+            ['Germany', 'Numeric', "Deutschland", "EUR", 84_000_000, "Europe", "World", 1, 1],
+            ["Europe", "Consolidated", "", "", "", "", "", 0, 0],
+            ["World", "Consolidated", "", "", "", "", "", 0, 0],
+        ]
+        df = DataFrame(data=data, columns=columns)
+
+        self.tm1.hierarchies.update_or_create_hierarchy_from_dataframe(
+            dimension_name=self.region_dimension_name,
+            hierarchy_name=self.region_dimension_name,
+            df=df,
+            element_column=self.region_dimension_name,
+            element_types_column="ElementType",
+            unwind=True
+        )
+
+        hierarchy = self.tm1.hierarchies.get(
+            dimension_name=self.region_dimension_name,
+            hierarchy_name=self.region_dimension_name)
+        self._verify_region_dimension(hierarchy)
+
+    def test_update_or_create_hierarchy_from_dataframe_with_no_element_type(self):
+        columns = ["Element Name", "Alias:a", "Currency:s", "population:n", "level001",
+                   "level000", "level001_weight", "level000_weight"]
+        data = [
+            ['France', "Frankreich", "EUR", 60_000_000, "Europe", "World", 1, 1],
+            ['Switzerland', "Schweiz", "CHF", 9_000_000, "Europe", "World", 1, 1],
+            ['Germany', "Deutschland", "EUR", 84_000_000, "Europe", "World", 1, 1],
+        ]
+        df = DataFrame(data=data, columns=columns)
+
+        self.tm1.hierarchies.update_or_create_hierarchy_from_dataframe(
+            dimension_name=self.region_dimension_name,
+            hierarchy_name=self.region_dimension_name,
+            df=df,
+            element_column="Element Name",
+            unwind=True
+        )
+
+        hierarchy = self.tm1.hierarchies.get(
+            dimension_name=self.region_dimension_name,
+            hierarchy_name=self.region_dimension_name)
+        self._verify_region_dimension(hierarchy)
+
+    def test_update_or_create_hierarchy_from_dataframe_without_levels(self):
+        columns = ["Element Name", "Alias:a", "Currency:s", "population:n"]
+        data = [
+            ['France', "Frankreich", "EUR", 60_000_000],
+            ['Switzerland', "Schweiz", "CHF", 9_000_000],
+            ['Germany', "Deutschland", "EUR", 84_000_000],
+        ]
+        df = DataFrame(data=data, columns=columns)
+
+        self.tm1.hierarchies.update_or_create_hierarchy_from_dataframe(
+            dimension_name=self.region_dimension_name,
+            hierarchy_name=self.region_dimension_name,
+            df=df,
+            element_column="Element Name",
+            unwind=True)
+
+        hierarchy = self.tm1.hierarchies.get(
+            dimension_name=self.region_dimension_name,
+            hierarchy_name=self.region_dimension_name)
+        self._verify_region_attributes(hierarchy)
+
+    def test_update_or_create_hierarchy_from_dataframe_imbalanced(self):
+        columns = [self.region_dimension_name, "ElementType", "Alias:a", "Currency:s", "population:n", "level002",
+                   "level001", "level000", "level002_weight", "level001_weight", "level000_weight"]
+        data = [
+            ['France', "Numeric", "Frankreich", "EUR", 60_000_000, "", "Europe", "World", 0, 1, 1],
+            ['Switzerland', 'Numeric', "Schweiz", "CHF", 9_000_000, "DACH", "Europe", "World", 1, 1, 1],
+            ['Germany', 'Numeric', "Deutschland", "EUR", 84_000_000, "DACH", "Europe", "World", 1, 1, 1],
+        ]
+        df = DataFrame(data=data, columns=columns)
+
+        self.tm1.hierarchies.update_or_create_hierarchy_from_dataframe(
+            dimension_name=self.region_dimension_name,
+            hierarchy_name=self.region_dimension_name,
+            df=df,
+            unwind=True
+        )
+
+        hierarchy = self.tm1.hierarchies.get(
+            dimension_name=self.region_dimension_name,
+            hierarchy_name=self.region_dimension_name)
+        self._verify_region_attributes(hierarchy)
+
+        self.assertEqual(1, hierarchy.edges["Europe", "France"])
+        self.assertEqual(1, hierarchy.edges["Europe", "DACH"])
+        self.assertEqual(1, hierarchy.edges["Europe", "DACH"])
+        self.assertEqual(1, hierarchy.edges["DACH", "Germany"])
+        self.assertEqual(1, hierarchy.edges["DACH", "Switzerland"])
+
+    def test_update_or_create_hierarchy_from_dataframe_inconsistent_records(self):
+        columns = [self.region_dimension_name, "ElementType", "Alias:a", "Currency:s", "population:n", "level001",
+                   "level000", "level001_weight", "level000_weight"]
+        data = [
+            ['France', "Numeric", "Frankreich", "EUR", 60_000_000, "Europe", "World", 1, 1],
+            ['Switzerland', 'Numeric', "Schweiz", "CHF", 9_000_000, "Europe", "World", 1, 1],
+            ['Germany', 'Numeric', "Deutschland", "EUR", 84_000_000, "Europe", "World", 1, 1],
+            ['Europe', "Numeric", "Europa", "EUR", 420_000_000, "", "World", 0, 1],
+        ]
+        df = DataFrame(data=data, columns=columns)
+
+        with self.assertRaises(ValueError):
+            self.tm1.hierarchies.update_or_create_hierarchy_from_dataframe(
+                dimension_name=self.region_dimension_name,
+                hierarchy_name=self.region_dimension_name,
+                df=df,
+                element_column=self.region_dimension_name,
+                element_types_column="ElementType",
+                unwind=True)
+
+    def test_update_or_create_hierarchy_from_dataframe_duplicate_records(self):
+        columns = [self.region_dimension_name, "ElementType", "Alias:a", "Currency:s", "population:n", "level001",
+                   "level000", "level001_weight", "level000_weight"]
+        data = [
+            ['France', "Numeric", "Frankreich", "EUR", 60_000_000, "Europe", "World", 1, 1],
+            ['France', "Numeric", "Frankreich", "EUR", 60_000_000, "Europe", "World", 1, 1],
+            ['Switzerland', 'Numeric', "Schweiz", "CHF", 9_000_000, "Europe", "World", 1, 1],
+            ['Germany', 'Numeric', "Deutschland", "EUR", 84_000_000, "Europe", "World", 1, 1],
+        ]
+        df = DataFrame(data=data, columns=columns)
+
+        self.tm1.hierarchies.update_or_create_hierarchy_from_dataframe(
+            dimension_name=self.region_dimension_name,
+            hierarchy_name=self.region_dimension_name,
+            df=df,
+            element_column=self.region_dimension_name,
+            element_types_column="ElementType",
+            unwind=True)
+
+        hierarchy = self.tm1.hierarchies.get(
+            dimension_name=self.region_dimension_name,
+            hierarchy_name=self.region_dimension_name)
+        self._verify_region_dimension(hierarchy)
+
+    def test_update_or_create_hierarchy_from_dataframe_multi_parents(self):
+        columns = [self.region_dimension_name, "ElementType", "Alias:a", "Currency:s", "population:n", "level001",
+                   "level000", "level001_weight", "level000_weight"]
+        data = [
+            ['France', "Numeric", "Frankreich", "EUR", 60_000_000, "Europe", "World", 1, 1],
+            ['Switzerland', 'Numeric', "Schweiz", "CHF", 9_000_000, "Europe", "World", 1, 1],
+            ['Germany', 'Numeric', "Deutschland", "EUR", 84_000_000, "Europe", "World", 1, 1],
+            ['Europe', "Consolidated", "Europa", "EUR", 420_000_000, "", "World", 0, 1],
+            ['Switzerland', 'Numeric', "Schweiz", "CHF", 9_000_000, "", "DACH", 0, 1],
+            ['Germany', 'Numeric', "Deutschland", "EUR", 84_000_000, "", "DACH", 0, 1],
+        ]
+        df = DataFrame(data=data, columns=columns)
+
+        self.tm1.hierarchies.update_or_create_hierarchy_from_dataframe(
+            dimension_name=self.region_dimension_name,
+            hierarchy_name=self.region_dimension_name,
+            df=df,
+            element_column=self.region_dimension_name,
+            element_types_column="ElementType",
+            unwind=True)
+
+        hierarchy = self.tm1.hierarchies.get(
+            dimension_name=self.region_dimension_name,
+            hierarchy_name=self.region_dimension_name)
+        self._verify_region_dimension(hierarchy)
+
+        self.assertEqual(hierarchy.edges["DACH", "Switzerland"], 1)
+        self.assertEqual(hierarchy.edges["DACH", "Germany"], 1)
+
+    def test_update_or_create_hierarchy_from_dataframe_invalid_alias(self):
+        columns = [self.region_dimension_name, "ElementType", "Alias:a", "Currency:s", "population:n", "level001",
+                   "level000", "level001_weight", "level000_weight"]
+        data = [
+            ['France', "Numeric", "Frankreich", "EUR", 60_000_000, "Europe", "World", 1, 1],
+            ['Switzerland', 'Numeric', "Schweiz", "CHF", 9_000_000, "Europe", "World", 1, 1],
+            ['Germany', 'Numeric', "Frankreich", "EUR", 84_000_000, "Europe", "World", 1, 1],
+        ]
+        df = DataFrame(data=data, columns=columns)
+
+        with self.assertRaises(ValueError):
+            self.tm1.hierarchies.update_or_create_hierarchy_from_dataframe(
+                dimension_name=self.region_dimension_name,
+                hierarchy_name=self.region_dimension_name,
+                df=df,
+                element_column=self.region_dimension_name,
+                element_types_column="ElementType",
+                unwind=True)
 
 
 if __name__ == '__main__':

--- a/Tests/HierarchyService_test.py
+++ b/Tests/HierarchyService_test.py
@@ -796,6 +796,50 @@ class TestHierarchyService(unittest.TestCase):
                 element_types_column="ElementType",
                 unwind=True)
 
+    def test_update_or_create_hierarchy_from_dataframe_circular_reference(self):
+        columns = [self.region_dimension_name, "ElementType", "Alias:a", "Currency:s", "population:n", "level001",
+                   "level000", "level001_weight", "level000_weight"]
+        data = [
+            ['France', "Numeric", "Frankreich", "EUR", 60_000_000, "EU", "World", 1, 1],
+            ['England', 'Numeric', "Schweiz", "CHF", 50_000_000, "UK", "World", 0, 1],
+            ['Wales', 'Numeric', "Deutschland", "EUR", 5_000_000, "UK", "World", 0, 1],
+            ["World", "Consolidated", "", "", "", "EU", "", 0, 0],
+            ["World", "Consolidated", "", "", "", "UK", "", 0, 0],
+        ]
+        df = DataFrame(data=data, columns=columns)
+
+        with self.assertRaises(ValueError):
+            self.tm1.hierarchies.update_or_create_hierarchy_from_dataframe(
+                dimension_name=self.region_dimension_name,
+                hierarchy_name=self.region_dimension_name,
+                df=df,
+                element_column=self.region_dimension_name,
+                element_types_column="ElementType",
+                unwind=True
+            )
+
+    def test_update_or_create_hierarchy_from_dataframe_circular_references(self):
+        columns = [self.region_dimension_name, "ElementType", "Alias:a", "Currency:s", "population:n", "level001",
+                   "level000", "level001_weight", "level000_weight"]
+        data = [
+            ['France', "Numeric", "Frankreich", "EUR", 60_000_000, "Europe", "World", 1, 1],
+            ['Switzerland', 'Numeric', "Schweiz", "CHF", 9_000_000, "Europe", "World", 1, 1],
+            ['Germany', 'Numeric', "Deutschland", "EUR", 84_000_000, "Europe", "World", 1, 1],
+            ["World", "Consolidated", "", "", "", "Europe", "", 0, 0],
+            ["World", "Consolidated", "", "", "", "Europe", "", 0, 0],
+        ]
+        df = DataFrame(data=data, columns=columns)
+
+        with self.assertRaises(ValueError):
+            self.tm1.hierarchies.update_or_create_hierarchy_from_dataframe(
+                dimension_name=self.region_dimension_name,
+                hierarchy_name=self.region_dimension_name,
+                df=df,
+                element_column=self.region_dimension_name,
+                element_types_column="ElementType",
+                unwind=True
+            )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/config.ini
+++ b/Tests/config.ini
@@ -1,11 +1,11 @@
-[tm1srv02]
+[tm1srv01]
 address=localhost
 port=12354
 user=admin
 password=apple
 ssl=True
 
-[tm1srv01]
+[tm1srv02]
 address=awstm1-ux-d01
 port=8010
 user=Admin

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,8 @@ setup(
         'requests',
         'pytz',
         'requests_negotiate_sspi;platform_system=="Windows"',
-        'mdxpy>=1.3.1'],
+        'mdxpy>=1.3.1',
+        'networkx'],
     extras_require={
         "pandas": ["pandas"]
     },


### PR DESCRIPTION
Create or Update Hierarchy based on data frame

Create or update an existing hierarchy based on data frame.
Attribute columns can be suffixed with a,s, or n to control the
attribute type.
Edges and Weights are created according to the provided level columns

Function supports
- multiple parents
- duplicate records
- explicit or implicit (through level columns) consolidation records
- optional unwind before manipulation
- attribute update
- imbalanced hierarchies

Function checks df before creation for:
- invalid alias
- contradictory records