### PR TITLE
Making Rule Object Updatable

### DIFF
--- a/TM1py/Objects/Rules.py
+++ b/TM1py/Objects/Rules.py
@@ -44,6 +44,31 @@ class Rules(TM1Object):
             return self.rules_analytics[:self._rules_analytics.index('FEEDERS')]
         return self.rules_analytics
 
+    def add_rule_statements(self, statements:Union[str, List[str]]):
+        if isinstance(statements, list):
+            statements = '\n'.join(statements)
+        if self.has_feeders:
+            text_split = self._text.split('FEEDERS;')
+            self._text = f"{text_split[0]}\n{statements}\nFEEDERS;\n{text_split[1]}"
+        else:
+            self._text += f"\n{statements}"
+        self.init_analytics()
+
+    # This function is a little more complicated, because it avoids calling init_analytics() to optimize processing time
+    def add_rule_statements(self, statements: Union[str, List[str]]):
+        if isinstance(statements, str):
+            statements = [statements]
+        modified_statements = list(map(lambda x: x[:-1] if ';' in x else x, statements))
+        if self.has_feeders:
+            text_split = self._text.split('FEEDERS;')
+            statements_string = "\n".join(statements)
+            self._text = f"{text_split[0]}{statements_string}\nFEEDERS;{text_split[1]}"
+            feeders_index = self._rules_analytics.index('FEEDERS')
+            self._rules_analytics = self._rules_analytics[:feeders_index] + modified_statements + self._rules_analytics[feeders_index:]
+        else:
+            self._text += "\n"+"\n".join(statements)
+            self._rules_analytics += modified_statements
+
     @property
     def feeder_statements(self) -> List[str]:
         if self.has_feeders:


### PR DESCRIPTION
There was a certain amount of clunkiness with modifying a cube's rule. The only way to do so is to get the entire text of the rule, make the changes, and then pass the text back to the rule. That method is especially difficult for adding rule statements when there are feeder statements present.
So I added functions "add_rule_statements" and "add_feeder_statements" to the Rule Object so that the Rule file can be modified, rather than having to be completely redefined. In the pull request, there are two options of functions to create this feature, I included both and leave it up to the maintainers to decide which one (or create a new one) is better.

Thank you!
Ben Dunleavy