### PR TITLE
V2/low level methods

### DIFF
--- a/TM1py/Services/AuditLogService.py
+++ b/TM1py/Services/AuditLogService.py
@@ -4,7 +4,8 @@ from warnings import warn
 from datetime import datetime
 from typing import Dict
 
-from TM1py import ObjectService, RestService
+from TM1py.Services.ObjectService import ObjectService
+from TM1py.Services.RestService import RestService
 from TM1py.Utils import verify_version, deprecated_in_version, odata_track_changes_header, require_admin, format_url, \
     require_version
 
@@ -12,12 +13,11 @@ from TM1py.Utils import verify_version, deprecated_in_version, odata_track_chang
 class AuditLogService(ObjectService):
 
     def __init__(self, rest: RestService):
-        if verify_version(required_version="12.0.0", version=self.version):
+        super().__init__(rest)
+        if verify_version(required_version="12.0.0", version=rest.version):
             # warn only due to use in Monitoring Service
             warn("Audit Logs are not available in this version of TM1, removed as of 12.0.0", DeprecationWarning,
                  2)
-
-        super().__init__(rest)
         self.last_delta_request = None
 
     @deprecated_in_version(version="12.0.0")

--- a/TM1py/Services/AuditLogService.py
+++ b/TM1py/Services/AuditLogService.py
@@ -1,13 +1,15 @@
-import pytz
 from warnings import warn
 
 from datetime import datetime
 from typing import Dict
 
+
 from TM1py.Services.ObjectService import ObjectService
 from TM1py.Services.RestService import RestService
-from TM1py.Utils import verify_version, deprecated_in_version, odata_track_changes_header, require_data_admin, format_url, \
-    require_version
+from TM1py.Utils import verify_version, deprecated_in_version, odata_track_changes_header, require_data_admin, \
+    format_url, \
+    require_version, require_ops_admin
+from TM1py.Services.ConfigurationService import ConfigurationService
 
 
 class AuditLogService(ObjectService):
@@ -19,6 +21,8 @@ class AuditLogService(ObjectService):
             warn("Audit Logs are not available in this version of TM1, removed as of 12.0.0", DeprecationWarning,
                  2)
         self.last_delta_request = None
+        self.configuration = ConfigurationService(rest)
+
 
     @deprecated_in_version(version="12.0.0")
     @odata_track_changes_header
@@ -85,3 +89,8 @@ class AuditLogService(ObjectService):
             url += '&$top={}'.format(top)
         response = self._rest.GET(url, **kwargs)
         return response.json()['value']
+
+    @require_ops_admin
+    def activate(self):
+        config = {'Administration': {'AuditLog': {'Enable': True}}}
+        self.configuration.update_static(config)

--- a/TM1py/Services/AuditLogService.py
+++ b/TM1py/Services/AuditLogService.py
@@ -6,7 +6,7 @@ from typing import Dict
 
 from TM1py.Services.ObjectService import ObjectService
 from TM1py.Services.RestService import RestService
-from TM1py.Utils import verify_version, deprecated_in_version, odata_track_changes_header, require_admin, format_url, \
+from TM1py.Utils import verify_version, deprecated_in_version, odata_track_changes_header, require_data_admin, format_url, \
     require_version
 
 
@@ -40,7 +40,7 @@ class AuditLogService(ObjectService):
             "AuditLogEntries/!delta('"):-2]
         return response.json()['value']
 
