### PR TITLE
Remove tcp_keepalive parameter

### DIFF
--- a/TM1py/Services/TM1Service.py
+++ b/TM1py/Services/TM1Service.py
@@ -45,8 +45,6 @@ class TM1Service:
         :param timeout: Float - Number of seconds that the client will wait to receive the first byte.
         :param cancel_at_timeout: Abort operation in TM1 when timeout is reached
         :param async_requests_mode: changes internal REST execution mode to avoid 60s timeout on IBM cloud
-        :param tcp_keepalive: maintain the TCP connection all the time, users should choose either async_requests_mode or tcp_keepalive to run a long-run request
-                If both are True, use async_requests_mode by default
         :param connection_pool_size - In a multi threaded environment, you should set this value to a
                 higher number, such as the number of threads
         :param integrated_login: True for IntegratedSecurityMode3


### PR DESCRIPTION
Hi, @rclapp , @MariusWirtz 
As discussed, I have removed the parameter for v12 in cloud environment going forward. I tested it with CP4D v12 version and it looks good to me. Please review and help to approve it. Thanks.