### PR TITLE
FileService updates

### DIFF
--- a/TM1py/Services/FileService.py
+++ b/TM1py/Services/FileService.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import json
+from typing import List, Iterable
 
 from TM1py.Services import RestService
 from TM1py.Services.ObjectService import ObjectService
@@ -87,3 +88,37 @@ class FileService(ObjectService):
             version_content_path=self.version_content_path)
 
         return self._rest.DELETE(url, **kwargs)
+    
+    def search_string_in_name(self, name_startswith: str = None, name_contains: Iterable = None, 
+                              name_contains_operator: str = 'and', **kwargs) -> List[str]:
+        
+        url = format_url(
+            "/Contents('{version_content_path}')/Contents?$select=Name",
+            version_content_path=self.version_content_path)
+        
+        name_contains_operator = name_contains_operator.strip().lower()
+        if name_contains_operator not in ("and", "or"):
+            raise ValueError("'name_contains_operator' must be either 'AND' or 'OR'")
+        
+        name_filters = []
+
+        if name_startswith:
+            name_filters.append(format_url("startswith(tolower(Name),tolower('{}'))", name_startswith))
+
+        if name_contains:
+            if isinstance(name_contains, str):
+                name_filters.append(format_url("contains(tolower(Name),tolower('{}'))", name_contains))
+
+            elif isinstance(name_contains, Iterable):
+                name_contains_filters = [format_url("contains(tolower(Name),tolower('{}'))", wildcard)
+                                         for wildcard in name_contains]
+                name_filters.append("({})".format(f" {name_contains_operator} ".join(name_contains_filters)))
+
+            else:
+                raise ValueError("'name_contains' must be str or iterable")
+
+        url += "&$filter={}".format(f" and ".join(name_filters))
+
+        response = self._rest.GET(url, **kwargs).content
+
+        return list(file['Name'] for file in json.loads(response)['value'])

--- a/TM1py/Services/FileService.py
+++ b/TM1py/Services/FileService.py
@@ -21,13 +21,15 @@ class FileService(ObjectService):
         else:
             self.version_content_path = 'Blobs'
 
-    def get_names(self, **kwargs) -> bytes:
+    def get_names(self, return_list: bool=False, **kwargs) -> bytes:
 
         url = format_url(
             "/Contents('{version_content_path}')/Contents?$select=Name",
             version_content_path=self.version_content_path)
 
-        return self._rest.GET(url, **kwargs).content
+        response = self._rest.GET(url, **kwargs).content
+
+        return response if not return_list else [file['Name'] for file in json.loads(response)['value']]
 
     def get(self, file_name: str, **kwargs) -> bytes:
 

--- a/TM1py/Services/FileService.py
+++ b/TM1py/Services/FileService.py
@@ -23,6 +23,10 @@ class FileService(ObjectService):
             self.version_content_path = 'Blobs'
 
     def get_names(self, return_list: bool=False, **kwargs) -> bytes:
+        """ return list of blob file names
+
+        :param return_list: True to return list, otherwise will return bytes        
+        """
 
         url = format_url(
             "/Contents('{version_content_path}')/Contents?$select=Name",
@@ -91,6 +95,12 @@ class FileService(ObjectService):
     
     def search_string_in_name(self, name_startswith: str = None, name_contains: Iterable = None, 
                               name_contains_operator: str = 'and', **kwargs) -> List[str]:
+        """ Return list of blob files that match search critera
+
+        :param name_startswith: str, file name begins with (case insensitive)
+        :param name_contains: iterable, found anywhere in name (case insensitive)
+        :param name_contains_operator: 'and' or 'or'
+        """
         
         url = format_url(
             "/Contents('{version_content_path}')/Contents?$select=Name",

--- a/Tests/FileService_test.py
+++ b/Tests/FileService_test.py
@@ -45,6 +45,19 @@ class TestFileService(unittest.TestCase):
             self.assertEqual(original_file.read(), created_file)
 
     @skip_if_insufficient_version(version="11.4")
+    def test_get_names(self):
+        self.assertEqual('bytes', type(self.tm1.files.get_names()))
+        self.assertEqual('list', type(self.tm1.files.get_names(return_list=True)))
+
+    @skip_if_insufficient_version(version="11.4")
+    def test_search_string_in_name(self):
+        self.assertTrue(self.FILE_NAME1 in self.tm1.files.search_string_in_name(name_starts_with=self.FILE_NAME1[:5]))
+        self.assertFalse(self.FILE_NAME1 in self.tm1.files.search_string_in_name(name_starts_with='not_the_file_im_looking_for'))
+        self.assertTrue(self.FILE_NAME1 in self.tm1.files.search_string_in_name(name_contains=[self.FILE_NAME1[:5], self.FILE_NAME1[-5:]]))
+        self.assertFalse(self.FILE_NAME1 in self.tm1.files.search_string_in_name(name_contains=[self.FILE_NAME1[:5], 'NotFound']))
+        self.assertTrue(self.FILE_NAME1 in self.tm1.files.search_string_in_name(name_contains=[self.FILE_NAME1[:5], 'NotFound']), name_contains_operator='OR')
+
+    @skip_if_insufficient_version(version="11.4")
     def test_delete_exists(self):
         self.assertTrue(self.tm1.files.exists(self.FILE_NAME1))
 


### PR DESCRIPTION
The function `get_names` in FileService currently returns bytes only. I've added a parameter _return_list_ to optionally return a list instead of bytes. Default behavior of the function is unchanged. I left the type indicator on the function as bytes even though the return can be either bytes or list. This inaction is due to my ignorance on how to properly use type indicators.

I've also added a function `search_string_in_name` that works similar to the function of the same name in ProcessService.

I've taken a stab at adding test cases for both functions to FileService_test.py, but don't have a good way to test the tests.

example usage of `search_string_in_name` assuming a file with name "TM1py_unittest_file1" exists on the server:

```
from TM1py import TM1Service

tm1params = {...}

with TM1Service(**tm1params) as tm1:
    filename = 'TM1py_unittest_file1'

    # will return True
    filename in tm1.search_string_in_name(name_startswith='tm1')

    # will also return True (name_contains_operator defaults to AND)
    filename in tm1.search_string_in_name(name_contains=['tm1', 'file'])

    # will return True (file starts with 'TM1' AND contains the word 'file'
    filename in tm1.search_string_in_name(name_startswith='TM1', name_contains='file')

    # will still return True
    filename in tm1.search_string_in_name(name_contains=['tm1', 'not my file'], name_contains_operator='or')



```

