### PR TITLE
Refactor: Simplified is_admin determination

### DIFF
--- a/TM1py/Services/RestService.py
+++ b/TM1py/Services/RestService.py
@@ -152,21 +152,17 @@ class RestService:
         self.handle_logging(kwargs.get('logging', False))
 
         self._proxies = self._handle_proxies(kwargs.get('proxies', None))
+        self._is_admin = None
+        self._is_data_admin = None
+        self._is_security_admin = None
+        self._is_ops_admin = None
 
         # populated later on the fly for users with the name different from 'Admin'
-        self._is_admin = self._determine_is_admin(kwargs.get('user', None))
-
-        # populated on the fly
-        if kwargs.get('user'):
-            self._is_admin = True if case_and_space_insensitive_equals(kwargs.get('user'), 'ADMIN') else None
-            self._is_data_admin = True if case_and_space_insensitive_equals(kwargs.get('user'), 'ADMIN') else None
-            self._is_security_admin = True if case_and_space_insensitive_equals(kwargs.get('user'), 'ADMIN') else None
-            self._is_ops_admin = True if case_and_space_insensitive_equals(kwargs.get('user'), 'ADMIN') else None
-        else:
-            self._is_admin = None
-            self._is_data_admin = None
-            self._is_security_admin = None
-            self._is_ops_admin = None
+        if self._user and case_and_space_insensitive_equals(self._user, 'ADMIN'):
+            self._is_admin = True
+            self._is_data_admin = True
+            self._is_security_admin = True
+            self._is_ops_admin = True
 
         self._verify = self._determine_verify(kwargs.get('verify', None))
 
@@ -189,12 +185,6 @@ class RestService:
             self.set_version()
 
         self._manage_http_adapter()
-
-    def _determine_is_admin(self, user: [None, str]) -> [None, bool]:
-        if user is None:
-            return None
-
-        return True if case_and_space_insensitive_equals(user, 'ADMIN') else None
 
     def _determine_verify(self, verify: [bool, str] = None) -> [bool, str]:
         if verify is None:


### PR DESCRIPTION
Determining whether a user is an admin based on the name is is simplified now

* Access to the `_user` property instead of multiple accesses kwargs.get('user')
* Use only one if statement with two conditions instead of multiple if statements
* "Default" value None moved to the top
* Removed method `_determine_is_admin` because the result was always overwritten afterwards
* Less code

Tests were passed successfully

```
============================================================= test session starts =============================================================
platform win32 -- Python 3.11.7, pytest-8.1.1, pluggy-1.4.0
rootdir: D:\dev\tm1py_onefloid
configfile: pyproject.toml
plugins: anyio-4.2.0, xdist-3.5.0, time-machine-2.13.0     
...
========================================== 816 passed, 36 skipped, 198 warnings in 981.11s (0:16:21) ==========================================