### PR TITLE
Update ApplicationService.py to support application update or create

### DIFF
--- a/TM1py/Services/ApplicationService.py
+++ b/TM1py/Services/ApplicationService.py
@@ -38,7 +38,24 @@ class ApplicationService(ObjectService):
         applications = list(application['Name'] for application in response.json()['value'])
         return applications
 
+    def get_names(self, path: str, private: bool = False, **kwargs):
+        """ Retrieve Planning Analytics Application names in given path
 
+        :param path: path with forward slashes
+        :param private: boolean
+        :return: list of application names
+        """
+        contents = 'PrivateContents' if private else 'Contents'
+        mid = ""
+        if path.strip() != '':
+            mid = "".join([format_url("/Contents('{}')", element) for element in path.split('/')])
+        base_url = "/api/v1/Contents('Applications')" + mid + "/" + contents
+
+        response = self._rest.GET(url=base_url, **kwargs)
+        applications = list(application['Name'] for application in response.json()['value'])
+        
+        return applications
+    
     def get(self, path: str, application_type: Union[str, ApplicationTypes], name: str, private: bool = False,
             **kwargs) -> Application:
         """ Retrieve Planning Analytics Application
@@ -252,6 +269,19 @@ class ApplicationService(ObjectService):
 
         return response
 
+    def update_or_create(self, application: Union[Application, DocumentApplication], private: bool = False, **kwargs) -> Response:
+        """ Update or create Planning Analytics application
+
+        :param application: instance of Application
+        :param private: boolean
+        :return: Response
+        """
+        if self.exists(path=application.path, application_type=application.application_type, name=application.name, private=private,**kwargs):
+            response = self.update(application=application, private=private, **kwargs)
+        else:
+            response = self.create(application=application, private=private, **kwargs)
+        return response
+    
     def update_or_create_document_from_file(self, path: str, name: str,
                                             path_to_file: str, private: bool = False, **kwargs) -> Response:
         """Update or create application from file


### PR DESCRIPTION
Hi,
 I have been working with Applications (Websheets) and I have created 2 useful functions to work with them to be able to update/sync Applications between TM1 instances:

get_names - returns all the applications in given path 
update_or_create - takes care of the applications that are not present in new model. 

On a side note - for Excel websheets the "create" only creates blob file instead of proper Excel fie in }Externals, while "update" updates Excel file correctly. It seems that REST API is not reflecting all the options that are possible with the Websheets in older TM1 Clients (Copy vs. Add as reference etc.) Has anyone come to that point too?

Thanks,
Tomas