### PR TITLE
Fix: Changed setUp and tearDown from class method to object method

### DIFF
--- a/Tests/AnnotationService_test.py
+++ b/Tests/AnnotationService_test.py
@@ -39,8 +39,7 @@ class TestAnnotationService(unittest.TestCase):
         cube = Cube(cls.cube_name, cls.dimension_names)
         cls.tm1.cubes.update_or_create(cube)
 
-    @classmethod
-    def setUp(cls):
+    def setUp(self):
         """
         Run before each test to create a test annotation
         """
@@ -48,18 +47,17 @@ class TestAnnotationService(unittest.TestCase):
         random_text = "".join([random.choice(string.printable) for _ in range(100)])
 
         annotation = Annotation(comment_value=random_text,
-                                object_name=cls.cube_name,
+                                object_name=self.cube_name,
                                 dimensional_context=random_intersection)
 
-        cls.annotation_id = cls.tm1.cubes.annotations.create(annotation).json().get("ID")
+        self.annotation_id = self.tm1.cubes.annotations.create(annotation).json().get("ID")
 
-    @classmethod
-    def tearDown(cls):
+    def tearDown(self):
         """
         Run at the end of each test to delete all test annotations
         """
-        for a in cls.tm1.cubes.annotations.get_all(cls.cube_name):
-            cls.tm1.annotations.delete(a.id)
+        for a in self.tm1.cubes.annotations.get_all(self.cube_name):
+            self.tm1.annotations.delete(a.id)
 
     def test_get_all(self):
         """

--- a/Tests/CellService_test.py
+++ b/Tests/CellService_test.py
@@ -190,45 +190,42 @@ class TestCellService(unittest.TestCase):
                 attribute_values[(element.name, "NA")] = "4"
             cls.tm1.cells.write(attribute_cube, attribute_values, use_blob=True)
 
-    @classmethod
-    def setUp(cls):
+    def setUp(self):
         """
         Reset data before each test run
         """
         # set correct version before test, as it is overwritten in a test case
-        cls.tm1._tm1_rest.set_version()
+        self.tm1._tm1_rest.set_version()
 
         # populate data in cube
 
         # cellset of data that shall be written
-        cls.cellset = Utils.CaseAndSpaceInsensitiveTuplesDict()
+        self.cellset = Utils.CaseAndSpaceInsensitiveTuplesDict()
         value = 1
-        for element1, element2, element3 in cls.target_coordinates:
-            cls.cellset[(element1, element2, element3)] = value
+        for element1, element2, element3 in self.target_coordinates:
+            self.cellset[(element1, element2, element3)] = value
 
         # Sum of all the values that we write in the cube. serves as a checksum.
-        cls.total_value = sum(cls.cellset.values())
+        self.total_value = sum(self.cellset.values())
 
         # Fill cube with values
-        cls.tm1.cells.write_values(cls.cube_name, cls.cellset)
+        self.tm1.cells.write_values(self.cube_name, self.cellset)
 
-        cls.tm1.cells.write_values(cls.string_cube_name, cls.cells_in_string_cube)
+        self.tm1.cells.write_values(self.string_cube_name, self.cells_in_string_cube)
 
-        if not cls.tm1.sandboxes.exists(cls.sandbox_name):
-            cls.tm1.sandboxes.create(Sandbox(cls.sandbox_name, True))
+        if not self.tm1.sandboxes.exists(self.sandbox_name):
+            self.tm1.sandboxes.create(Sandbox(self.sandbox_name, True))
 
-        cls._write_attribute_values()
+        self._write_attribute_values()
 
-
-    @classmethod
-    def tearDown(cls):
+    def tearDown(self):
         """
         Clear data from cubes after each test run
         """
-        cls.tm1.processes.execute_ti_code("CubeClearData('" + cls.cube_name + "');")
-        cls.tm1.processes.execute_ti_code("CubeClearData('" + cls.string_cube_name + "');")
-        cls.tm1.processes.execute_ti_code("CubeClearData('" + cls.cube_rps1_name + "');")
-        cls.tm1.processes.execute_ti_code("CubeClearData('" + cls.cube_rps2_name + "');")
+        self.tm1.processes.execute_ti_code("CubeClearData('" + self.cube_name + "');")
+        self.tm1.processes.execute_ti_code("CubeClearData('" + self.string_cube_name + "');")
+        self.tm1.processes.execute_ti_code("CubeClearData('" + self.cube_rps1_name + "');")
+        self.tm1.processes.execute_ti_code("CubeClearData('" + self.cube_rps2_name + "');")
 
     @classmethod
     def build_string_cube(cls):

--- a/Tests/ChoreService_test.py
+++ b/Tests/ChoreService_test.py
@@ -55,45 +55,43 @@ class TestChoreService(unittest.TestCase):
         p2.add_parameter('pRegion', 'pRegion (String)', value='UK')
         cls.tm1.processes.update_or_create(p2)
 
-    @classmethod
-    def setUp(cls):
+    def setUp(self):
         # create chores
-        c1 = Chore(name=cls.chore_name1,
-                   start_time=ChoreStartTime(cls.start_time.year, cls.start_time.month, cls.start_time.day,
-                                             cls.start_time.hour, cls.start_time.minute, cls.start_time.second),
+        c1 = Chore(name=self.chore_name1,
+                   start_time=ChoreStartTime(self.start_time.year, self.start_time.month, self.start_time.day,
+                                             self.start_time.hour, self.start_time.minute, self.start_time.second),
                    dst_sensitivity=True,
                    active=True,
                    execution_mode=Chore.MULTIPLE_COMMIT,
-                   frequency=cls.frequency,
-                   tasks=cls.tasks)
-        cls.tm1.chores.update_or_create(c1)
+                   frequency=self.frequency,
+                   tasks=self.tasks)
+        self.tm1.chores.update_or_create(c1)
 
-        c2 = Chore(name=cls.chore_name2,
-                   start_time=ChoreStartTime(cls.start_time.year, cls.start_time.month, cls.start_time.day,
-                                             cls.start_time.hour, cls.start_time.minute, cls.start_time.second),
+        c2 = Chore(name=self.chore_name2,
+                   start_time=ChoreStartTime(self.start_time.year, self.start_time.month, self.start_time.day,
+                                             self.start_time.hour, self.start_time.minute, self.start_time.second),
                    dst_sensitivity=True,
                    active=False,
                    execution_mode=Chore.SINGLE_COMMIT,
-                   frequency=cls.frequency,
-                   tasks=cls.tasks)
-        cls.tm1.chores.update_or_create(c2)
+                   frequency=self.frequency,
+                   tasks=self.tasks)
+        self.tm1.chores.update_or_create(c2)
 
         # chore without tasks
         c3 = copy.copy(c2)
-        c3.name = cls.chore_name3
+        c3.name = self.chore_name3
         c3.tasks = []
-        cls.tm1.chores.update_or_create(c3)
+        self.tm1.chores.update_or_create(c3)
 
-    @classmethod
-    def tearDown(cls):
-        if cls.tm1.chores.exists(cls.chore_name1):
-            cls.tm1.chores.delete(cls.chore_name1)
-        if cls.tm1.chores.exists(cls.chore_name2):
-            cls.tm1.chores.delete(cls.chore_name2)
-        if cls.tm1.chores.exists(cls.chore_name3):
-            cls.tm1.chores.delete(cls.chore_name3)
-        if cls.tm1.chores.exists(cls.chore_name4):
-            cls.tm1.chores.delete(cls.chore_name4)
+    def tearDown(self):
+        if self.tm1.chores.exists(self.chore_name1):
+            self.tm1.chores.delete(self.chore_name1)
+        if self.tm1.chores.exists(self.chore_name2):
+            self.tm1.chores.delete(self.chore_name2)
+        if self.tm1.chores.exists(self.chore_name3):
+            self.tm1.chores.delete(self.chore_name3)
+        if self.tm1.chores.exists(self.chore_name4):
+            self.tm1.chores.delete(self.chore_name4)
 
     @skip_if_insufficient_version(version="11.7.00002.1")
     def test_create_chore_with_dst_multi_commit(self):

--- a/Tests/CubeService_test.py
+++ b/Tests/CubeService_test.py
@@ -22,40 +22,39 @@ class TestCubeService(unittest.TestCase):
         prefix + "dimension2",
         prefix + "dimension3"]
 
-    @classmethod
-    def setUp(cls):
+    def setUp(self):
 
         # Connection to TM1
-        cls.config = configparser.ConfigParser()
-        cls.config.read(Path(__file__).parent.joinpath('config.ini'))
-        cls.tm1 = TM1Service(**cls.config['tm1srv01'])
+        self.config = configparser.ConfigParser()
+        self.config.read(Path(__file__).parent.joinpath('config.ini'))
+        self.tm1 = TM1Service(**self.config['tm1srv01'])
 
-        for dimension_name in cls.dimension_names:
+        for dimension_name in self.dimension_names:
             elements = [Element('Element {}'.format(str(j)), 'Numeric') for j in range(1, 1001)]
             hierarchy = Hierarchy(dimension_name=dimension_name,
                                   name=dimension_name,
                                   elements=elements)
             dimension = Dimension(dimension_name, [hierarchy])
-            if not cls.tm1.dimensions.exists(dimension.name):
-                cls.tm1.dimensions.create(dimension)
+            if not self.tm1.dimensions.exists(dimension.name):
+                self.tm1.dimensions.create(dimension)
 
         # Build Cube
-        cube = Cube(cls.cube_name, cls.dimension_names)
-        if not cls.tm1.cubes.exists(cls.cube_name):
-            cls.tm1.cubes.create(cube)
-        c = Cube(cls.cube_name, dimensions=cls.dimension_names, rules=Rules(''))
-        if cls.tm1.cubes.exists(c.name):
-            cls.tm1.cubes.delete(c.name)
-        cls.tm1.cubes.create(c)
+        cube = Cube(self.cube_name, self.dimension_names)
+        if not self.tm1.cubes.exists(self.cube_name):
+            self.tm1.cubes.create(cube)
+        c = Cube(self.cube_name, dimensions=self.dimension_names, rules=Rules(''))
+        if self.tm1.cubes.exists(c.name):
+            self.tm1.cubes.delete(c.name)
+        self.tm1.cubes.create(c)
 
         # Build Control Cube
-        control_cube = Cube(cls.control_cube_name, cls.dimension_names)
-        if not cls.tm1.cubes.exists(cls.control_cube_name):
-            cls.tm1.cubes.create(control_cube)
-        c = Cube(cls.control_cube_name, dimensions=cls.dimension_names, rules=Rules(''))
-        if cls.tm1.cubes.exists(c.name):
-            cls.tm1.cubes.delete(c.name)
-        cls.tm1.cubes.create(c)
+        control_cube = Cube(self.control_cube_name, self.dimension_names)
+        if not self.tm1.cubes.exists(self.control_cube_name):
+            self.tm1.cubes.create(control_cube)
+        c = Cube(self.control_cube_name, dimensions=self.dimension_names, rules=Rules(''))
+        if self.tm1.cubes.exists(c.name):
+            self.tm1.cubes.delete(c.name)
+        self.tm1.cubes.create(c)
 
     def test_get_cube(self):
         c = self.tm1.cubes.get(self.cube_name)
@@ -302,14 +301,13 @@ class TestCubeService(unittest.TestCase):
 
         self.assertEqual(self.dimension_names[-1], measure_dimension)
 
-    @classmethod
-    def tearDown(cls):
-        cls.tm1.cubes.delete(cls.cube_name)
-        if cls.tm1.cubes.exists(cls.cube_name_to_delete):
-            cls.tm1.cubes.delete(cls.cube_name_to_delete)
-        for dimension in cls.dimension_names:
-            cls.tm1.dimensions.delete(dimension)
-        cls.tm1.logout()
+    def tearDown(self):
+        self.tm1.cubes.delete(self.cube_name)
+        if self.tm1.cubes.exists(self.cube_name_to_delete):
+            self.tm1.cubes.delete(self.cube_name_to_delete)
+        for dimension in self.dimension_names:
+            self.tm1.dimensions.delete(dimension)
+        self.tm1.logout()
 
 
 if __name__ == '__main__':

--- a/Tests/DimensionService_test.py
+++ b/Tests/DimensionService_test.py
@@ -26,13 +26,11 @@ class TestDimensionService(unittest.TestCase):
         cls.config.read(Path(__file__).parent.joinpath('config.ini'))
         cls.tm1 = TM1Service(**cls.config['tm1srv01'])
 
-    @classmethod
-    def setUp(cls):
-        cls.create_dimensions()
+    def setUp(self):
+        self.create_dimensions()
 
-    @classmethod
-    def tearDown(cls):
-        cls.delete_dimensions()
+    def tearDown(self):
+        self.delete_dimensions()
 
     @classmethod
     def create_dimensions(cls):

--- a/Tests/ElementService_test.py
+++ b/Tests/ElementService_test.py
@@ -31,53 +31,51 @@ class TestElementService(unittest.TestCase):
         cls.config.read(Path(__file__).parent.joinpath('config.ini'))
         cls.tm1 = TM1Service(**cls.config['tm1srv01'])
 
-    @classmethod
-    def setUp(cls):
+    def setUp(self):
         # create dimension with a default hierarchy
-        d = Dimension(cls.dimension_name)
-        h = Hierarchy(cls.dimension_name, cls.hierarchy_name)
+        d = Dimension(self.dimension_name)
+        h = Hierarchy(self.dimension_name, self.hierarchy_name)
 
         # add elements
-        cls.years = ("No Year", "1989", "1990", "1991", "1992")
-        cls.extra_year = "4321"
+        self.years = ("No Year", "1989", "1990", "1991", "1992")
+        self.extra_year = "4321"
 
         h.add_element('Total Years', 'Consolidated')
         h.add_element('All Consolidations', 'Consolidated')
         h.add_edge("All Consolidations", "Total Years", 1)
-        for year in cls.years:
+        for year in self.years:
             h.add_element(year, 'Numeric')
             h.add_edge('Total Years', year, 1)
 
         # add attributes
-        cls.attributes = ('Previous Year', 'Next Year')
-        cls.alias_attributes = ("Financial Year",)
+        self.attributes = ('Previous Year', 'Next Year')
+        self.alias_attributes = ("Financial Year",)
 
-        for attribute in cls.attributes:
+        for attribute in self.attributes:
             h.add_element_attribute(attribute, "String")
-        for attribute in cls.alias_attributes:
+        for attribute in self.alias_attributes:
             h.add_element_attribute(attribute, "Alias")
         d.add_hierarchy(h)
-        cls.tm1.dimensions.update_or_create(d)
+        self.tm1.dimensions.update_or_create(d)
 
-        cls.added_attribute_name = "NewAttribute"
+        self.added_attribute_name = "NewAttribute"
 
         # write attribute values
-        cls.tm1.cubes.cells.write_value('1988', cls.attribute_cube_name, ('1989', 'Previous Year'))
-        cls.tm1.cubes.cells.write_value('1989', cls.attribute_cube_name, ('1990', 'Previous Year'))
-        cls.tm1.cubes.cells.write_value('1990', cls.attribute_cube_name, ('1991', 'Previous Year'))
-        cls.tm1.cubes.cells.write_value('1991', cls.attribute_cube_name, ('1992', 'Previous Year'))
+        self.tm1.cubes.cells.write_value('1988', self.attribute_cube_name, ('1989', 'Previous Year'))
+        self.tm1.cubes.cells.write_value('1989', self.attribute_cube_name, ('1990', 'Previous Year'))
+        self.tm1.cubes.cells.write_value('1990', self.attribute_cube_name, ('1991', 'Previous Year'))
+        self.tm1.cubes.cells.write_value('1991', self.attribute_cube_name, ('1992', 'Previous Year'))
 
-        cls.tm1.cubes.cells.write_value('1988/89', cls.attribute_cube_name, ('1989', 'Financial Year'))
-        cls.tm1.cubes.cells.write_value('1989/90', cls.attribute_cube_name, ('1990', 'Financial Year'))
-        cls.tm1.cubes.cells.write_value('1990/91', cls.attribute_cube_name, ('1991', 'Financial Year'))
-        cls.tm1.cubes.cells.write_value('1991/92', cls.attribute_cube_name, ('1992', 'Financial Year'))
+        self.tm1.cubes.cells.write_value('1988/89', self.attribute_cube_name, ('1989', 'Financial Year'))
+        self.tm1.cubes.cells.write_value('1989/90', self.attribute_cube_name, ('1990', 'Financial Year'))
+        self.tm1.cubes.cells.write_value('1990/91', self.attribute_cube_name, ('1991', 'Financial Year'))
+        self.tm1.cubes.cells.write_value('1991/92', self.attribute_cube_name, ('1992', 'Financial Year'))
 
-        cls.create_or_update_dimension_with_hierarchies()
+        self.create_or_update_dimension_with_hierarchies()
 
-    @classmethod
-    def tearDown(cls):
-        cls.tm1.dimensions.delete(cls.dimension_name)
-        cls.tm1.dimensions.delete(cls.dimension_with_hierarchies_name)
+    def tearDown(self):
+        self.tm1.dimensions.delete(self.dimension_name)
+        self.tm1.dimensions.delete(self.dimension_with_hierarchies_name)
 
     @classmethod
     def create_or_update_dimension_with_hierarchies(cls):

--- a/Tests/FileService_test.py
+++ b/Tests/FileService_test.py
@@ -12,17 +12,16 @@ class TestFileService(unittest.TestCase):
     FILE_NAME1 = "TM1py_unittest_file1"
     FILE_NAME2 = "TM1py_unittest_file2"
 
-    @classmethod
-    def setUp(cls) -> None:
-        cls.config = configparser.ConfigParser()
-        cls.config.read(Path(__file__).parent.joinpath('config.ini'))
-        cls.tm1 = TM1Service(**cls.config['tm1srv01'])
+    def setUp(self) -> None:
+        self.config = configparser.ConfigParser()
+        self.config.read(Path(__file__).parent.joinpath('config.ini'))
+        self.tm1 = TM1Service(**self.config['tm1srv01'])
 
         with open(Path(__file__).parent.joinpath('resources', 'file.csv'), "rb") as file:
-            cls.tm1.files.update_or_create(cls.FILE_NAME1, file.read())
+            self.tm1.files.update_or_create(self.FILE_NAME1, file.read())
 
-        if cls.tm1.files.exists(cls.FILE_NAME2):
-            cls.tm1.files.delete(cls.FILE_NAME2)
+        if self.tm1.files.exists(self.FILE_NAME2):
+            self.tm1.files.delete(self.FILE_NAME2)
 
     @skip_if_insufficient_version(version="11.4")
     def test_create_get(self):

--- a/Tests/HierarchyService_test.py
+++ b/Tests/HierarchyService_test.py
@@ -37,15 +37,13 @@ class TestHierarchyService(unittest.TestCase):
     def teardown_class(cls):
         cls.tm1.logout()
 
-    @classmethod
-    def setUp(cls):
-        cls.delete_dimensions()
-        cls.create_dimension()
-        cls.create_subset()
+    def setUp(self):
+        self.delete_dimensions()
+        self.create_dimension()
+        self.create_subset()
 
-    @classmethod
-    def tearDown(cls):
-        cls.delete_dimensions()
+    def tearDown(self):
+        self.delete_dimensions()
 
     @classmethod
     def create_dimension(cls):

--- a/Tests/ProcessService_test.py
+++ b/Tests/ProcessService_test.py
@@ -96,25 +96,23 @@ class TestProcessService(unittest.TestCase):
         with open(Path(__file__).parent.joinpath('resources', 'Bedrock.Server.Wait.json'), 'r') as file:
             cls.p_bedrock_server_wait = Process.from_json(file.read())
 
-    @classmethod
-    def setUp(cls):
-        cls.tm1.processes.update_or_create(cls.p_none)
-        cls.tm1.processes.update_or_create(cls.p_ascii)
-        cls.tm1.processes.update_or_create(cls.p_view)
-        cls.tm1.processes.update_or_create(cls.p_odbc)
-        cls.tm1.processes.update_or_create(cls.p_subset)
-        cls.tm1.processes.update_or_create(cls.p_debug)
-        cls.tm1.processes.update_or_create(cls.p_error)
+    def setUp(self):
+        self.tm1.processes.update_or_create(self.p_none)
+        self.tm1.processes.update_or_create(self.p_ascii)
+        self.tm1.processes.update_or_create(self.p_view)
+        self.tm1.processes.update_or_create(self.p_odbc)
+        self.tm1.processes.update_or_create(self.p_subset)
+        self.tm1.processes.update_or_create(self.p_debug)
+        self.tm1.processes.update_or_create(self.p_error)
 
-    @classmethod
-    def tearDown(cls):
-        cls.tm1.processes.delete(cls.p_none.name)
-        cls.tm1.processes.delete(cls.p_ascii.name)
-        cls.tm1.processes.delete(cls.p_view.name)
-        cls.tm1.processes.delete(cls.p_odbc.name)
-        cls.tm1.processes.delete(cls.p_subset.name)
-        cls.tm1.processes.delete(cls.p_debug.name)
-        cls.tm1.processes.delete(cls.p_error.name)
+    def tearDown(self):
+        self.tm1.processes.delete(self.p_none.name)
+        self.tm1.processes.delete(self.p_ascii.name)
+        self.tm1.processes.delete(self.p_view.name)
+        self.tm1.processes.delete(self.p_odbc.name)
+        self.tm1.processes.delete(self.p_subset.name)
+        self.tm1.processes.delete(self.p_debug.name)
+        self.tm1.processes.delete(self.p_error.name)
 
     def test_update_or_create(self):
         if self.tm1.processes.exists(self.p_bedrock_server_wait.name):

--- a/Tests/SandboxService_test.py
+++ b/Tests/SandboxService_test.py
@@ -22,34 +22,33 @@ class TestSandboxService(unittest.TestCase):
     sandbox_name2 = prefix + "sandbox2"
     sandbox_name3 = prefix + "sandbox3"
 
-    @classmethod
-    def setUp(cls):
+    def setUp(self):
 
         # Connection to TM1
-        cls.config = configparser.ConfigParser()
-        cls.config.read(Path(__file__).parent.joinpath('config.ini'))
-        cls.tm1 = TM1Service(**cls.config['tm1srv01'])
+        self.config = configparser.ConfigParser()
+        self.config.read(Path(__file__).parent.joinpath('config.ini'))
+        self.tm1 = TM1Service(**self.config['tm1srv01'])
 
-        for dimension_name in cls.dimension_names:
+        for dimension_name in self.dimension_names:
             elements = [Element('Element {}'.format(str(j)), 'Numeric') for j in range(1, 1001)]
             hierarchy = Hierarchy(dimension_name=dimension_name,
                                   name=dimension_name,
                                   elements=elements)
             dimension = Dimension(dimension_name, [hierarchy])
-            if not cls.tm1.dimensions.exists(dimension.name):
-                cls.tm1.dimensions.create(dimension)
+            if not self.tm1.dimensions.exists(dimension.name):
+                self.tm1.dimensions.create(dimension)
 
         # Build Cube
-        cube = Cube(cls.cube_name, cls.dimension_names)
-        if not cls.tm1.cubes.exists(cls.cube_name):
-            cls.tm1.cubes.create(cube)
-        c = Cube(cls.cube_name, dimensions=cls.dimension_names, rules=Rules(''))
-        if cls.tm1.cubes.exists(c.name):
-            cls.tm1.cubes.delete(c.name)
-        cls.tm1.cubes.create(c)
+        cube = Cube(self.cube_name, self.dimension_names)
+        if not self.tm1.cubes.exists(self.cube_name):
+            self.tm1.cubes.create(cube)
+        c = Cube(self.cube_name, dimensions=self.dimension_names, rules=Rules(''))
+        if self.tm1.cubes.exists(c.name):
+            self.tm1.cubes.delete(c.name)
+        self.tm1.cubes.create(c)
 
-        if not cls.tm1.sandboxes.exists(cls.sandbox_name1):
-            cls.tm1.sandboxes.create(Sandbox(name=cls.sandbox_name1, include_in_sandbox_dimension=True))
+        if not self.tm1.sandboxes.exists(self.sandbox_name1):
+            self.tm1.sandboxes.create(Sandbox(name=self.sandbox_name1, include_in_sandbox_dimension=True))
 
     def test_get_sandbox(self):
         sandbox = self.tm1.sandboxes.get(self.sandbox_name1)
@@ -216,16 +215,15 @@ class TestSandboxService(unittest.TestCase):
         queued = (self.tm1.sandboxes.get(self.sandbox_name3)).queued
         self.assertFalse(queued)
 
-    @classmethod
-    def tearDown(cls):
-        for sandbox_name in [cls.sandbox_name1, cls.sandbox_name2, cls.sandbox_name3]:
-            if cls.tm1.sandboxes.exists(sandbox_name):
-                cls.tm1.sandboxes.delete(sandbox_name)
+    def tearDown(self):
+        for sandbox_name in [self.sandbox_name1, self.sandbox_name2, self.sandbox_name3]:
+            if self.tm1.sandboxes.exists(sandbox_name):
+                self.tm1.sandboxes.delete(sandbox_name)
 
-        cls.tm1.cubes.delete(cls.cube_name)
-        for dimension in cls.dimension_names:
-            cls.tm1.dimensions.delete(dimension)
-        cls.tm1.logout()
+        self.tm1.cubes.delete(self.cube_name)
+        for dimension in self.dimension_names:
+            self.tm1.dimensions.delete(dimension)
+        self.tm1.logout()
 
 
 if __name__ == '__main__':

--- a/Tests/TM1pyDict_test.py
+++ b/Tests/TM1pyDict_test.py
@@ -21,17 +21,15 @@ class TestCaseAndSpaceInsensitiveDict(unittest.TestCase):
         cls.config.read(Path(__file__).parent.joinpath('config.ini'))
         cls.tm1 = TM1Service(**cls.config['tm1srv01'])
         
-    @classmethod
-    def setUp(cls):
+    def setUp(self):
 
-        cls.map = CaseAndSpaceInsensitiveDict()
-        cls.map["key1"] = "value1"
-        cls.map["key2"] = "value2"
-        cls.map["key3"] = "value3"
+        self.map = CaseAndSpaceInsensitiveDict()
+        self.map["key1"] = "value1"
+        self.map["key2"] = "value2"
+        self.map["key3"] = "value3"
 
-    @classmethod
-    def tearDown(cls):
-        del cls.map
+    def tearDown(self):
+        del self.map
 
     def test_set(self):
         self.map["key4"] = "value4"
@@ -98,17 +96,15 @@ class TestCaseAndSpaceInsensitiveDict(unittest.TestCase):
 class TestCaseAndSpaceInsensitiveSet(unittest.TestCase):
     set: CaseAndSpaceInsensitiveSet
 
-    @classmethod
-    def setUp(cls):
-        cls.original_values = ("Value1", "Value 2", "V A L U E 3")
-        cls.set = CaseAndSpaceInsensitiveSet()
-        cls.set.add(cls.original_values[0])
-        cls.set.add(cls.original_values[1])
-        cls.set.add(cls.original_values[2])
+    def setUp(self):
+        self.original_values = ("Value1", "Value 2", "V A L U E 3")
+        self.set = CaseAndSpaceInsensitiveSet()
+        self.set.add(self.original_values[0])
+        self.set.add(self.original_values[1])
+        self.set.add(self.original_values[2])
 
-    @classmethod
-    def tearDown(cls):
-        del cls.set
+    def tearDown(self):
+        del self.set
 
     def test_get(self):
         self.assertIn("Value1", self.set)


### PR DESCRIPTION
The methods `setUp()` and `tearDown()` are not meant to be class methods. I have double checked the [docs](https://docs.python.org/3/library/unittest.html#unittest.TestCase.setUp) and can't find any reason to declare them as class methods.

All tests run without failures after these changes. 

This PR contains:
- Removed @classmethod decorators for `setUp()` and `tearDown()`
- Renamed the argument from `cls` to `self`