### PR TITLE
Created a new method to expose Cell Partitioning

### DIFF
--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -2914,7 +2914,21 @@ class CellService(ObjectService):
                                   skip_zeros: bool = False,
                                   skip_consolidated_cells: bool = False,
                                   skip_rule_derived_cells: bool = False,
-                                  sandbox_name: str = None):
+                                  sandbox_name: str = None) -> object: """
+        Method to extract a cellset partition. Cellset partitions are a collection of cellset cells where they have
+        a defined top left boundary, and bottom right boundary. 
+        Read More: https://www.ibm.com/docs/en/planning-analytics/2.0.0?topic=data-cellsets#dg_tm1_odata_get_cells__title__1
+        :param partition_start_ordinal: top left cell boundary
+        :param partition_end_ordinal: bottom right cell boundary
+        :param cell_properties: cell properties to include, default: Orginal, Value
+        :param top: Integer limiting the number of cells and the number or rows returned
+        :param skip: Integer limiting the number of cells and the number or rows returned
+        :param skip_zeros: skip zeros in cellset (irrespective of zero suppression in MDX / view)
+        :param skip_consolidated_cells: skip consolidated cells in cellset
+        :param skip_rule_derived_cells: skip rule derived cells in cellset
+        :param sandbox_name: str
+        :return: CellSet Dictionary
+        """
 
         if not cell_properties:
             cell_properties = ['Value', 'Ordinal']

--- a/Tests/CellService_test.py
+++ b/Tests/CellService_test.py
@@ -4450,6 +4450,42 @@ class TestCellService(unittest.TestCase):
 
         self.assertEqual(expected_result, result)
 
+    def test_extract_cellset_partition(self):
+        # write cube content
+        self.tm1.cubes.cells.write_values(self.cube_name, self.cellset)
+
+        # MDX Query that gets full cube content with zero suppression
+        mdx = MdxBuilder.from_cube(self.cube_name) \
+            .rows_non_empty() \
+            .add_hierarchy_set_to_row_axis(
+            MdxHierarchySet.all_members(self.dimension_names[0], self.dimension_names[0])) \
+            .add_hierarchy_set_to_row_axis(
+            MdxHierarchySet.all_members(self.dimension_names[1], self.dimension_names[1])) \
+            .add_hierarchy_set_to_column_axis(
+            MdxHierarchySet.all_members(self.dimension_names[2], self.dimension_names[2])) \
+            .to_mdx()
+
+        #create cellset
+        cellset = self.tm1.cells.create_cellset(mdx)
+
+        partition = self.tm1.cells.extract_cellset_partition(cellset_id=cellset,
+                                                            partition_start_ordinal=0,
+                                                            partition_end_ordinal=1)
+
+        expected_result = [{'Ordinal': 0, 'Value': 1}, {'Ordinal': 1, 'Value': None}]
+        self.assertEqual(partition, expected_result)
+
+        partition_skip_zero = self.tm1.cells.extract_cellset_partition(cellset_id=cellset,
+                                                            partition_start_ordinal=0,
+                                                            partition_end_ordinal=1,
+                                                            skip_zeros=True)
+
+        expected_result_skip_zero = [{'Ordinal': 0, 'Value': 1}]
+        self.assertEqual(partition_skip_zero, expected_result_skip_zero)
+
+
+
+
     # Delete Cube and Dimensions
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Method to expose CellSet Partitions. The functions tm1.GetPartition returns a collection of CellSet Cells. Therefore partitioning could not be easily integrated into other "execute...." functions. To do so it would require the ability to view the axis information for the given partition, that is not available directly in the API. Enabling it would require TM1py to stitch together the partitions based on cell ordinals. There is no direct way to navigate from a cellset cell to the cell address (https://www.ibm.com/docs/en/cognos-tm1/10.2.2?topic=1022-schema#restapi_v1_csdl_entitytype_CellsetCell)