-    @require_admin
+    @require_data_admin
     @deprecated_in_version(version="12.0.0")
     @require_version(version="11.6")
     def get_entries(self, user: str = None, object_type: str = None, object_name: str = None,

--- a/TM1py/Services/AuditLogService.py
+++ b/TM1py/Services/AuditLogService.py
@@ -1,0 +1,87 @@
+import pytz
+from warnings import warn
+
+from datetime import datetime
+from typing import Dict
+
+from TM1py import ObjectService, RestService
+from TM1py.Utils import verify_version, deprecated_in_version, odata_track_changes_header, require_admin, format_url, \
+    require_version
+
+
+class AuditLogService(ObjectService):
+
+    def __init__(self, rest: RestService):
+        if verify_version(required_version="12.0.0", version=self.version):
+            # warn only due to use in Monitoring Service
+            warn("Audit Logs are not available in this version of TM1, removed as of 12.0.0", DeprecationWarning,
+                 2)
+
+        super().__init__(rest)
+        self.last_delta_request = None
+
+    @deprecated_in_version(version="12.0.0")
+    @odata_track_changes_header
+    def initialize_delta_requests(self, filter=None, **kwargs):
+        url = "/TailAuditLog()"
+        if filter:
+            url += "?$filter={}".format(filter)
+        response = self._rest.GET(url=url, **kwargs)
+        # Read the next delta-request-url from the response
+        self.last_delta_request = response.text[response.text.rfind(
+            "AuditLogEntries/!delta('"):-2]
+
+    @deprecated_in_version(version="12.0.0")
+    @odata_track_changes_header
+    def execute_delta_request(self, **kwargs) -> Dict:
+        response = self._rest.GET(
+            url="/" + self.last_delta_request, **kwargs)
+        self.last_delta_request = response.text[response.text.rfind(
+            "AuditLogEntries/!delta('"):-2]
+        return response.json()['value']
+
+    @require_admin
+    @deprecated_in_version(version="12.0.0")
+    @require_version(version="11.6")
+    def get_entries(self, user: str = None, object_type: str = None, object_name: str = None,
+                              since: datetime = None, until: datetime = None, top: int = None, **kwargs) -> Dict:
+        """
+        :param user: UserName
+        :param object_type: ObjectType
+        :param object_name: ObjectName
+        :param since: of type datetime. If it doesn't have tz information, UTC is assumed.
+        :param until: of type datetime. If it doesn't have tz information, UTC is assumed.
+        :param top: int
+        :return:
+        """
+
+        url = '/AuditLogEntries?$expand=AuditDetails'
+        # filter on user, object_type, object_name  and time
+        if any([user, object_type, object_name, since, until]):
+            log_filters = []
+            if user:
+                log_filters.append(format_url("UserName eq '{}'", user))
+            if object_type:
+                log_filters.append(format_url(
+                    "ObjectType eq '{}'", object_type))
+            if object_name:
+                log_filters.append(format_url(
+                    "ObjectName eq '{}'", object_name))
+            if since:
+                # If since doesn't have tz information, UTC is assumed
+                if not since.tzinfo:
+                    since = self.utc_localize_time(since)
+                log_filters.append(format_url(
+                    "TimeStamp ge {}", since.strftime("%Y-%m-%dT%H:%M:%SZ")))
+            if until:
+                # If until doesn't have tz information, UTC is assumed
+                if not until.tzinfo:
+                    until = self.utc_localize_time(until)
+                log_filters.append(format_url(
+                    "TimeStamp le {}", until.strftime("%Y-%m-%dT%H:%M:%SZ")))
+            url += "&$filter={}".format(" and ".join(log_filters))
+        # top limit
+        if top:
+            url += '&$top={}'.format(top)
+        response = self._rest.GET(url, **kwargs)
+        return response.json()['value']

--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -4,7 +4,6 @@ import csv
 import functools
 import itertools
 import json
-import math
 import uuid
 import warnings
 from collections import OrderedDict

--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -4,6 +4,7 @@ import csv
 import functools
 import itertools
 import json
+import math
 import uuid
 import warnings
 from collections import OrderedDict

--- a/TM1py/Services/ConfigurationService.py
+++ b/TM1py/Services/ConfigurationService.py
@@ -4,10 +4,10 @@ import pytz
 from requests import Response
 from warnings import warn
 
-from datetime import datetime
 from typing import Dict
 
-from TM1py import ObjectService, RestService
+from TM1py.Services.ObjectService import ObjectService
+from TM1py.Services.RestService import RestService
 from TM1py.Utils import verify_version, deprecated_in_version, odata_track_changes_header, require_admin, format_url
 
 

--- a/TM1py/Services/ConfigurationService.py
+++ b/TM1py/Services/ConfigurationService.py
@@ -8,7 +8,7 @@ from typing import Dict
 
 from TM1py.Services.ObjectService import ObjectService
 from TM1py.Services.RestService import RestService
-from TM1py.Utils import verify_version, deprecated_in_version, odata_track_changes_header, require_admin, format_url
+from TM1py.Utils import verify_version, deprecated_in_version, odata_track_changes_header, require_ops_admin, format_url
 
 
 class ConfigurationService(ObjectService):
@@ -50,7 +50,7 @@ class ConfigurationService(ObjectService):
         del config["@odata.context"]
         return config
 
-    @require_admin
+    @require_ops_admin
     def get_static(self, **kwargs) -> Dict:
         """ Read TM1 config settings as dictionary from TM1 Server
 
@@ -61,7 +61,7 @@ class ConfigurationService(ObjectService):
         del config["@odata.context"]
         return config
 
-    @require_admin
+    @require_ops_admin
     def get_active(self, **kwargs) -> Dict:
         """ Read effective(!) TM1 config settings as dictionary from TM1 Server
 
@@ -72,7 +72,7 @@ class ConfigurationService(ObjectService):
         del config["@odata.context"]
         return config
 
-    @require_admin
+    @require_ops_admin
     def update_static_configuration(self, configuration: Dict) -> Response:
         """ Update the .cfg file and triggers TM1 to re-read the file.
 

--- a/TM1py/Services/ConfigurationService.py
+++ b/TM1py/Services/ConfigurationService.py
@@ -1,0 +1,75 @@
+import pytz
+from warnings import warn
+
+from datetime import datetime
+from typing import Dict
+
+from TM1py import ObjectService, RestService
+from TM1py.Utils import verify_version, deprecated_in_version, odata_track_changes_header, require_admin, format_url
+
+
+class ConfigurationService(ObjectService):
+
+    def __init__(self, rest: RestService):
+        if verify_version(required_version="12.0.0", version=self.version):
+            # warn only due to use in Monitoring Service
+            warn("Transaction Logs are not available in this version of TM1, removed as of 12.0.0", DeprecationWarning,
+                 2)
+
+        super().__init__(rest)
+
+    def get_server_name(self, **kwargs) -> str:
+        """ Ask TM1 Server for its name
+
+        :Returns:
+            String, the server name
+        """
+        url = '/Configuration/ServerName/$value'
+        return self._rest.GET(url, **kwargs).text
+
+    def get_product_version(self, **kwargs) -> str:
+        """ Ask TM1 Server for its version
+
+        :Returns:
+            String, the version
+        """
+        url = '/Configuration/ProductVersion/$value'
+        return self._rest.GET(url, **kwargs).text
+
+    @deprecated_in_version(version="12.0.0")
+    def get_admin_host(self, **kwargs) -> str:
+        url = '/Configuration/AdminHost/$value'
+        return self._rest.GET(url, **kwargs).text
+
+    @deprecated_in_version(version="12.0.0")
+    def get_data_directory(self, **kwargs) -> str:
+        url = '/Configuration/DataBaseDirectory/$value'
+        return self._rest.GET(url, **kwargs).text
+
+    def get(self, **kwargs) -> Dict:
+        url = '/Configuration'
+        config = self._rest.GET(url, **kwargs).json()
+        del config["@odata.context"]
+        return config
+
+    @require_admin
+    def get_static(self, **kwargs) -> Dict:
+        """ Read TM1 config settings as dictionary from TM1 Server
+
+        :return: config as dictionary
+        """
+        url = '/StaticConfiguration'
+        config = self._rest.GET(url, **kwargs).json()
+        del config["@odata.context"]
+        return config
+
+    @require_admin
+    def get_active(self, **kwargs) -> Dict:
+        """ Read effective(!) TM1 config settings as dictionary from TM1 Server
+
+        :return: config as dictionary
+        """
+        url = '/ActiveConfiguration'
+        config = self._rest.GET(url, **kwargs).json()
+        del config["@odata.context"]
+        return config

--- a/TM1py/Services/ConfigurationService.py
+++ b/TM1py/Services/ConfigurationService.py
@@ -1,20 +1,24 @@
 import json
 
-import pytz
 from requests import Response
-from warnings import warn
 
 from typing import Dict
 
 from TM1py.Services.ObjectService import ObjectService
 from TM1py.Services.RestService import RestService
-from TM1py.Utils import verify_version, deprecated_in_version, odata_track_changes_header, require_ops_admin, format_url
+from TM1py.Utils import deprecated_in_version, require_ops_admin
 
 
 class ConfigurationService(ObjectService):
 
     def __init__(self, rest: RestService):
         super().__init__(rest)
+
+    def get_all(self, **kwargs) -> Dict:
+        url = '/Configuration'
+        config = self._rest.GET(url, **kwargs).json()
+        del config["@odata.context"]
+        return config
 
     def get_server_name(self, **kwargs) -> str:
         """ Ask TM1 Server for its name
@@ -44,12 +48,6 @@ class ConfigurationService(ObjectService):
         url = '/Configuration/DataBaseDirectory/$value'
         return self._rest.GET(url, **kwargs).text
 
-    def get(self, **kwargs) -> Dict:
-        url = '/Configuration'
-        config = self._rest.GET(url, **kwargs).json()
-        del config["@odata.context"]
-        return config
-
     @require_ops_admin
     def get_static(self, **kwargs) -> Dict:
         """ Read TM1 config settings as dictionary from TM1 Server
@@ -73,7 +71,7 @@ class ConfigurationService(ObjectService):
         return config
 
     @require_ops_admin
-    def update_static_configuration(self, configuration: Dict) -> Response:
+    def update_static(self, configuration: Dict) -> Response:
         """ Update the .cfg file and triggers TM1 to re-read the file.
 
         :param configuration:

--- a/TM1py/Services/ConfigurationService.py
+++ b/TM1py/Services/ConfigurationService.py
@@ -11,11 +11,6 @@ from TM1py.Utils import verify_version, deprecated_in_version, odata_track_chang
 class ConfigurationService(ObjectService):
 
     def __init__(self, rest: RestService):
-        if verify_version(required_version="12.0.0", version=self.version):
-            # warn only due to use in Monitoring Service
-            warn("Transaction Logs are not available in this version of TM1, removed as of 12.0.0", DeprecationWarning,
-                 2)
-
         super().__init__(rest)
 
     def get_server_name(self, **kwargs) -> str:

--- a/TM1py/Services/ConfigurationService.py
+++ b/TM1py/Services/ConfigurationService.py
@@ -1,4 +1,7 @@
+import json
+
 import pytz
+from requests import Response
 from warnings import warn
 
 from datetime import datetime
@@ -68,3 +71,13 @@ class ConfigurationService(ObjectService):
         config = self._rest.GET(url, **kwargs).json()
         del config["@odata.context"]
         return config
+
+    @require_admin
+    def update_static_configuration(self, configuration: Dict) -> Response:
+        """ Update the .cfg file and triggers TM1 to re-read the file.
+
+        :param configuration:
+        :return: Response
+        """
+        url = '/StaticConfiguration'
+        return self._rest.PATCH(url, json.dumps(configuration))

--- a/TM1py/Services/JobService.py
+++ b/TM1py/Services/JobService.py
@@ -1,15 +1,12 @@
-from warnings import warn
-
 try:
     import pandas as pd
     _has_pandas = True
 except ImportError:
     _has_pandas = False
 
-from TM1py.Exceptions import TM1pyVersionException
 from TM1py.Services.ObjectService import ObjectService
 from TM1py.Services.RestService import RestService
-from TM1py.Utils.Utils import format_url, require_pandas, verify_version
+from TM1py.Utils.Utils import format_url, require_pandas, require_version
 
 
 class JobService(ObjectService):
@@ -20,8 +17,8 @@ class JobService(ObjectService):
     def __init__(self, rest: RestService):
         super().__init__(rest)
 
-    @verify_version(version="12.0.0")
-    def get(self, **kwargs):
+    @require_version(version="12.0.0")
+    def get_all(self, **kwargs):
         """ Return a dict of the currently running jobs from the TM1 Server
 
             :return:
@@ -31,7 +28,7 @@ class JobService(ObjectService):
         response = self._rest.GET(url, **kwargs)
         return response.json()['value']
 
-    @verify_version(version="12.0.0")
+    @require_version(version="12.0.0")
     def cancel(self, job_id, **kwargs):
         """ Cancels a running Job
 
@@ -42,7 +39,7 @@ class JobService(ObjectService):
         response = self._rest.POST(url, **kwargs)
         return response
 
-    @verify_version(version="12.0.0")
+    @require_version(version="12.0.0")
     def cancel_all(self, **kwargs):
         jobs = self.get()
         canceled_jobs = list()
@@ -52,7 +49,7 @@ class JobService(ObjectService):
         return canceled_jobs
 
     @require_pandas
-    @verify_version(version="12.0.0")
+    @require_version(version="12.0.0")
     def get_as_dataframe(self):
         """ Gets jobs and returns them as a dataframe
 

--- a/TM1py/Services/JobService.py
+++ b/TM1py/Services/JobService.py
@@ -1,0 +1,60 @@
+try:
+    import pandas as pd
+    _has_pandas = True
+except ImportError:
+    _has_pandas = False
+
+from TM1py.Exceptions import TM1pyVersionException
+from TM1py.Services.ObjectService import ObjectService
+from TM1py.Services.RestService import RestService
+from TM1py.Utils.Utils import format_url, require_pandas, verify_version
+
+
+class JobService(ObjectService):
+    """ Service to handle TM1 Job objects introduced in v12
+
+    """
+
+    def __init__(self, rest: RestService):
+        super().__init__(rest)
+        if not verify_version(required_version="12.0.0", version=self.version):
+            raise TM1pyVersionException("init Jobs Service", "12.0.0")
+
+    def get(self, **kwargs):
+        """ Return a dict of the currently running jobs from the TM1 Server
+
+            :return:
+                dict: the response
+        """
+        url = '/Jobs'
+        response = self._rest.GET(url, **kwargs)
+        return response.json()['value']
+
+    def cancel(self, job_id, **kwargs):
+        """ Cancels a running Job
+
+        :param job_id:
+        :return:
+        """
+        url = format_url("/Jobs('{}')/tm1.Cancel", str(job_id))
+        response = self._rest.POST(url, **kwargs)
+        return response
+
+    def cancel_all(self, **kwargs):
+        jobs = self.get()
+        canceled_jobs = list()
+        for job in jobs:
+            self.cancel(job["ID"])
+            canceled_jobs.append(job)
+        return canceled_jobs
+
+    @require_pandas
+    def get_as_dataframe(self):
+        """ Gets jobs and returns them as a dataframe
+
+        """
+        jobs = self.get()
+        df = pd.DataFrame.from_records(jobs)
+        return df
+
+

--- a/TM1py/Services/JobService.py
+++ b/TM1py/Services/JobService.py
@@ -1,3 +1,5 @@
+from warnings import warn
+
 try:
     import pandas as pd
     _has_pandas = True
@@ -17,9 +19,8 @@ class JobService(ObjectService):
 
     def __init__(self, rest: RestService):
         super().__init__(rest)
-        if not verify_version(required_version="12.0.0", version=self.version):
-            raise TM1pyVersionException("init Jobs Service", "12.0.0")
 
+    @verify_version(version="12.0.0")
     def get(self, **kwargs):
         """ Return a dict of the currently running jobs from the TM1 Server
 
@@ -30,6 +31,7 @@ class JobService(ObjectService):
         response = self._rest.GET(url, **kwargs)
         return response.json()['value']
 
+    @verify_version(version="12.0.0")
     def cancel(self, job_id, **kwargs):
         """ Cancels a running Job
 
@@ -40,6 +42,7 @@ class JobService(ObjectService):
         response = self._rest.POST(url, **kwargs)
         return response
 
+    @verify_version(version="12.0.0")
     def cancel_all(self, **kwargs):
         jobs = self.get()
         canceled_jobs = list()
@@ -49,6 +52,7 @@ class JobService(ObjectService):
         return canceled_jobs
 
     @require_pandas
+    @verify_version(version="12.0.0")
     def get_as_dataframe(self):
         """ Gets jobs and returns them as a dataframe
 

--- a/TM1py/Services/LoggerService.py
+++ b/TM1py/Services/LoggerService.py
@@ -15,7 +15,6 @@ class LoggerService(ObjectService):
     def __init__(self, rest: RestService):
         super().__init__(rest)
 
-
     @require_ops_admin
     def get_all(self, **kwargs) -> Dict:
         url = f"/Loggers"
@@ -23,7 +22,7 @@ class LoggerService(ObjectService):
         return loggers['value']
 
     @require_ops_admin
-    def get_all(self, **kwargs) -> List[str]:
+    def get_all_names(self, **kwargs) -> List[str]:
         loggers = self.get_all(**kwargs)
         return [logger['Name'] for logger in loggers]
 
@@ -40,7 +39,7 @@ class LoggerService(ObjectService):
         return logger
 
     @require_ops_admin
-    def search(self, wildcard: str='', level: str='', **kwargs) -> Dict:
+    def search(self, wildcard: str = '', level: str = '', **kwargs) -> Dict:
         """ Searches logger names by wildcard or by level. Combining wildcard and level will filter via AND and not OR
 
         :param wildcard: string to match in logger name
@@ -87,7 +86,7 @@ class LoggerService(ObjectService):
 
         if not self.exists(logger=logger, **kwargs):
             raise ValueError('{} is not a valid logger'.format(logger))
-        
+
         level_dict = CaseAndSpaceInsensitiveDict(
             {'FATAL': 0, 'ERROR': 1, 'WARNING': 2, 'INFO': 3, 'DEBUG': 4, 'UNKNOWN': 5, 'OFF': 6}
         )
@@ -96,5 +95,5 @@ class LoggerService(ObjectService):
             logger = {'Level': level_index}
         else:
             raise ValueError('{} is not a valid level'.format(level))
-        
+
         return self._rest.PATCH(url, json.dumps(logger))

--- a/TM1py/Services/LoggerService.py
+++ b/TM1py/Services/LoggerService.py
@@ -1,0 +1,100 @@
+import json
+from typing import Dict, List
+
+from TM1py.Services.ObjectService import ObjectService
+from TM1py.Services.RestService import RestService
+from TM1py.Utils import format_url
+from TM1py.Utils.Utils import CaseAndSpaceInsensitiveDict, require_ops_admin
+
+
+class LoggerService(ObjectService):
+    """ Service to query and update loggers
+
+    """
+
+    def __init__(self, rest: RestService):
+        super().__init__(rest)
+
+
+    @require_ops_admin
+    def get_all(self, **kwargs) -> Dict:
+        url = f"/Loggers"
+        loggers = self._rest.GET(url, **kwargs).json()
+        return loggers['value']
+
+    @require_ops_admin
+    def get_all(self, **kwargs) -> List[str]:
+        loggers = self.get_all(**kwargs)
+        return [logger['Name'] for logger in loggers]
+
+    @require_ops_admin
+    def get(self, logger: str, **kwargs) -> Dict:
+        """ Get level for specified logger
+
+        :param logger: string name of logger
+        :return: Dict of logger and level
+        """
+        url = format_url("/Loggers('{}')", logger)
+        logger = self._rest.GET(url, **kwargs).json()
+        del logger["@odata.context"]
+        return logger
+
+    @require_ops_admin
+    def search(self, wildcard: str='', level: str='', **kwargs) -> Dict:
+        """ Searches logger names by wildcard or by level. Combining wildcard and level will filter via AND and not OR
+
+        :param wildcard: string to match in logger name
+        :param level: string e.g. FATAL, ERROR, WARNING, INFO, DEBUG, UNKOWN, OFF
+        :return: Dict of matching loggers and levels
+        """
+        url = f"/Loggers"
+
+        logger_filters = []
+
+        if level:
+            level_dict = CaseAndSpaceInsensitiveDict(
+                {'FATAL': 0, 'ERROR': 1, 'WARNING': 2, 'INFO': 3, 'DEBUG': 4, 'UNKNOWN': 5, 'OFF': 6}
+            )
+            level_index = level_dict.get(level)
+            if level_index:
+                logger_filters.append("Level eq {}".format(level_index))
+
+        if wildcard:
+            logger_filters.append("contains(tolower(Name), tolower('{}'))".format(wildcard))
+
+        url += "?$filter={}".format(" and ".join(logger_filters))
+
+        loggers = self._rest.GET(url, **kwargs).json()
+        return loggers['value']
+
+    @require_ops_admin
+    def exists(self, logger: str, **kwargs) -> bool:
+        """ Test if logger exists
+        :param logger: string name of logger
+        :return: bool
+        """
+        url = format_url("/Loggers('{}')", logger)
+        return self._exists(url, **kwargs)
+
+    @require_ops_admin
+    def set_level(self, logger: str, level: str, **kwargs):
+        """ Set logger level
+        :param logger: string name of logger
+        :param level: string e.g. FATAL, ERROR, WARNING, INFO, DEBUG, UNKOWN, OFF
+        :return: response
+        """
+        url = format_url("/Loggers('{}')", logger)
+
+        if not self.exists(logger=logger, **kwargs):
+            raise ValueError('{} is not a valid logger'.format(logger))
+        
+        level_dict = CaseAndSpaceInsensitiveDict(
+            {'FATAL': 0, 'ERROR': 1, 'WARNING': 2, 'INFO': 3, 'DEBUG': 4, 'UNKNOWN': 5, 'OFF': 6}
+        )
+        level_index = level_dict.get(level)
+        if level_index:
+            logger = {'Level': level_index}
+        else:
+            raise ValueError('{} is not a valid level'.format(level))
+        
+        return self._rest.PATCH(url, json.dumps(logger))

--- a/TM1py/Services/ManageService.py
+++ b/TM1py/Services/ManageService.py
@@ -172,13 +172,14 @@ class ManageService:
         response = requests.post(url=url, json=payload, auth=self._auth_header)
         return response
 
-    def create_database_backup(self, instance_name: str, database_name: str, backup_url: str):
+    def create_database_backup(self, instance_name: str, database_name: str, backup_set_name: str):
         url = f"{self._root_url}/Instances('{instance_name}')/Databases('{database_name}')/tm1s.Backup"
-        payload = {"URL": backup_url}
+        payload = {"URL": f"{backup_set_name}.tgz"}
         response = requests.post(url=url, json=payload, auth=self._auth_header)
         return response
 
     def create_and_upload_database_backup_set_file(self, instance_name: str, database_name: str, backup_set_name: str):
+
         create_url = f"{self._root_url}/Instances('{instance_name}')/Databases('{database_name}')" \
                      f"/Contents('Files')/Contents('.backupsets')/Contents"
         payload = {"@odata.type": "#ibm.tm1.api.v1.Document", "Name": f"{backup_set_name}.tgz"}
@@ -206,9 +207,21 @@ class ManageService:
         response = requests.get(url=url, auth=self._auth_header)
         return json.loads(response.content)
 
+    def get_application(self, instance_name, application_name):
+        url = f"{self._root_url}/Instances('{instance_name}')/Applications('{application_name}')"
+        response = requests.get(url=url, auth=self._auth_header)
+        return json.loads(response.content)
+
     def create_application(self, instance_name, application_name):
         url = f"{self._root_url}/Instances('{instance_name}')/Applications"
         payload = {"Name": application_name}
         response = requests.post(url=url, json=payload, auth=self._auth_header)
         response_json = json.loads(response.content)
         return response_json['ClientID'], response_json['ClientSecret']
+
+    def get_metadata(self):
+        url = f"{self._root_url}/$metadata?$format=json"
+        response = requests.get(url=url, auth=self._auth_header)
+        return json.loads(response.content)
+
+

--- a/TM1py/Services/ManageService.py
+++ b/TM1py/Services/ManageService.py
@@ -224,4 +224,19 @@ class ManageService:
         response = requests.get(url=url, auth=self._auth_header)
         return json.loads(response.content)
 
+    def subscribe_to_data_changes(self, instance_name, database_name, target_url, additional_properties: dict = {}):
+        url = f"{self._root_url}/Instances('{instance_name}')/Databases('{database_name}')/tm1.Subscribe"
+        payload = {
+            "URL": target_url,
+            "AdditionalProperties": additional_properties
+        }
+        response = requests.post(url=url, json=payload, auth=self._auth_header)
+        return response
+
+    def unsubscribe_from_data_changes(self, instance_name, database_name, target_url):
+        url = f"{self._root_url}/Instances('{instance_name}')/Databases('{database_name}')/tm1.Unsubscribe"
+        response = requests.post(url=url, auth=self._auth_header)
+        return response
+
+
 

--- a/TM1py/Services/ManageService.py
+++ b/TM1py/Services/ManageService.py
@@ -65,7 +65,7 @@ class ManageService:
                         instance_name,
                         database_name,
                         number_replicas,
-                        product_version="12.0.0-alpha.1",
+                        product_version,
                         cpu_requests="1000m",
                         cpu_limits="2000m",
                         memory_requests="1G",
@@ -95,6 +95,62 @@ class ManageService:
                    }
         response = requests.post(url=url, json=payload, auth=self._auth_header)
 
+        return response
+
+    def update_database_cpu(self,
+                            instance_name,
+                            database_name,
+                            cpu_requests,
+                            cpu_limits,
+                            ):
+        url = f"{self._root_url}/Instances('{instance_name}')/Databases('{database_name}')"
+
+        payload = {"Resources": {
+            "Replica": {
+                "CPU": {
+                    "Requests": cpu_requests,
+                    "Limits": cpu_limits
+                },
+            }
+        }
+        }
+        response = requests.patch(url=url, json=payload, auth=self._auth_header)
+        return response
+
+    def update_database_memory(self,
+                               instance_name,
+                               database_name,
+                               memory_requests,
+                               memory_limits,
+                               ):
+        url = f"{self._root_url}/Instances('{instance_name}')/Databases('{database_name}')"
+
+        payload = {"Resources": {
+            "Replica": {
+                "Memory": {
+                    "Requests": memory_requests,
+                    "Limits": memory_limits
+                }
+            }
+        }
+        }
+        response = requests.patch(url=url, json=payload, auth=self._auth_header)
+        return response
+
+    def update_database_storage(self,
+                                instance_name,
+                                database_name,
+                                storage_size
+                                ):
+        url = f"{self._root_url}/Instances('{instance_name}')/Databases('{database_name}')"
+
+        payload = {"Resources": {
+            "Storage": {
+                "Size": storage_size
+            }
+        }
+        }
+        response = requests.patch(url=url, json=payload, auth=self._auth_header)
         return response
 
     def delete_database(self, instance_name, database_name):
@@ -156,6 +212,3 @@ class ManageService:
         response = requests.post(url=url, json=payload, auth=self._auth_header)
         response_json = json.loads(response.content)
         return response_json['ClientID'], response_json['ClientSecret']
-
-
-

--- a/TM1py/Services/MessageLogService.py
+++ b/TM1py/Services/MessageLogService.py
@@ -5,7 +5,8 @@ from datetime import datetime
 from typing import Dict, Iterable, Optional
 
 from TM1py.Objects.Process import Process
-from TM1py import ObjectService, RestService
+from TM1py.Services.ObjectService import ObjectService
+from TM1py.Services.RestService import RestService
 from TM1py.Utils import verify_version, deprecated_in_version, odata_track_changes_header, require_admin, format_url, \
     CaseAndSpaceInsensitiveDict, CaseAndSpaceInsensitiveSet
 
@@ -13,12 +14,11 @@ from TM1py.Utils import verify_version, deprecated_in_version, odata_track_chang
 class MessageLogService(ObjectService):
 
     def __init__(self, rest: RestService):
-        if verify_version(required_version="12.0.0", version=self.version):
+        super().__init__(rest)
+        if verify_version(required_version="12.0.0", version=rest.version):
             # warn only due to use in Monitoring Service
             warn("Message Logs are not available in this version of TM1, removed as of 12.0.0", DeprecationWarning,
                  2)
-
-        super().__init__(rest)
         self.last_delta_request = None
 
     @deprecated_in_version(version="12.0.0")

--- a/TM1py/Services/MessageLogService.py
+++ b/TM1py/Services/MessageLogService.py
@@ -1,0 +1,155 @@
+import pytz
+from warnings import warn
+
+from datetime import datetime
+from typing import Dict, Iterable, Optional
+
+from TM1py.Objects.Process import Process
+from TM1py import ObjectService, RestService
+from TM1py.Utils import verify_version, deprecated_in_version, odata_track_changes_header, require_admin, format_url, \
+    CaseAndSpaceInsensitiveDict, CaseAndSpaceInsensitiveSet
+
+
+class MessageLogService(ObjectService):
+
+    def __init__(self, rest: RestService):
+        if verify_version(required_version="12.0.0", version=self.version):
+            # warn only due to use in Monitoring Service
+            warn("Message Logs are not available in this version of TM1, removed as of 12.0.0", DeprecationWarning,
+                 2)
+
+        super().__init__(rest)
+        self.last_delta_request = None
+
+    @deprecated_in_version(version="12.0.0")
+    @odata_track_changes_header
+    def initialize_delta_requests(self, filter=None, **kwargs):
+        url = "/TailMessageLog()"
+        if filter:
+            url += "?$filter={}".format(filter)
+        response = self._rest.GET(url=url, **kwargs)
+        # Read the next delta-request-url from the response
+        self.last_delta_request = response.text[response.text.rfind(
+            "MessageLogEntries/!delta('"):-2]
+
+    @deprecated_in_version(version="12.0.0")
+    @odata_track_changes_header
+    def execute_delta_request(self, **kwargs) -> Dict:
+        response = self._rest.GET(
+            url="/" + self.last_delta_request, **kwargs)
+        self.last_delta_request = response.text[response.text.rfind(
+            "MessageLogEntries/!delta('"):-2]
+        return response.json()['value']
+
+    @deprecated_in_version(version="12.0.0")
+    @require_admin
+    def get_entries(self, reverse: bool = True, since: datetime = None,
+                                until: datetime = None, top: int = None, logger: str = None,
+                                level: str = None, msg_contains: Iterable = None, msg_contains_operator: str = 'and',
+                                **kwargs) -> Dict:
+        """
+        :param reverse: Boolean
+        :param since: of type datetime. If it doesn't have tz information, UTC is assumed.
+        :param until: of type datetime. If it doesn't have tz information, UTC is assumed.
+        :param top: Integer
+        :param logger: string, eg TM1.Server, TM1.Chore, TM1.Mdx.Interface, TM1.Process
+        :param level: string, ERROR, WARNING, INFO, DEBUG, UNKNOWN
+        :param msg_contains: iterable, find substring in log message; list of substrings will be queried as AND statement
+        :param msg_contains_operator: 'and' or 'or'
+
+        :param kwargs:
+        :return: Dict of server log
+        """
+        msg_contains_operator = msg_contains_operator.strip().lower()
+        if msg_contains_operator not in ("and", "or"):
+            raise ValueError(
+                "'msg_contains_operator' must be either 'AND' or 'OR'")
+
+        reverse = 'desc' if reverse else 'asc'
+        url = '/MessageLogEntries?$orderby=TimeStamp {}'.format(reverse)
+
+        if since or until or logger or level or msg_contains:
+            log_filters = []
+
+            if since:
+                # If since doesn't have tz information, UTC is assumed
+                if not since.tzinfo:
+                    since = self.utc_localize_time(since)
+                log_filters.append(format_url(
+                    "TimeStamp ge {}", since.strftime("%Y-%m-%dT%H:%M:%SZ")))
+
+            if until:
+                # If until doesn't have tz information, UTC is assumed
+                if not until.tzinfo:
+                    until = self.utc_localize_time(until)
+                log_filters.append(format_url(
+                    "TimeStamp le {}", until.strftime("%Y-%m-%dT%H:%M:%SZ")))
+
+            if logger:
+                log_filters.append(format_url("Logger eq '{}'", logger))
+
+            if level:
+                level_dict = CaseAndSpaceInsensitiveDict(
+                    {'ERROR': 1, 'WARNING': 2, 'INFO': 3, 'DEBUG': 4, 'UNKNOWN': 5})
+                level_index = level_dict.get(level)
+                if level_index:
+                    log_filters.append("Level eq {}".format(level_index))
+
+            if msg_contains:
+                if isinstance(msg_contains, str):
+                    log_filters.append(format_url(
+                        "contains(toupper(Message),toupper('{}'))", msg_contains))
+                else:
+                    msg_filters = [format_url("contains(toupper(Message),toupper('{}'))", wildcard)
+                                   for wildcard in msg_contains]
+                    log_filters.append("({})".format(
+                        f" {msg_contains_operator} ".join(msg_filters)))
+
+            url += "&$filter={}".format(" and ".join(log_filters))
+
+        if top:
+            url += '&$top={}'.format(top)
+
+        response = self._rest.GET(url, **kwargs)
+        return response.json()['value']
+
+    @require_admin
+    def create_entry(self, level: str, message: str, **kwargs) -> None:
+        """
+        :param level: string, FATAL, ERROR, WARN, INFO, DEBUG
+        :param message: string
+        :return:
+        """
+
+        valid_levels = CaseAndSpaceInsensitiveSet(
+            {'FATAL', 'ERROR', 'WARN', 'INFO', 'DEBUG'})
+        if level not in valid_levels:
+            raise ValueError(f"Invalid level: '{level}'")
+
+        from TM1py.Services import ProcessService
+        process_service = ProcessService(self._rest)
+        process = Process(
+            name="", prolog_procedure="LogOutput('{}', '{}');".format(level, message))
+        success, status, _ = process_service.execute_process_with_return(
+            process, **kwargs)
+
+        if not success:
+            raise RuntimeError(
+                f"Failed to write to TM1 Message Log through unbound process. Status: '{status}'")
+
+    @require_admin
+    @deprecated_in_version(version="12.0.0")
+    def get_last_process_message(self, process_name: str, **kwargs) -> Optional[str]:
+        """ Get the latest message log entry for a process
+
+            :param process_name: name of the process
+            :return: String - the message, for instance: "Ausführung normal beendet, verstrichene Zeit 0.03  Sekunden"
+        """
+        url = format_url(
+            "/MessageLog()?$orderby='TimeStamp'&$filter=Logger eq 'TM1.Process' and contains(Message, '{}')",
+            process_name)
+        response = self._rest.GET(url=url, **kwargs)
+        response_as_list = response.json()['value']
+        if len(response_as_list) > 0:
+            message_log_entry = response_as_list[0]
+            return message_log_entry['Message']

--- a/TM1py/Services/MessageLogService.py
+++ b/TM1py/Services/MessageLogService.py
@@ -7,8 +7,8 @@ from typing import Dict, Iterable, Optional
 from TM1py.Objects.Process import Process
 from TM1py.Services.ObjectService import ObjectService
 from TM1py.Services.RestService import RestService
-from TM1py.Utils import verify_version, deprecated_in_version, odata_track_changes_header, require_admin, format_url, \
-    CaseAndSpaceInsensitiveDict, CaseAndSpaceInsensitiveSet
+from TM1py.Utils import verify_version, deprecated_in_version, odata_track_changes_header, require_ops_admin, require_data_admin, \
+    format_url, CaseAndSpaceInsensitiveDict, CaseAndSpaceInsensitiveSet
 
 
 class MessageLogService(ObjectService):
@@ -42,7 +42,7 @@ class MessageLogService(ObjectService):
         return response.json()['value']
 
     @deprecated_in_version(version="12.0.0")
-    @require_admin
+    @require_ops_admin
     def get_entries(self, reverse: bool = True, since: datetime = None,
                                 until: datetime = None, top: int = None, logger: str = None,
                                 level: str = None, msg_contains: Iterable = None, msg_contains_operator: str = 'and',
@@ -113,7 +113,7 @@ class MessageLogService(ObjectService):
         response = self._rest.GET(url, **kwargs)
         return response.json()['value']
 
-    @require_admin
+    @require_data_admin
     def create_entry(self, level: str, message: str, **kwargs) -> None:
         """
         :param level: string, FATAL, ERROR, WARN, INFO, DEBUG
@@ -137,7 +137,7 @@ class MessageLogService(ObjectService):
             raise RuntimeError(
                 f"Failed to write to TM1 Message Log through unbound process. Status: '{status}'")
 
-    @require_admin
+    @require_ops_admin
     @deprecated_in_version(version="12.0.0")
     def get_last_process_message(self, process_name: str, **kwargs) -> Optional[str]:
         """ Get the latest message log entry for a process

--- a/TM1py/Services/MonitoringService.py
+++ b/TM1py/Services/MonitoringService.py
@@ -30,7 +30,7 @@ class MonitoringService(ObjectService):
             :return:
                 dict: the response
         """
-        return self.threads.get(**kwargs)
+        return self.threads.get_all(**kwargs)
 
     def get_active_threads(self, **kwargs):
         """Return a list of non-idle threads from the TM1 Server
@@ -72,13 +72,13 @@ class MonitoringService(ObjectService):
         :param user_name: 
         :return: 
         """
-        return self.users.is_active(user_name, **kwargs)
+        return self.users.disconnect(user_name, **kwargs)
 
     def get_active_session_threads(self, exclude_idle: bool = True, **kwargs):
         return self.session.get_threads_for_current(exclude_idle, **kwargs)
 
     def get_sessions(self, include_user: bool = True, include_threads: bool = True, **kwargs) -> List:
-        return self.session.get(include_user, include_threads, **kwargs)
+        return self.session.get_all(include_user, include_threads, **kwargs)
 
     @require_admin
     def disconnect_all_users(self, **kwargs) -> list:

--- a/TM1py/Services/MonitoringService.py
+++ b/TM1py/Services/MonitoringService.py
@@ -3,11 +3,13 @@ from typing import List
 from warnings import warn
 from requests import Response
 
-from TM1py import ThreadService, SessionService, UserService
 from TM1py.Objects.User import User
 from TM1py.Services.ObjectService import ObjectService
 from TM1py.Services.RestService import RestService
 from TM1py.Utils import require_admin
+from TM1py.Services.ThreadService import ThreadService
+from TM1py.Services.SessionService import SessionService
+from TM1py.Services.UserService import UserService
 
 
 class MonitoringService(ObjectService):
@@ -62,7 +64,7 @@ class MonitoringService(ObjectService):
         :param user_name:
         :return: Boolean
         """
-        return self.users.is_active(user_name,**kwargs)
+        return self.users.is_active(user_name, **kwargs)
 
     def disconnect_user(self, user_name: str, **kwargs) -> Response:
         """ Disconnect User
@@ -83,7 +85,7 @@ class MonitoringService(ObjectService):
         return self.users.disconnect_all(**kwargs)
 
     def close_session(self, session_id, **kwargs) -> Response:
-        return self.session.close(session_id,**kwargs)
+        return self.session.close(session_id, **kwargs)
 
     @require_admin
     def close_all_sessions(self, **kwargs) -> list:

--- a/TM1py/Services/RestService.py
+++ b/TM1py/Services/RestService.py
@@ -28,7 +28,7 @@ try:
 except ImportError:
     warnings.warn("requests_negotiate_sspi failed to import. SSO will not work", ImportWarning)
 
-from TM1py.Exceptions import TM1pyRestException, TM1pyException
+from TM1py.Exceptions import TM1pyRestException
 
 import http.client as http_client
 
@@ -788,6 +788,15 @@ class RestService:
         url = '/Configuration/ProductVersion/$value'
         response = self.GET(url=url)
         self._version = response.text
+
+    def get_api_metadata(self) -> dict:
+        """ Get API Metadata
+
+        :return: Dictionary
+        """
+        url = '/$metadata'
+        metadata = self.GET(url=url).content.decode("utf-8")
+        return json.loads(metadata)
 
     @property
     def version(self) -> str:

--- a/TM1py/Services/ServerService.py
+++ b/TM1py/Services/ServerService.py
@@ -3,8 +3,10 @@ import json
 from collections.abc import Iterable
 from datetime import datetime
 from enum import Enum
+from typing import Dict, Optional, List
 from typing import Dict, Optional
 from warnings import warn
+import pytz
 
 from requests import Response
 
@@ -13,6 +15,7 @@ from TM1py.Services.ConfigurationService import ConfigurationService
 from TM1py.Services.MessageLogService import MessageLogService
 from TM1py.Services.ObjectService import ObjectService
 from TM1py.Services.RestService import RestService
+from TM1py.Utils.Utils import require_admin, require_ops_admin, require_data_admin, deprecated_in_version
 from TM1py.Services.TransactionLogService import TransactionLogService
 from TM1py.Utils.Utils import require_admin, require_version, \
     deprecated_in_version
@@ -283,3 +286,4 @@ class ServerService(ObjectService):
         '''
         url = f"/Loggers"
         return self._rest.GET(url).content
+

--- a/TM1py/Services/ServerService.py
+++ b/TM1py/Services/ServerService.py
@@ -11,6 +11,7 @@ from typing import Dict, Optional
 import pytz
 from requests import Response
 
+from TM1py import AuditLogService
 from TM1py.Objects.Process import Process
 from TM1py.Services.ObjectService import ObjectService
 from TM1py.Services.RestService import RestService
@@ -45,8 +46,8 @@ class ServerService(ObjectService):
         self.transaction_logs = TransactionLogService(rest)
         self.message_logs = MessageLogService(rest)
         self.configuration = ConfigurationService(rest)
-        self.mlog_last_delta_request = None
-        self.alog_last_delta_request = None
+        self.audit_logs = AuditLogService(rest)
+
 
     def initialize_transaction_log_delta_requests(self, filter=None, **kwargs):
         self.transaction_logs.initialize_delta_requests(filter, **kwargs)
@@ -54,25 +55,11 @@ class ServerService(ObjectService):
     def execute_transaction_log_delta_request(self, **kwargs) -> Dict:
         self.transaction_logs.execute_delta_request(**kwargs)
 
-    @deprecated_in_version(version="12.0.0")
-    @odata_track_changes_header
     def initialize_audit_log_delta_requests(self, filter=None, **kwargs):
-        url = "/TailAuditLog()"
-        if filter:
-            url += "?$filter={}".format(filter)
-        response = self._rest.GET(url=url, **kwargs)
-        # Read the next delta-request-url from the response
-        self.alog_last_delta_request = response.text[response.text.rfind(
-            "AuditLogEntries/!delta('"):-2]
+        return self.audit_logs.initialize_audit_log_delta_requests(filter, **kwargs)
 
-    @deprecated_in_version(version="12.0.0")
-    @odata_track_changes_header
     def execute_audit_log_delta_request(self, **kwargs) -> Dict:
-        response = self._rest.GET(
-            url="/" + self.alog_last_delta_request, **kwargs)
-        self.alog_last_delta_request = response.text[response.text.rfind(
-            "AuditLogEntries/!delta('"):-2]
-        return response.json()['value']
+        return self.audit_logs.execute_delta_request(**kwargs)
 
     def initialize_message_log_delta_requests(self, filter=None, **kwargs):
         return self.message_logs.initialize_delta_requests(filter, **kwargs)
@@ -170,37 +157,13 @@ class ServerService(ObjectService):
         :param top: int
         :return:
         """
-
-        url = '/AuditLogEntries?$expand=AuditDetails'
-        # filter on user, object_type, object_name  and time
-        if any([user, object_type, object_name, since, until]):
-            log_filters = []
-            if user:
-                log_filters.append(format_url("UserName eq '{}'", user))
-            if object_type:
-                log_filters.append(format_url(
-                    "ObjectType eq '{}'", object_type))
-            if object_name:
-                log_filters.append(format_url(
-                    "ObjectName eq '{}'", object_name))
-            if since:
-                # If since doesn't have tz information, UTC is assumed
-                if not since.tzinfo:
-                    since = self.utc_localize_time(since)
-                log_filters.append(format_url(
-                    "TimeStamp ge {}", since.strftime("%Y-%m-%dT%H:%M:%SZ")))
-            if until:
-                # If until doesn't have tz information, UTC is assumed
-                if not until.tzinfo:
-                    until = self.utc_localize_time(until)
-                log_filters.append(format_url(
-                    "TimeStamp le {}", until.strftime("%Y-%m-%dT%H:%M:%SZ")))
-            url += "&$filter={}".format(" and ".join(log_filters))
-        # top limit
-        if top:
-            url += '&$top={}'.format(top)
-        response = self._rest.GET(url, **kwargs)
-        return response.json()['value']
+        return self.audit_logs.get_entries(user=user,
+                                           object_type=object_type,
+                                           object_name=object_name,
+                                           since=since,
+                                           until=until,
+                                           top=top,
+                                           **kwargs)
 
     @require_ops_admin
     @deprecated_in_version(version="12.0.0")
@@ -228,11 +191,9 @@ class ServerService(ObjectService):
         """
         return self.configuration.get_product_version()
 
-    @deprecated_in_version(version="12.0.0")
     def get_admin_host(self, **kwargs) -> str:
         return self.configuration.get_admin_host
 
-    @deprecated_in_version(version="12.0.0")
     def get_data_directory(self, **kwargs) -> str:
         return self.configuration.get_data_directory
 
@@ -267,8 +228,7 @@ class ServerService(ObjectService):
         :param configuration:
         :return: Response
         """
-        url = '/StaticConfiguration'
-        return self._rest.PATCH(url, json.dumps(configuration))
+        return self.configuration.update_static_configuration(configuration)
 
     @deprecated_in_version(version="12.0.0")
     @require_data_admin

--- a/TM1py/Services/ServerService.py
+++ b/TM1py/Services/ServerService.py
@@ -1,29 +1,23 @@
 # -*- coding: utf-8 -*-
-from warnings import warn
-
-import functools
 import json
 from collections.abc import Iterable
 from datetime import datetime
 from enum import Enum
 from typing import Dict, Optional
+from warnings import warn
 
-import pytz
 from requests import Response
 
-from TM1py import AuditLogService
-from TM1py.Objects.Process import Process
+from TM1py.Services.AuditLogService import AuditLogService
+from TM1py.Services.ConfigurationService import ConfigurationService
+from TM1py.Services.MessageLogService import MessageLogService
 from TM1py.Services.ObjectService import ObjectService
 from TM1py.Services.RestService import RestService
-from TM1py.Utils import format_url
-from TM1py.Utils.Utils import CaseAndSpaceInsensitiveDict, CaseAndSpaceInsensitiveSet, require_data_admin, \
-    require_ops_admin, require_version, decohints, deprecated_in_version, require_admin
-from TM1py.Utils import format_url, odata_track_changes_header
-from TM1py.Utils.Utils import CaseAndSpaceInsensitiveDict, CaseAndSpaceInsensitiveSet, require_admin, require_version, \
-    decohints, deprecated_in_version
 from TM1py.Services.TransactionLogService import TransactionLogService
-from TM1py.Services.MessageLogService import MessageLogService
-from TM1py.Services.ConfigurationService import ConfigurationService
+from TM1py.Utils.Utils import require_admin, require_version, \
+    deprecated_in_version
+from TM1py.Utils.Utils import require_data_admin, \
+    require_ops_admin
 
 
 class LogLevel(Enum):
@@ -47,7 +41,6 @@ class ServerService(ObjectService):
         self.message_logs = MessageLogService(rest)
         self.configuration = ConfigurationService(rest)
         self.audit_logs = AuditLogService(rest)
-
 
     def initialize_transaction_log_delta_requests(self, filter=None, **kwargs):
         self.transaction_logs.initialize_delta_requests(filter, **kwargs)
@@ -192,10 +185,10 @@ class ServerService(ObjectService):
         return self.configuration.get_product_version()
 
     def get_admin_host(self, **kwargs) -> str:
-        return self.configuration.get_admin_host
+        return self.configuration.get_admin_host()
 
     def get_data_directory(self, **kwargs) -> str:
-        return self.configuration.get_data_directory
+        return self.configuration.get_data_directory()
 
     def get_configuration(self, **kwargs) -> Dict:
         return self.configuration.get()
@@ -212,14 +205,12 @@ class ServerService(ObjectService):
         """
         return self.configuration.get_active()
 
-    def get_api_metadata(self, **kwargs):
+    def get_api_metadata(self):
         """ Read effective(!) TM1 config settings as dictionary from TM1 Server
 
         :return: config as dictionary
         """
-        url = '/$metadata'
-        metadata = self._rest.GET(url, **kwargs).content.decode("utf-8")
-        return json.loads(metadata)
+        return self._rest.get_api_metadata()
 
     @require_ops_admin
     def update_static_configuration(self, configuration: Dict) -> Response:

--- a/TM1py/Services/ServerService.py
+++ b/TM1py/Services/ServerService.py
@@ -17,6 +17,10 @@ from TM1py.Services.RestService import RestService
 from TM1py.Utils import format_url
 from TM1py.Utils.Utils import CaseAndSpaceInsensitiveDict, CaseAndSpaceInsensitiveSet, require_data_admin, \
     require_ops_admin, require_version, decohints, deprecated_in_version, require_admin
+from TM1py.Utils import format_url, odata_track_changes_header
+from TM1py.Utils.Utils import CaseAndSpaceInsensitiveDict, CaseAndSpaceInsensitiveSet, require_admin, require_version, \
+    decohints, deprecated_in_version
+from TM1py.Services.TransactionLogService import TransactionLogService
 
 
 class LogLevel(Enum):
@@ -28,27 +32,6 @@ class LogLevel(Enum):
     OFF = "off"
 
 
-@decohints
-def odata_track_changes_header(func):
-    """ Higher Order function to handle addition and removal of odata.track-changes HTTP Header
-
-    :param func: 
-    :return: 
-    """
-
-    @functools.wraps(func)
-    def wrapper(self, *args, **kwargs):
-        # Add header
-        self._rest.add_http_header("Prefer", "odata.track-changes")
-        # Do stuff
-        response = func(self, *args, **kwargs)
-        # Remove Header
-        self._rest.remove_http_header("Prefer")
-        return response
-
-    return wrapper
-
-
 class ServerService(ObjectService):
     """ Service to query common information from the TM1 Server
 
@@ -57,29 +40,15 @@ class ServerService(ObjectService):
     def __init__(self, rest: RestService):
         super().__init__(rest)
         warn("Server Service will be moved to a new location in a future version", DeprecationWarning, 2)
-        self.tlog_last_delta_request = None
+        self.transaction_logs = TransactionLogService(rest)
         self.mlog_last_delta_request = None
         self.alog_last_delta_request = None
 
-    @deprecated_in_version(version="12.0.0")
-    @odata_track_changes_header
     def initialize_transaction_log_delta_requests(self, filter=None, **kwargs):
-        url = "/TailTransactionLog()"
-        if filter:
-            url += "?$filter={}".format(filter)
-        response = self._rest.GET(url=url, **kwargs)
-        # Read the next delta-request-url from the response
-        self.tlog_last_delta_request = response.text[response.text.rfind(
-            "TransactionLogEntries/!delta('"):-2]
+        self.transaction_logs.initialize_log_delta_requests(filter, **kwargs)
 
-    @deprecated_in_version(version="12.0.0")
-    @odata_track_changes_header
     def execute_transaction_log_delta_request(self, **kwargs) -> Dict:
-        response = self._rest.GET(
-            url="/" + self.tlog_last_delta_request, **kwargs)
-        self.tlog_last_delta_request = response.text[response.text.rfind(
-            "TransactionLogEntries/!delta('"):-2]
-        return response.json()['value']
+        self.transaction_logs.execute_log_delta_request(**kwargs)
 
     @deprecated_in_version(version="12.0.0")
     @odata_track_changes_header
@@ -224,7 +193,7 @@ class ServerService(ObjectService):
         return timestamp_utc
 
     @deprecated_in_version(version="12.0.0")
-    @require_data_admin
+    @require_admin
     def get_transaction_log_entries(self, reverse: bool = True, user: str = None, cube: str = None,
                                     since: datetime = None, until: datetime = None, top: int = None,
                                     element_tuple_filter: Dict[str, str] = None,
@@ -241,40 +210,15 @@ class ServerService(ObjectService):
         tuple={'Actual':'eq','2020': 'ge'}
         :return:
         """
-        if element_position_filter:
-            raise NotImplementedError("Feature expected in upcoming releases of TM1, TM1py")
-
-        reverse = 'desc' if reverse else 'asc'
-        url = '/TransactionLogEntries?$orderby=TimeStamp {} '.format(reverse)
-
-        # filter on user, cube, time and elements
-        if any([user, cube, since, until, element_tuple_filter, element_position_filter]):
-            log_filters = []
-            if user:
-                log_filters.append(format_url("User eq '{}'", user))
-            if cube:
-                log_filters.append(format_url("Cube eq '{}'", cube))
-            if element_tuple_filter:
-                log_filters.append(format_url(
-                    "Tuple/any(e: {})".format(" or ".join([f"e {v} '{k}'" for k, v in element_tuple_filter.items()]))))
-            if since:
-                # If since doesn't have tz information, UTC is assumed
-                if not since.tzinfo:
-                    since = self.utc_localize_time(since)
-                log_filters.append(format_url(
-                    "TimeStamp ge {}", since.strftime("%Y-%m-%dT%H:%M:%SZ")))
-            if until:
-                # If until doesn't have tz information, UTC is assumed
-                if not until.tzinfo:
-                    until = self.utc_localize_time(until)
-                log_filters.append(format_url(
-                    "TimeStamp le {}", until.strftime("%Y-%m-%dT%H:%M:%SZ")))
-            url += "&$filter={}".format(" and ".join(log_filters))
-        # top limit
-        if top:
-            url += '&$top={}'.format(top)
-        response = self._rest.GET(url, **kwargs)
-        return response.json()['value']
+        return self.transaction_logs.get_entries(reverse=reverse,
+                                                 user=user,
+                                                 cube=cube,
+                                                 since=since,
+                                                 until=until,
+                                                 top=top,
+                                                 element_tuple_filter=element_tuple_filter,
+                                                 element_position_filter=element_position_filter,
+                                                 **kwargs)
 
     @require_data_admin
     @deprecated_in_version(version="12.0.0")

--- a/TM1py/Services/ServerService.py
+++ b/TM1py/Services/ServerService.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+from warnings import warn
+
+import functools
 import json
 from collections.abc import Iterable
 from datetime import datetime
@@ -7,8 +10,12 @@ from typing import Dict, Optional, List
 from typing import Dict, Optional
 from warnings import warn
 import pytz
-
+import pytz
 from requests import Response
+from typing import Dict, Optional, List
+from typing import Dict, Optional
+from warnings import warn
+import pytz
 
 from TM1py.Services.AuditLogService import AuditLogService
 from TM1py.Services.ConfigurationService import ConfigurationService
@@ -17,6 +24,10 @@ from TM1py.Services.ObjectService import ObjectService
 from TM1py.Services.RestService import RestService
 from TM1py.Utils.Utils import require_admin, require_ops_admin, require_data_admin, deprecated_in_version
 from TM1py.Services.TransactionLogService import TransactionLogService
+from TM1py.Utils.Utils import require_admin, require_version, \
+    deprecated_in_version
+from TM1py.Utils.Utils import require_data_admin, \
+    require_ops_admin
 from TM1py.Utils.Utils import require_admin, require_version, \
     deprecated_in_version
 from TM1py.Utils.Utils import require_data_admin, \
@@ -44,15 +55,15 @@ class ServerService(ObjectService):
         self.message_logs = MessageLogService(rest)
         self.configuration = ConfigurationService(rest)
         self.audit_logs = AuditLogService(rest)
-
+        self.loggers = LoggerService(rest)
     def initialize_transaction_log_delta_requests(self, filter=None, **kwargs):
-        self.transaction_logs.initialize_delta_requests(filter, **kwargs)
+        return self.transaction_logs.initialize_delta_requests(filter, **kwargs)
 
     def execute_transaction_log_delta_request(self, **kwargs) -> Dict:
-        self.transaction_logs.execute_delta_request(**kwargs)
+        return self.transaction_logs.execute_delta_request(**kwargs)
 
     def initialize_audit_log_delta_requests(self, filter=None, **kwargs):
-        return self.audit_logs.initialize_audit_log_delta_requests(filter, **kwargs)
+        return self.audit_logs.initialize_delta_requests(filter, **kwargs)
 
     def execute_audit_log_delta_request(self, **kwargs) -> Dict:
         return self.audit_logs.execute_delta_request(**kwargs)
@@ -194,13 +205,11 @@ class ServerService(ObjectService):
         return self.configuration.get_data_directory()
 
     def get_configuration(self, **kwargs) -> Dict:
-        return self.configuration.get()
+        return self.configuration.get_all()
 
-    @require_ops_admin
     def get_static_configuration(self, **kwargs) -> Dict:
         return self.configuration.get_static()
 
-    @require_ops_admin
     def get_active_configuration(self, **kwargs) -> Dict:
         """ Read effective(!) TM1 config settings as dictionary from TM1 Server
 
@@ -215,14 +224,13 @@ class ServerService(ObjectService):
         """
         return self._rest.get_api_metadata()
 
-    @require_ops_admin
     def update_static_configuration(self, configuration: Dict) -> Response:
         """ Update the .cfg file and triggers TM1 to re-read the file.
 
         :param configuration:
         :return: Response
         """
-        return self.configuration.update_static_configuration(configuration)
+        return self.configuration.update_static(configuration)
 
     @deprecated_in_version(version="12.0.0")
     @require_data_admin
@@ -239,24 +247,20 @@ class ServerService(ObjectService):
         process_service = ProcessService(self._rest)
         return process_service.execute_ti_code(ti, **kwargs)
 
-    @require_ops_admin
     def start_performance_monitor(self):
         config = {
             "Administration": {"PerformanceMonitorOn": True}
         }
-        self.update_static_configuration(config)
+        self.configuration.update_static(config)
 
-    @require_ops_admin
     def stop_performance_monitor(self):
         config = {
             "Administration": {"PerformanceMonitorOn": False}
         }
-        self.update_static_configuration(config)
+        self.configuration.update_static(config)
 
-    @require_ops_admin
     def activate_audit_log(self):
-        config = {'Administration': {'AuditLog': {'Enable': True}}}
-        self.update_static_configuration(config)
+        self.audit_logs.activate()
 
     @require_ops_admin
     def deactivate_audit_log(self):
@@ -272,9 +276,7 @@ class ServerService(ObjectService):
         :return:
         '''
 
-        payload = {"Level": level}
-        url = f"/Loggers('{logger}')"
-        return self._rest.PATCH(url, json.dumps(payload))
+        return self.loggers.set_level(logger, level)
 
     @require_admin
     def get_all_message_logger_level(self):
@@ -284,6 +286,5 @@ class ServerService(ObjectService):
         :param level:
         :return:
         '''
-        url = f"/Loggers"
-        return self._rest.GET(url).content
 
+        return self.loggers.get_all()

--- a/TM1py/Services/ServerService.py
+++ b/TM1py/Services/ServerService.py
@@ -1,33 +1,21 @@
 # -*- coding: utf-8 -*-
-from warnings import warn
 
-import functools
-import json
 from collections.abc import Iterable
 from datetime import datetime
 from enum import Enum
-from typing import Dict, Optional, List
 from typing import Dict, Optional
 from warnings import warn
-import pytz
+
 import pytz
 from requests import Response
-from typing import Dict, Optional, List
-from typing import Dict, Optional
-from warnings import warn
-import pytz
 
 from TM1py.Services.AuditLogService import AuditLogService
 from TM1py.Services.ConfigurationService import ConfigurationService
+from TM1py.Services.LoggerService import LoggerService
 from TM1py.Services.MessageLogService import MessageLogService
 from TM1py.Services.ObjectService import ObjectService
 from TM1py.Services.RestService import RestService
-from TM1py.Utils.Utils import require_admin, require_ops_admin, require_data_admin, deprecated_in_version
 from TM1py.Services.TransactionLogService import TransactionLogService
-from TM1py.Utils.Utils import require_admin, require_version, \
-    deprecated_in_version
-from TM1py.Utils.Utils import require_data_admin, \
-    require_ops_admin
 from TM1py.Utils.Utils import require_admin, require_version, \
     deprecated_in_version
 from TM1py.Utils.Utils import require_data_admin, \
@@ -56,6 +44,7 @@ class ServerService(ObjectService):
         self.configuration = ConfigurationService(rest)
         self.audit_logs = AuditLogService(rest)
         self.loggers = LoggerService(rest)
+
     def initialize_transaction_log_delta_requests(self, filter=None, **kwargs):
         return self.transaction_logs.initialize_delta_requests(filter, **kwargs)
 

--- a/TM1py/Services/ServerService.py
+++ b/TM1py/Services/ServerService.py
@@ -22,6 +22,7 @@ from TM1py.Utils.Utils import CaseAndSpaceInsensitiveDict, CaseAndSpaceInsensiti
     decohints, deprecated_in_version
 from TM1py.Services.TransactionLogService import TransactionLogService
 from TM1py.Services.MessageLogService import MessageLogService
+from TM1py.Services.ConfigurationService import ConfigurationService
 
 
 class LogLevel(Enum):
@@ -43,6 +44,7 @@ class ServerService(ObjectService):
         warn("Server Service will be moved to a new location in a future version", DeprecationWarning, 2)
         self.transaction_logs = TransactionLogService(rest)
         self.message_logs = MessageLogService(rest)
+        self.configuration = ConfigurationService(rest)
         self.mlog_last_delta_request = None
         self.alog_last_delta_request = None
 
@@ -202,7 +204,7 @@ class ServerService(ObjectService):
 
     @require_ops_admin
     @deprecated_in_version(version="12.0.0")
-    def get_last_process_message_from_messagelog(self, process_name: str, **kwargs) -> Optional[str]:
+    def get_last_process_message_from_message_log(self, process_name: str, **kwargs) -> Optional[str]:
         """ Get the latest message log entry for a process
 
             :param process_name: name of the process
@@ -216,8 +218,7 @@ class ServerService(ObjectService):
         :Returns:
             String, the server name
         """
-        url = '/Configuration/ServerName/$value'
-        return self._rest.GET(url, **kwargs).text
+        return self.configuration.get_server_name()
 
     def get_product_version(self, **kwargs) -> str:
         """ Ask TM1 Server for its version
@@ -225,35 +226,22 @@ class ServerService(ObjectService):
         :Returns:
             String, the version
         """
-        url = '/Configuration/ProductVersion/$value'
-        return self._rest.GET(url, **kwargs).text
+        return self.configuration.get_product_version()
 
     @deprecated_in_version(version="12.0.0")
     def get_admin_host(self, **kwargs) -> str:
-        url = '/Configuration/AdminHost/$value'
-        return self._rest.GET(url, **kwargs).text
+        return self.configuration.get_admin_host
 
     @deprecated_in_version(version="12.0.0")
     def get_data_directory(self, **kwargs) -> str:
-        url = '/Configuration/DataBaseDirectory/$value'
-        return self._rest.GET(url, **kwargs).text
+        return self.configuration.get_data_directory
 
     def get_configuration(self, **kwargs) -> Dict:
-        url = '/Configuration'
-        config = self._rest.GET(url, **kwargs).json()
-        del config["@odata.context"]
-        return config
+        return self.configuration.get()
 
     @require_ops_admin
     def get_static_configuration(self, **kwargs) -> Dict:
-        """ Read TM1 config settings as dictionary from TM1 Server
-
-        :return: config as dictionary
-        """
-        url = '/StaticConfiguration'
-        config = self._rest.GET(url, **kwargs).json()
-        del config["@odata.context"]
-        return config
+        return self.configuration.get_static()
 
     @require_ops_admin
     def get_active_configuration(self, **kwargs) -> Dict:
@@ -261,10 +249,7 @@ class ServerService(ObjectService):
 
         :return: config as dictionary
         """
-        url = '/ActiveConfiguration'
-        config = self._rest.GET(url, **kwargs).json()
-        del config["@odata.context"]
-        return config
+        return self.configuration.get_active()
 
     def get_api_metadata(self, **kwargs):
         """ Read effective(!) TM1 config settings as dictionary from TM1 Server

--- a/TM1py/Services/ServerService.py
+++ b/TM1py/Services/ServerService.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from warnings import warn
 
 import functools
 import json
@@ -55,6 +56,7 @@ class ServerService(ObjectService):
 
     def __init__(self, rest: RestService):
         super().__init__(rest)
+        warn("Server Service will be moved to a new location in a future version", DeprecationWarning, 2)
         self.tlog_last_delta_request = None
         self.mlog_last_delta_request = None
         self.alog_last_delta_request = None

--- a/TM1py/Services/SessionService.py
+++ b/TM1py/Services/SessionService.py
@@ -16,7 +16,7 @@ class SessionService(ObjectService):
         super().__init__(rest)
         self.users = UserService(rest)
 
-    def get(self, include_user: bool = True, include_threads: bool = True, **kwargs) -> List:
+    def get_all(self, include_user: bool = True, include_threads: bool = True, **kwargs) -> List:
         url = "/Sessions"
         if include_user or include_threads:
             expands = list()
@@ -50,7 +50,7 @@ class SessionService(ObjectService):
     @require_admin
     def close_all(self, **kwargs) -> list:
         current_user = self.users.get_current(**kwargs)
-        sessions = self.get(**kwargs)
+        sessions = self.get_all(**kwargs)
         closed_sessions = list()
         for session in sessions:
             if "User" not in session:

--- a/TM1py/Services/SessionService.py
+++ b/TM1py/Services/SessionService.py
@@ -1,0 +1,66 @@
+from typing import List
+from requests import Response
+
+from TM1py.Services.ObjectService import ObjectService
+from TM1py.Services.RestService import RestService
+from TM1py.Services.UserService import UserService
+from TM1py.Utils import format_url, case_and_space_insensitive_equals, require_admin
+
+
+class SessionService(ObjectService):
+    """ Service to Query and Cancel Threads in TM1
+
+    """
+
+    def __init__(self, rest: RestService):
+        super().__init__(rest)
+        self.users = UserService(rest)
+
+    def get(self, include_user: bool = True, include_threads: bool = True, **kwargs) -> List:
+        url = "/Sessions"
+        if include_user or include_threads:
+            expands = list()
+            if include_user:
+                expands.append("User")
+            if include_threads:
+                expands.append("Threads")
+            url += "?$expand=" + ",".join(expands)
+
+        response = self._rest.GET(url, **kwargs)
+        return response.json()["value"]
+
+    def get_current(self, **kwargs):
+        url = "/ActiveSession"
+
+        response = self._rest.GET(url, **kwargs)
+        return response.json()['value']
+
+    def get_threads_for_current(self, exclude_idle: bool = True, **kwargs):
+        url = "/ActiveSession/Threads?$filter=Function ne 'GET /ActiveSession/Threads'"
+        if exclude_idle:
+            url += " and State ne 'Idle'"
+
+        response = self._rest.GET(url, **kwargs)
+        return response.json()['value']
+
+    def close(self, session_id, **kwargs) -> Response:
+        url = format_url(f"/Sessions('{session_id}')/tm1.Close")
+        return self._rest.POST(url, **kwargs)
+
+    @require_admin
+    def close_all(self, **kwargs) -> list:
+        current_user = self.users.get_current(**kwargs)
+        sessions = self.get(**kwargs)
+        closed_sessions = list()
+        for session in sessions:
+            if "User" not in session:
+                continue
+            if session["User"] is None:
+                continue
+            if "Name" not in session["User"]:
+                continue
+            if case_and_space_insensitive_equals(current_user.name, session["User"]["Name"]):
+                continue
+            self.close(session['ID'], **kwargs)
+            closed_sessions.append(session)
+        return closed_sessions

--- a/TM1py/Services/TM1Service.py
+++ b/TM1py/Services/TM1Service.py
@@ -1,9 +1,9 @@
 import pickle
 
 
-from TM1py.Services import HierarchyService, SecurityService, ApplicationService, SubsetService, ServerService, \
-    MonitoringService, ProcessService, PowerBiService, AnnotationService, ViewService, RestService, CellService, \
-    ChoreService, DimensionService, CubeService, ElementService, SandboxService, GitService
+from TM1py.Services import HierarchyService, SecurityService, ApplicationService, SubsetService, \
+     ProcessService, AnnotationService, ViewService, RestService, CellService, \
+     ChoreService, DimensionService, CubeService, ElementService, SandboxService, GitService
 from TM1py.Services.FileService import FileService
 from TM1py.Services.JobService import JobService
 from TM1py.Services.UserService import UserService
@@ -13,6 +13,10 @@ from TM1py.Services.TransactionLogService import TransactionLogService
 from TM1py.Services.MessageLogService import MessageLogService
 from TM1py.Services.ConfigurationService import ConfigurationService
 from TM1py.Services.AuditLogService import AuditLogService
+
+from TM1py.Services.PowerBiService import PowerBiService
+from TM1py.Services.ServerService import ServerService
+from TM1py.Services.MonitoringService import MonitoringService
 
 class TM1Service:
     """ All features of TM1py are exposed through this service
@@ -67,11 +71,8 @@ class TM1Service:
         self.elements = ElementService(self._tm1_rest)
         self.git = GitService(self._tm1_rest)
         self.hierarchies = HierarchyService(self._tm1_rest)
-        self.monitoring = MonitoringService(self._tm1_rest)
-        self.power_bi = PowerBiService(self._tm1_rest)
         self.processes = ProcessService(self._tm1_rest)
         self.security = SecurityService(self._tm1_rest)
-        self.server = ServerService(self._tm1_rest)
         self.subsets = SubsetService(self._tm1_rest)
         self.applications = ApplicationService(self._tm1_rest)
         self.views = ViewService(self._tm1_rest)
@@ -86,6 +87,11 @@ class TM1Service:
         self.configuration = ConfigurationService(self._tm1_rest)
         self.audit_logs = AuditLogService(self._tm1_rest)
 
+        #higher level modules
+        self.server = ServerService(self._tm1_rest)
+        self.monitoring = MonitoringService(self._tm1_rest)
+        self.power_bi = PowerBiService(self._tm1_rest)
+
     def logout(self, **kwargs):
         self._tm1_rest.logout(**kwargs)
 
@@ -98,6 +104,10 @@ class TM1Service:
     @property
     def whoami(self):
         return self.security.get_current_user()
+
+    @property
+    def metadata(self):
+        return self._tm1_rest.get_api_metadata()
 
     @property
     def version(self):

--- a/TM1py/Services/TM1Service.py
+++ b/TM1py/Services/TM1Service.py
@@ -13,6 +13,7 @@ from TM1py.Services.TransactionLogService import TransactionLogService
 from TM1py.Services.MessageLogService import MessageLogService
 from TM1py.Services.ConfigurationService import ConfigurationService
 from TM1py.Services.AuditLogService import AuditLogService
+from TM1py.Services.LoggerService import LoggerService
 
 from TM1py.Services.PowerBiService import PowerBiService
 from TM1py.Services.ServerService import ServerService
@@ -91,6 +92,7 @@ class TM1Service:
         self.server = ServerService(self._tm1_rest)
         self.monitoring = MonitoringService(self._tm1_rest)
         self.power_bi = PowerBiService(self._tm1_rest)
+        self.loggers = LoggerService(self._tm1_rest)
 
     def logout(self, **kwargs):
         self._tm1_rest.logout(**kwargs)

--- a/TM1py/Services/TM1Service.py
+++ b/TM1py/Services/TM1Service.py
@@ -7,6 +7,7 @@ from TM1py.Services.FileService import FileService
 from TM1py.Services.JobService import JobService
 from TM1py.Services.UserService import UserService
 from TM1py.Services.ThreadService import ThreadService
+from TM1py.Services.SessionService import SessionService
 
 
 class TM1Service:
@@ -75,6 +76,7 @@ class TM1Service:
         self.jobs = JobService(self._tm1_rest)
         self.users = UserService(self._tm1_rest)
         self.threads = ThreadService(self._tm1_rest)
+        self.sessions = SessionService(self._tm1_rest)
 
     def logout(self, **kwargs):
         self._tm1_rest.logout(**kwargs)

--- a/TM1py/Services/TM1Service.py
+++ b/TM1py/Services/TM1Service.py
@@ -1,5 +1,6 @@
 import pickle
 
+
 from TM1py.Services import HierarchyService, SecurityService, ApplicationService, SubsetService, ServerService, \
     MonitoringService, ProcessService, PowerBiService, AnnotationService, ViewService, RestService, CellService, \
     ChoreService, DimensionService, CubeService, ElementService, SandboxService, GitService
@@ -8,7 +9,7 @@ from TM1py.Services.JobService import JobService
 from TM1py.Services.UserService import UserService
 from TM1py.Services.ThreadService import ThreadService
 from TM1py.Services.SessionService import SessionService
-
+from TM1py.Services.TransactionLogService import TransactionLogService
 
 class TM1Service:
     """ All features of TM1py are exposed through this service
@@ -77,6 +78,7 @@ class TM1Service:
         self.users = UserService(self._tm1_rest)
         self.threads = ThreadService(self._tm1_rest)
         self.sessions = SessionService(self._tm1_rest)
+        self.transaction_logs = TransactionLogService(self._tm1_rest)
 
     def logout(self, **kwargs):
         self._tm1_rest.logout(**kwargs)

--- a/TM1py/Services/TM1Service.py
+++ b/TM1py/Services/TM1Service.py
@@ -10,7 +10,7 @@ from TM1py.Services.UserService import UserService
 from TM1py.Services.ThreadService import ThreadService
 from TM1py.Services.SessionService import SessionService
 from TM1py.Services.TransactionLogService import TransactionLogService
-
+from TM1py.Services.MessageLogService import MessageLogService
 class TM1Service:
     """ All features of TM1py are exposed through this service
     
@@ -79,6 +79,7 @@ class TM1Service:
         self.threads = ThreadService(self._tm1_rest)
         self.sessions = SessionService(self._tm1_rest)
         self.transaction_logs = TransactionLogService(self._tm1_rest)
+        self.message_logs = MessageLogService(self._tm1_rest)
 
     def logout(self, **kwargs):
         self._tm1_rest.logout(**kwargs)

--- a/TM1py/Services/TM1Service.py
+++ b/TM1py/Services/TM1Service.py
@@ -11,6 +11,7 @@ from TM1py.Services.ThreadService import ThreadService
 from TM1py.Services.SessionService import SessionService
 from TM1py.Services.TransactionLogService import TransactionLogService
 from TM1py.Services.MessageLogService import MessageLogService
+from TM1py.Services.ConfigurationService import ConfigurationService
 class TM1Service:
     """ All features of TM1py are exposed through this service
     
@@ -80,6 +81,7 @@ class TM1Service:
         self.sessions = SessionService(self._tm1_rest)
         self.transaction_logs = TransactionLogService(self._tm1_rest)
         self.message_logs = MessageLogService(self._tm1_rest)
+        self.configuration = ConfigurationService(self._tm1_rest)
 
     def logout(self, **kwargs):
         self._tm1_rest.logout(**kwargs)

--- a/TM1py/Services/TM1Service.py
+++ b/TM1py/Services/TM1Service.py
@@ -4,6 +4,7 @@ from TM1py.Services import HierarchyService, SecurityService, ApplicationService
     MonitoringService, ProcessService, PowerBiService, AnnotationService, ViewService, RestService, CellService, \
     ChoreService, DimensionService, CubeService, ElementService, SandboxService, GitService
 from TM1py.Services.FileService import FileService
+from TM1py.Services.JobService import JobService
 
 
 class TM1Service:
@@ -69,6 +70,7 @@ class TM1Service:
         self.views = ViewService(self._tm1_rest)
         self.sandboxes = SandboxService(self._tm1_rest)
         self.files = FileService(self._tm1_rest)
+        self.jobs = JobService(self._tm1_rest)
 
     def logout(self, **kwargs):
         self._tm1_rest.logout(**kwargs)

--- a/TM1py/Services/TM1Service.py
+++ b/TM1py/Services/TM1Service.py
@@ -5,6 +5,8 @@ from TM1py.Services import HierarchyService, SecurityService, ApplicationService
     ChoreService, DimensionService, CubeService, ElementService, SandboxService, GitService
 from TM1py.Services.FileService import FileService
 from TM1py.Services.JobService import JobService
+from TM1py.Services.UserService import UserService
+from TM1py.Services.ThreadService import ThreadService
 
 
 class TM1Service:
@@ -71,6 +73,8 @@ class TM1Service:
         self.sandboxes = SandboxService(self._tm1_rest)
         self.files = FileService(self._tm1_rest)
         self.jobs = JobService(self._tm1_rest)
+        self.users = UserService(self._tm1_rest)
+        self.threads = ThreadService(self._tm1_rest)
 
     def logout(self, **kwargs):
         self._tm1_rest.logout(**kwargs)

--- a/TM1py/Services/TM1Service.py
+++ b/TM1py/Services/TM1Service.py
@@ -12,6 +12,8 @@ from TM1py.Services.SessionService import SessionService
 from TM1py.Services.TransactionLogService import TransactionLogService
 from TM1py.Services.MessageLogService import MessageLogService
 from TM1py.Services.ConfigurationService import ConfigurationService
+from TM1py.Services.AuditLogService import AuditLogService
+
 class TM1Service:
     """ All features of TM1py are exposed through this service
     
@@ -82,6 +84,7 @@ class TM1Service:
         self.transaction_logs = TransactionLogService(self._tm1_rest)
         self.message_logs = MessageLogService(self._tm1_rest)
         self.configuration = ConfigurationService(self._tm1_rest)
+        self.audit_logs = AuditLogService(self._tm1_rest)
 
     def logout(self, **kwargs):
         self._tm1_rest.logout(**kwargs)

--- a/TM1py/Services/ThreadService.py
+++ b/TM1py/Services/ThreadService.py
@@ -20,7 +20,7 @@ class ThreadService(ObjectService):
             warn("Threads not available in this version of TM1, removed as of 12.0.0", DeprecationWarning, 2)
 
     @deprecated_in_version(version="12.0.0")
-    def get(self, **kwargs) -> List:
+    def get_all(self, **kwargs) -> List:
         """ Return a list of the currently running threads from the TM1 Server
 
             :return:
@@ -54,7 +54,7 @@ class ThreadService(ObjectService):
 
     @deprecated_in_version(version="12.0.0")
     def cancel_all_running(self, **kwargs) -> list:
-        running_threads = self.get(**kwargs)
+        running_threads = self.get_all(**kwargs)
         canceled_threads = list()
         for thread in running_threads:
             if thread["State"] == "Idle":

--- a/TM1py/Services/ThreadService.py
+++ b/TM1py/Services/ThreadService.py
@@ -1,0 +1,71 @@
+from requests import Response
+from warnings import warn
+
+from typing import List
+
+from TM1py.Exceptions.Exceptions import TM1pyVersionDeprecationException
+from TM1py.Services.ObjectService import ObjectService
+from TM1py.Services.RestService import RestService
+from TM1py.Utils.Utils import format_url, verify_version, deprecated_in_version
+
+
+class ThreadService(ObjectService):
+    """ Service to handle TM1 Job objects introduced in v12
+
+    """
+
+    def __init__(self, rest: RestService):
+        super().__init__(rest)
+        if verify_version(required_version="12.0.0", version=self.version):
+            # warn only due to use in Monitoring Service
+            warn("Threads not available in this version of TM1, removed as of 12.0.0", DeprecationWarning, 2)
+
+    @deprecated_in_version(version="12.0.0")
+    def get(self, **kwargs) -> List:
+        """ Return a list of the currently running threads from the TM1 Server
+
+            :return:
+                dict: the response
+        """
+        url = '/Threads'
+        response = self._rest.GET(url, **kwargs)
+        return response.json()['value']
+
+    @deprecated_in_version(version="12.0.0")
+    def get_active(self, **kwargs):
+        """Return a list of non-idle threads from the TM1 Server
+
+            :return:
+                list: TM1 threads as dict
+        """
+        url = "/Threads?$filter=Function ne 'GET /Threads' and State ne 'Idle'"
+        response = self._rest.GET(url, **kwargs)
+        return response.json()['value']
+
+    @deprecated_in_version(version="12.0.0")
+    def cancel(self, thread_id: int, **kwargs) -> Response:
+        """ Kill a running thread
+
+        :param thread_id:
+        :return:
+        """
+        url = format_url("/Threads('{}')/tm1.CancelOperation", str(thread_id))
+        response = self._rest.POST(url, **kwargs)
+        return response
+
+    @deprecated_in_version(version="12.0.0")
+    def cancel_all_running(self, **kwargs) -> list:
+        running_threads = self.get(**kwargs)
+        canceled_threads = list()
+        for thread in running_threads:
+            if thread["State"] == "Idle":
+                continue
+            if thread["Type"] == "System":
+                continue
+            if thread["Name"] == "Pseudo":
+                continue
+            if thread["Function"] == "GET /Threads":
+                continue
+            self.cancel(thread["ID"], **kwargs)
+            canceled_threads.append(thread)
+        return canceled_threads

--- a/TM1py/Services/ThreadService.py
+++ b/TM1py/Services/ThreadService.py
@@ -3,7 +3,6 @@ from warnings import warn
 
 from typing import List
 
-from TM1py.Exceptions.Exceptions import TM1pyVersionDeprecationException
 from TM1py.Services.ObjectService import ObjectService
 from TM1py.Services.RestService import RestService
 from TM1py.Utils.Utils import format_url, verify_version, deprecated_in_version

--- a/TM1py/Services/ThreadService.py
+++ b/TM1py/Services/ThreadService.py
@@ -9,7 +9,8 @@ from TM1py.Utils.Utils import format_url, verify_version, deprecated_in_version
 
 
 class ThreadService(ObjectService):
-    """ Service to handle TM1 Job objects introduced in v12
+    """ Service to work with Threads in TM1
+    Deprecated as of TM1 Server v12
 
     """
 

--- a/TM1py/Services/TransactionLogService.py
+++ b/TM1py/Services/TransactionLogService.py
@@ -27,7 +27,7 @@ class TransactionLogService(ObjectService):
 
     @deprecated_in_version(version="12.0.0")
     @odata_track_changes_header
-    def initialize_log_delta_requests(self, filter=None, **kwargs):
+    def initialize_delta_requests(self, filter=None, **kwargs):
         url = "/TailTransactionLog()"
         if filter:
             url += "?$filter={}".format(filter)
@@ -38,7 +38,7 @@ class TransactionLogService(ObjectService):
 
     @deprecated_in_version(version="12.0.0")
     @odata_track_changes_header
-    def execute_log_delta_request(self, **kwargs) -> Dict:
+    def execute_delta_request(self, **kwargs) -> Dict:
         response = self._rest.GET(
             url="/" + self.last_delta_request, **kwargs)
         self.last_delta_request = response.text[response.text.rfind(

--- a/TM1py/Services/TransactionLogService.py
+++ b/TM1py/Services/TransactionLogService.py
@@ -4,19 +4,19 @@ from warnings import warn
 from datetime import datetime
 from typing import Dict
 
-from TM1py import ObjectService, RestService
+from TM1py.Services.ObjectService import ObjectService
+from TM1py.Services.RestService import RestService
 from TM1py.Utils import verify_version, deprecated_in_version, odata_track_changes_header, require_admin, format_url
 
 
 class TransactionLogService(ObjectService):
 
     def __init__(self, rest: RestService):
-        if verify_version(required_version="12.0.0", version=self.version):
+        super().__init__(rest)
+        if verify_version(required_version="12.0.0", version=rest.version):
             # warn only due to use in Monitoring Service
             warn("Transaction Logs are not available in this version of TM1, removed as of 12.0.0", DeprecationWarning,
                  2)
-
-        super().__init__(rest)
         self.last_delta_request = None
 
     @staticmethod

--- a/TM1py/Services/TransactionLogService.py
+++ b/TM1py/Services/TransactionLogService.py
@@ -1,0 +1,99 @@
+import pytz
+from warnings import warn
+
+from datetime import datetime
+from typing import Dict
+
+from TM1py import ObjectService, RestService
+from TM1py.Utils import verify_version, deprecated_in_version, odata_track_changes_header, require_admin, format_url
+
+
+class TransactionLogService(ObjectService):
+
+    def __init__(self, rest: RestService):
+        if verify_version(required_version="12.0.0", version=self.version):
+            # warn only due to use in Monitoring Service
+            warn("Transaction Logs are not available in this version of TM1, removed as of 12.0.0", DeprecationWarning,
+                 2)
+
+        super().__init__(rest)
+        self.last_delta_request = None
+
+    @staticmethod
+    def utc_localize_time(timestamp):
+        timestamp = pytz.utc.localize(timestamp)
+        timestamp_utc = timestamp.astimezone(pytz.utc)
+        return timestamp_utc
+
+    @deprecated_in_version(version="12.0.0")
+    @odata_track_changes_header
+    def initialize_log_delta_requests(self, filter=None, **kwargs):
+        url = "/TailTransactionLog()"
+        if filter:
+            url += "?$filter={}".format(filter)
+        response = self._rest.GET(url=url, **kwargs)
+        # Read the next delta-request-url from the response
+        self.last_delta_request = response.text[response.text.rfind(
+            "TransactionLogEntries/!delta('"):-2]
+
+    @deprecated_in_version(version="12.0.0")
+    @odata_track_changes_header
+    def execute_log_delta_request(self, **kwargs) -> Dict:
+        response = self._rest.GET(
+            url="/" + self.last_delta_request, **kwargs)
+        self.last_delta_request = response.text[response.text.rfind(
+            "TransactionLogEntries/!delta('"):-2]
+        return response.json()['value']
+
+    @deprecated_in_version(version="12.0.0")
+    @require_admin
+    def get_entries(self, reverse: bool = True, user: str = None, cube: str = None,
+                    since: datetime = None, until: datetime = None, top: int = None,
+                    element_tuple_filter: Dict[str, str] = None,
+                    element_position_filter: Dict[int, Dict[str, str]] = None, **kwargs) -> Dict:
+        """
+        :param reverse: Boolean
+        :param user: UserName
+        :param cube: CubeName
+        :param since: of type datetime. If it doesn't have tz information, UTC is assumed.
+        :param until: of type datetime. If it doesn't have tz information, UTC is assumed.
+        :param top: int
+        :param element_tuple_filter: of type dict. Element name as key and comparison operator as value
+        :param element_position_filter: not yet implemented
+        tuple={'Actual':'eq','2020': 'ge'}
+        :return:
+        """
+        if element_position_filter:
+            raise NotImplementedError("Feature expected in upcoming releases of TM1, TM1py")
+
+        reverse = 'desc' if reverse else 'asc'
+        url = '/TransactionLogEntries?$orderby=TimeStamp {} '.format(reverse)
+
+        # filter on user, cube, time and elements
+        if any([user, cube, since, until, element_tuple_filter, element_position_filter]):
+            log_filters = []
+            if user:
+                log_filters.append(format_url("User eq '{}'", user))
+            if cube:
+                log_filters.append(format_url("Cube eq '{}'", cube))
+            if element_tuple_filter:
+                log_filters.append(format_url(
+                    "Tuple/any(e: {})".format(" or ".join([f"e {v} '{k}'" for k, v in element_tuple_filter.items()]))))
+            if since:
+                # If since doesn't have tz information, UTC is assumed
+                if not since.tzinfo:
+                    since = self.utc_localize_time(since)
+                log_filters.append(format_url(
+                    "TimeStamp ge {}", since.strftime("%Y-%m-%dT%H:%M:%SZ")))
+            if until:
+                # If until doesn't have tz information, UTC is assumed
+                if not until.tzinfo:
+                    until = self.utc_localize_time(until)
+                log_filters.append(format_url(
+                    "TimeStamp le {}", until.strftime("%Y-%m-%dT%H:%M:%SZ")))
+            url += "&$filter={}".format(" and ".join(log_filters))
+        # top limit
+        if top:
+            url += '&$top={}'.format(top)
+        response = self._rest.GET(url, **kwargs)
+        return response.json()['value']

--- a/TM1py/Services/TransactionLogService.py
+++ b/TM1py/Services/TransactionLogService.py
@@ -6,7 +6,7 @@ from typing import Dict
 
 from TM1py.Services.ObjectService import ObjectService
 from TM1py.Services.RestService import RestService
-from TM1py.Utils import verify_version, deprecated_in_version, odata_track_changes_header, require_admin, format_url
+from TM1py.Utils import verify_version, deprecated_in_version, odata_track_changes_header, require_data_admin, format_url
 
 
 class TransactionLogService(ObjectService):
@@ -46,7 +46,7 @@ class TransactionLogService(ObjectService):
         return response.json()['value']
 
     @deprecated_in_version(version="12.0.0")
-    @require_admin
+    @require_data_admin
     def get_entries(self, reverse: bool = True, user: str = None, cube: str = None,
                     since: datetime = None, until: datetime = None, top: int = None,
                     element_tuple_filter: Dict[str, str] = None,

--- a/TM1py/Services/UserService.py
+++ b/TM1py/Services/UserService.py
@@ -12,7 +12,7 @@ class UserService(ObjectService):
     def __init__(self, rest: RestService):
         super().__init__(rest)
 
-    def get(self, **kwargs) ->List[User]:
+    def get_all(self, **kwargs) ->List[User]:
         """ Get all users
 
         :return: List of TM1py.User instances

--- a/TM1py/Services/UserService.py
+++ b/TM1py/Services/UserService.py
@@ -1,0 +1,69 @@
+from requests import Response
+from typing import List
+
+from TM1py.Objects.User import User
+from TM1py.Services.ObjectService import ObjectService
+from TM1py.Services.RestService import RestService
+from TM1py.Utils import format_url, case_and_space_insensitive_equals, require_admin, deprecated_in_version
+
+
+class UserService(ObjectService):
+
+    def __init__(self, rest: RestService):
+        super().__init__(rest)
+
+    def get(self, **kwargs) ->List[User]:
+        """ Get all users
+
+        :return: List of TM1py.User instances
+        """
+        url = '/Users?$expand=Groups'
+        response = self._rest.GET(url, **kwargs)
+        users = [User.from_dict(user) for user in response.json()['value']]
+        return users
+
+    def get_active(self, **kwargs) -> List[User]:
+        """ Get the activate users in TM1
+
+        :return: List of TM1py.User instances
+        """
+        url = '/Users?$filter=IsActive eq true&$expand=Groups'
+        response = self._rest.GET(url, **kwargs)
+        users = [User.from_dict(user) for user in response.json()['value']]
+        return users
+
+    def is_active(self, user_name: str, **kwargs) -> bool:
+        """ Check if user is currently active in TM1
+
+        :param user_name:
+        :return: Boolean
+        """
+        url = format_url("/Users('{}')/IsActive", user_name)
+        response = self._rest.GET(url, **kwargs)
+        return bool(response.json()['value'])
+
+    def disconnect(self, user_name: str, **kwargs) -> Response:
+        """ Disconnect User
+
+        :param user_name:
+        :return:
+        """
+        url = format_url("/Users('{}')/tm1.Disconnect", user_name)
+        response = self._rest.POST(url, **kwargs)
+        return response
+
+    @require_admin
+    def disconnect_all(self, **kwargs) -> list:
+        current_user = self.get_current(**kwargs)
+        active_users = self.get_active(**kwargs)
+        disconnected_users = list()
+        for active_user in active_users:
+            if not case_and_space_insensitive_equals(current_user.name, active_user.name):
+                self.disconnect(active_user.name, **kwargs)
+                disconnected_users += [active_user.name]
+        return disconnected_users
+
+    def get_current(self, **kwargs):
+        from TM1py import SecurityService
+        security_service = SecurityService(self._rest)
+        return security_service.get_current_user(**kwargs)

--- a/TM1py/Services/__init__.py
+++ b/TM1py/Services/__init__.py
@@ -24,3 +24,4 @@ from TM1py.Services.UserService import UserService
 from TM1py.Services.ThreadService import ThreadService
 from TM1py.Services.SessionService import SessionService
 from TM1py.Services.TransactionLogService import TransactionLogService
+from TM1py.Services.MessageLogService import MessageLogService

--- a/TM1py/Services/__init__.py
+++ b/TM1py/Services/__init__.py
@@ -7,13 +7,10 @@ from TM1py.Services.DimensionService import DimensionService
 from TM1py.Services.ElementService import ElementService
 from TM1py.Services.GitService import GitService
 from TM1py.Services.HierarchyService import HierarchyService
-from TM1py.Services.MonitoringService import MonitoringService
-from TM1py.Services.PowerBiService import PowerBiService
 from TM1py.Services.ProcessService import ProcessService
 from TM1py.Services.RestService import RestService
 from TM1py.Services.SandboxService import SandboxService
 from TM1py.Services.SecurityService import SecurityService
-from TM1py.Services.ServerService import ServerService
 from TM1py.Services.SubsetService import SubsetService
 from TM1py.Services.ViewService import ViewService
 from TM1py.Services.GitService import GitService
@@ -27,3 +24,7 @@ from TM1py.Services.TransactionLogService import TransactionLogService
 from TM1py.Services.MessageLogService import MessageLogService
 from TM1py.Services.ConfigurationService import ConfigurationService
 from TM1py.Services.AuditLogService import AuditLogService
+
+from TM1py.Services.ServerService import ServerService
+from TM1py.Services.MonitoringService import MonitoringService
+from TM1py.Services.PowerBiService import PowerBiService

--- a/TM1py/Services/__init__.py
+++ b/TM1py/Services/__init__.py
@@ -23,3 +23,4 @@ from TM1py.Services.JobService import JobService
 from TM1py.Services.UserService import UserService
 from TM1py.Services.ThreadService import ThreadService
 from TM1py.Services.SessionService import SessionService
+from TM1py.Services.TransactionLogService import TransactionLogService

--- a/TM1py/Services/__init__.py
+++ b/TM1py/Services/__init__.py
@@ -19,3 +19,4 @@ from TM1py.Services.ViewService import ViewService
 from TM1py.Services.GitService import GitService
 from TM1py.Services.TM1Service import TM1Service
 from TM1py.Services.ManageService import ManageService
+from TM1py.Services.JobService import JobService

--- a/TM1py/Services/__init__.py
+++ b/TM1py/Services/__init__.py
@@ -25,3 +25,4 @@ from TM1py.Services.ThreadService import ThreadService
 from TM1py.Services.SessionService import SessionService
 from TM1py.Services.TransactionLogService import TransactionLogService
 from TM1py.Services.MessageLogService import MessageLogService
+from TM1py.Services.ConfigurationService import ConfigurationService

--- a/TM1py/Services/__init__.py
+++ b/TM1py/Services/__init__.py
@@ -21,3 +21,4 @@ from TM1py.Services.TM1Service import TM1Service
 from TM1py.Services.ManageService import ManageService
 from TM1py.Services.JobService import JobService
 from TM1py.Services.UserService import UserService
+from TM1py.Services.ThreadService import ThreadService

--- a/TM1py/Services/__init__.py
+++ b/TM1py/Services/__init__.py
@@ -26,3 +26,4 @@ from TM1py.Services.SessionService import SessionService
 from TM1py.Services.TransactionLogService import TransactionLogService
 from TM1py.Services.MessageLogService import MessageLogService
 from TM1py.Services.ConfigurationService import ConfigurationService
+from TM1py.Services.AuditLogService import AuditLogService

--- a/TM1py/Services/__init__.py
+++ b/TM1py/Services/__init__.py
@@ -22,3 +22,4 @@ from TM1py.Services.ManageService import ManageService
 from TM1py.Services.JobService import JobService
 from TM1py.Services.UserService import UserService
 from TM1py.Services.ThreadService import ThreadService
+from TM1py.Services.SessionService import SessionService

--- a/TM1py/Services/__init__.py
+++ b/TM1py/Services/__init__.py
@@ -20,3 +20,4 @@ from TM1py.Services.GitService import GitService
 from TM1py.Services.TM1Service import TM1Service
 from TM1py.Services.ManageService import ManageService
 from TM1py.Services.JobService import JobService
+from TM1py.Services.UserService import UserService

--- a/TM1py/Services/__init__.py
+++ b/TM1py/Services/__init__.py
@@ -24,6 +24,7 @@ from TM1py.Services.TransactionLogService import TransactionLogService
 from TM1py.Services.MessageLogService import MessageLogService
 from TM1py.Services.ConfigurationService import ConfigurationService
 from TM1py.Services.AuditLogService import AuditLogService
+from TM1py.Services.LoggerService import LoggerService
 
 from TM1py.Services.ServerService import ServerService
 from TM1py.Services.MonitoringService import MonitoringService

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -39,6 +39,27 @@ def decohints(decorator: Callable) -> Callable:
 
 
 @decohints
+def odata_track_changes_header(func):
+    """ Higher Order function to handle addition and removal of odata.track-changes HTTP Header
+
+    :param func:
+    :return:
+    """
+
+    @functools.wraps(func)
+    def wrapper(self, *args, **kwargs):
+        # Add header
+        self._rest.add_http_header("Prefer", "odata.track-changes")
+        # Do stuff
+        response = func(self, *args, **kwargs)
+        # Remove Header
+        self._rest.remove_http_header("Prefer")
+        return response
+
+    return wrapper
+
+
+@decohints
 def require_admin(func):
     @functools.wraps(func)
     def wrapper(self, *args, **kwargs):

--- a/TM1py/__init__.py
+++ b/TM1py/__init__.py
@@ -69,5 +69,6 @@ from TM1py.Services.ThreadService import ThreadService
 from TM1py.Services.SessionService import SessionService
 from TM1py.Services.TransactionLogService import TransactionLogService
 from TM1py.Services.MessageLogService import MessageLogService
+from TM1py.Services.ConfigurationService import ConfigurationService
 
 __version__ = "2.0"

--- a/TM1py/__init__.py
+++ b/TM1py/__init__.py
@@ -64,5 +64,6 @@ from TM1py.Services.ViewService import ViewService
 from TM1py.Services.ManageService import ManageService
 from TM1py.Utils import Utils
 from TM1py.Services.JobService import JobService
+from TM1py.Services.UserService import UserService
 
 __version__ = "2.0"

--- a/TM1py/__init__.py
+++ b/TM1py/__init__.py
@@ -66,5 +66,6 @@ from TM1py.Utils import Utils
 from TM1py.Services.JobService import JobService
 from TM1py.Services.UserService import UserService
 from TM1py.Services.ThreadService import ThreadService
+from TM1py.Services.SessionService import SessionService
 
 __version__ = "2.0"

--- a/TM1py/__init__.py
+++ b/TM1py/__init__.py
@@ -63,5 +63,6 @@ from TM1py.Services.TM1Service import TM1Service
 from TM1py.Services.ViewService import ViewService
 from TM1py.Services.ManageService import ManageService
 from TM1py.Utils import Utils
+from TM1py.Services.JobService import JobService
 
 __version__ = "2.0"

--- a/TM1py/__init__.py
+++ b/TM1py/__init__.py
@@ -67,5 +67,6 @@ from TM1py.Services.JobService import JobService
 from TM1py.Services.UserService import UserService
 from TM1py.Services.ThreadService import ThreadService
 from TM1py.Services.SessionService import SessionService
+from TM1py.Services.TransactionLogService import TransactionLogService
 
 __version__ = "2.0"

--- a/TM1py/__init__.py
+++ b/TM1py/__init__.py
@@ -40,6 +40,8 @@ from TM1py.Objects.Server import Server
 from TM1py.Objects.Subset import Subset, AnonymousSubset
 from TM1py.Objects.User import User
 from TM1py.Objects.View import View
+from TM1py.Services.ObjectService import ObjectService
+from TM1py.Services.RestService import RestService
 from TM1py.Services.AnnotationService import AnnotationService
 from TM1py.Services.ApplicationService import ApplicationService
 from TM1py.Services.CellService import CellService
@@ -50,19 +52,13 @@ from TM1py.Services.ElementService import ElementService
 from TM1py.Services.FileService import FileService
 from TM1py.Services.GitService import GitService
 from TM1py.Services.HierarchyService import HierarchyService
-from TM1py.Services.MonitoringService import MonitoringService
-from TM1py.Services.ObjectService import ObjectService
-from TM1py.Services.PowerBiService import PowerBiService
 from TM1py.Services.ProcessService import ProcessService
-from TM1py.Services.RestService import RestService
 from TM1py.Services.SandboxService import SandboxService
 from TM1py.Services.SecurityService import SecurityService
-from TM1py.Services.ServerService import ServerService
 from TM1py.Services.SubsetService import SubsetService
 from TM1py.Services.TM1Service import TM1Service
 from TM1py.Services.ViewService import ViewService
 from TM1py.Services.ManageService import ManageService
-from TM1py.Utils import Utils
 from TM1py.Services.JobService import JobService
 from TM1py.Services.UserService import UserService
 from TM1py.Services.ThreadService import ThreadService
@@ -71,5 +67,11 @@ from TM1py.Services.TransactionLogService import TransactionLogService
 from TM1py.Services.MessageLogService import MessageLogService
 from TM1py.Services.ConfigurationService import ConfigurationService
 from TM1py.Services.AuditLogService import AuditLogService
+
+from TM1py.Services.ServerService import ServerService
+from TM1py.Services.PowerBiService import PowerBiService
+from TM1py.Services.MonitoringService import MonitoringService
+
+from TM1py.Utils import Utils
 
 __version__ = "2.0"

--- a/TM1py/__init__.py
+++ b/TM1py/__init__.py
@@ -68,5 +68,6 @@ from TM1py.Services.UserService import UserService
 from TM1py.Services.ThreadService import ThreadService
 from TM1py.Services.SessionService import SessionService
 from TM1py.Services.TransactionLogService import TransactionLogService
+from TM1py.Services.MessageLogService import MessageLogService
 
 __version__ = "2.0"

--- a/TM1py/__init__.py
+++ b/TM1py/__init__.py
@@ -65,5 +65,6 @@ from TM1py.Services.ManageService import ManageService
 from TM1py.Utils import Utils
 from TM1py.Services.JobService import JobService
 from TM1py.Services.UserService import UserService
+from TM1py.Services.ThreadService import ThreadService
 
 __version__ = "2.0"

--- a/TM1py/__init__.py
+++ b/TM1py/__init__.py
@@ -70,5 +70,6 @@ from TM1py.Services.SessionService import SessionService
 from TM1py.Services.TransactionLogService import TransactionLogService
 from TM1py.Services.MessageLogService import MessageLogService
 from TM1py.Services.ConfigurationService import ConfigurationService
+from TM1py.Services.AuditLogService import AuditLogService
 
 __version__ = "2.0"

--- a/Tests/CubeService_test.py
+++ b/Tests/CubeService_test.py
@@ -15,6 +15,7 @@ class TestCubeService(unittest.TestCase):
     prefix = "TM1py_Tests_Cube_"
 
     cube_name = prefix + "some_name"
+    cube_name_to_delete = prefix + "Some_Other_Name"
     control_cube_name = '}' + prefix + 'some_control_cube_name'
     dimension_names = [
         prefix + "dimension1",
@@ -104,7 +105,7 @@ class TestCubeService(unittest.TestCase):
         self.assertFalse(self.tm1.cubes.exists(uuid.uuid4()))
 
     def test_create_delete_cube(self):
-        cube_name = self.prefix + "Some_Other_Name"
+        cube_name = self.cube_name_to_delete
         # element with index 0 is Sandboxes
         dimension_names = self.tm1.dimensions.get_all_names()[1:3]
         cube = Cube(cube_name, dimension_names)
@@ -304,6 +305,8 @@ class TestCubeService(unittest.TestCase):
     @classmethod
     def tearDown(cls):
         cls.tm1.cubes.delete(cls.cube_name)
+        if cls.tm1.cubes.exists(cls.cube_name_to_delete):
+            cls.tm1.cubes.delete(cls.cube_name_to_delete)
         for dimension in cls.dimension_names:
             cls.tm1.dimensions.delete(dimension)
         cls.tm1.logout()

--- a/Tests/ManageService_test.py
+++ b/Tests/ManageService_test.py
@@ -1,0 +1,131 @@
+import configparser
+import pytest
+import random
+import string
+import unittest
+from pathlib import Path
+import time
+
+from TM1py.Services import ManageService, TM1Service
+from .Utils import skip_if_insufficient_version
+from .Utils import verify_version
+
+
+class TestManagerService(unittest.TestCase):
+    manager: ManageService
+    instance = "TM1py_tests_instance"
+    database = "TM1py_tests_database"
+    application = "TM1py_tests_application"
+    backup_set = f"{database}_backup"
+    starting_replicas = 0
+    cpu_requests = "1000m"
+    cpu_limits = "2000m"
+    memory_requests = "1G"
+    memory_limits = "2G"
+    storage_size = "20Gi"
+    version = "12.3.4"
+    application_client = None
+    application_secret = None
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Establishes a connection to the manager endpoint and creates a testing environment
+        """
+        # Manager Connection
+        cls.config = configparser.ConfigParser()
+        cls.config.read(Path(__file__).parent.joinpath('config.ini'))
+        connection_details = cls.config['tm1srv01']
+
+        #Connect to TM1 to get server versions.
+        cls.tm1 = TM1Service(**cls.config['tm1srv01'])
+
+        if verify_version(required_version="12.0.0", version=cls.tm1.version):
+
+            cls.manager = ManageService(domain=connection_details["domain"],
+                                        root_client=connection_details["root_client"],
+                                        root_secret=connection_details["root_secret"])
+
+            # Cleanup and Create New Instance
+            if cls.manager.instance_exists(instance_name=cls.instance):
+                cls.manager.delete_instance(instance_name=cls.instance)
+            cls.manager.create_instance(instance_name=cls.instance)
+
+            # Cleanup and Create New Database
+            if cls.manager.database_exists(instance_name=cls.instance, database_name=cls.database):
+                cls.manager.delete_database(instance_name=cls.instance, database_name=cls.database)
+            cls.manager.create_database(instance_name=cls.instance,
+                                        database_name=cls.database,
+                                        product_version=cls.version,
+                                        number_replicas=cls.starting_replicas,
+                                        cpu_requests=cls.cpu_requests,
+                                        cpu_limits=cls.cpu_limits,
+                                        memory_limits=cls.memory_limits,
+                                        memory_requests=cls.memory_requests,
+                                        storage_size=cls.storage_size)
+        else:
+            raise unittest.SkipTest(f"Skipping all Manager Service tests, version minimum not met, "
+                                    f"12.0.0 > {cls.tm1.version}")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.manager.delete_database(instance_name=cls.instance,
+                                    database_name=cls.database)
+        cls.manager.delete_instance(instance_name=cls.instance)
+
+    def test_get_instance(self):
+        instance = self.manager.get_instance(instance_name=self.instance)
+        self.assertEqual(self.instance, instance.get('Name'))
+
+    def test_get_database(self):
+        database = self.manager.get_database(instance_name=self.instance,
+                                             database_name=self.database)
+        self.assertEqual(self.database, database.get('Name'))
+
+    @pytest.mark.skip(reason="Too slow for regular tests. Only run before releases")
+    def test_scale_database(self):
+        self.manager.scale_database(instance_name=self.instance,
+                                    database_name=self.database,
+                                    replicas=(self.starting_replicas + 1))
+
+        replicas = self.manager.get_database(instance_name=self.instance,
+                                             database_name=self.database).get('Replicas')
+
+        self.assertEqual(replicas, (self.starting_replicas + 1))
+
+        time.sleep(30)
+
+        self.manager.scale_database(instance_name=self.instance,
+                                    database_name=self.database,
+                                    replicas=self.starting_replicas)
+
+        replicas = self.manager.get_database(instance_name=self.instance,
+                                             database_name=self.database).get('Replicas')
+
+        self.assertEqual(replicas, self.starting_replicas)
+
+    def test_create_and_get_application(self):
+
+        # Create Application and Store Credentials
+        self.clientID, self.clientSecret = self.manager.create_application(instance_name=self.instance,
+                                                                           application_name=self.application)
+
+        self.assertIsNotNone(self.clientID)
+        self.assertIsNotNone(self.clientSecret)
+
+        application = self.manager.get_application(instance_name=self.instance, application_name=self.application)
+
+        self.assertEqual(self.application, application.get('Name'))
+
+    @pytest.mark.skip(reason="Too slow for regular tests. Only run before releases")
+    def test_create_backup_set(self):
+
+        response = self.manager.create_database_backup(instance_name=self.instance,
+                                                       database_name=self.database,
+                                                       backup_set_name=self.backup_set)
+
+        self.assertTrue(response.ok)
+
+
+if __name__ == '__main__':
+    unittest.main(failfast=True)


### PR DESCRIPTION
Successor of #1036 

> Creation of new low level methods to standardize how TM1py services line up with the API entities. New services include
> 
> Threads
> Users
> Sessions
> AuditLogs
> MessageLogs
> TransactionLogs
> Configuration
> Loggers
> Testing remains in the Server and Monitor tests, but should be moved eventually
> 
> v12 connections will show warnings of deprecated modules.
> v11 connections will not be allowed to call v12 only methods via required version decorators
> 
> Some minor methods remain in the Server module until they find a better home.

Nice work @rclapp and @adscheevel!!
The separation into low-level and high-level services is very tidy. Glad to have this for the v2 release.
Please feel free to take a final look and approve before we merge.

I had to rebase on the current master. Therefor the separate PR
