### PR TITLE
Test/speed up element service tests

### DIFF
--- a/Tests/ElementService_test.py
+++ b/Tests/ElementService_test.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from TM1py.Exceptions import TM1pyRestException, TM1pyException
 from TM1py.Objects import Dimension, Hierarchy, Element, ElementAttribute
 from TM1py.Services import TM1Service
-from Tests.Utils import skip_if_no_pandas
+from Tests.Utils import skip_if_insufficient_version, skip_if_no_pandas
 
 
 class TestElementService(unittest.TestCase):
@@ -1079,6 +1079,18 @@ class TestElementService(unittest.TestCase):
 
         edges = self.tm1.elements.get_edges(self.dimension_name, self.dimension_name)
         self.assertNotIn(("Total Years", "1989"), edges)
+    
+    @skip_if_insufficient_version(version="11.4")
+    def test_delete_edges(self):
+        self.tm1.elements.delete_edges(
+            dimension_name=self.dimension_name,
+            hierarchy_name=self.hierarchy_name,
+            edges=[("Total Years", "1989"), ("Total Years", "1990")]
+        )
+
+        edges = self.tm1.elements.get_edges(self.dimension_name, self.dimension_name)
+        self.assertNotIn(("Total Years", "1989"), edges)
+        self.assertNotIn(("Total Years", "1990"), edges)
 
     def test_remove_edge_parent_not_existing(self):
         with self.assertRaises(TM1pyRestException):

--- a/Tests/ElementService_test.py
+++ b/Tests/ElementService_test.py
@@ -2,6 +2,7 @@ import configparser
 import copy
 import unittest
 from pathlib import Path
+from uuid import uuid1
 
 from TM1py.Exceptions import TM1pyRestException, TM1pyException
 from TM1py.Objects import Dimension, Hierarchy, Element, ElementAttribute
@@ -24,8 +25,10 @@ class TestElementService(unittest.TestCase):
         cls.tm1 = TM1Service(**cls.config['tm1srv01'])
 
     def setUp(self):
+        dimension_uuid = str(uuid1()).replace('-', "_")
         prefix = 'TM1py_unittest_element'
-        pure_dimension_name = f"{prefix}_dimension"
+        pure_dimension_name = f"{prefix}_dimension_{dimension_uuid}"
+
         self.dimension_name = pure_dimension_name
         self.dimension_with_hierarchies_name = pure_dimension_name + '_with_hierarchies'
         self.hierarchy_name = pure_dimension_name
@@ -232,7 +235,7 @@ class TestElementService(unittest.TestCase):
             use_blob=use_blob)
 
         expected_columns = (
-            "TM1py_unittest_element_dimension",
+            self.dimension_name,
             "Type",
             "Attribute Next Year",
             "Attribute Previous Year",
@@ -272,7 +275,7 @@ class TestElementService(unittest.TestCase):
             use_blob=use_blob)
 
         expected_columns = (
-            "TM1py_unittest_element_dimension",
+            self.dimension_name,
             "Type",
             "Financial Year",
             "Previous Year",
@@ -313,7 +316,7 @@ class TestElementService(unittest.TestCase):
             use_blob=use_blob)
 
         expected_columns = (
-            "TM1py_unittest_element_dimension",
+            self.dimension_name,
             "Type",
             "Financial Year",
             "Previous Year",
@@ -354,7 +357,7 @@ class TestElementService(unittest.TestCase):
             use_blob=use_blob)
 
         expected_columns = (
-            "TM1py_unittest_element_dimension",
+            self.dimension_name,
             "Type",
             "Financial Year",
             "Previous Year",
@@ -436,7 +439,7 @@ class TestElementService(unittest.TestCase):
             use_blob=use_blob)
 
         expected_columns = (
-            "TM1py_unittest_element_dimension",
+            self.dimension_name,
             "Type",
             "Next Year:s",
             "Previous Year:s",
@@ -477,7 +480,7 @@ class TestElementService(unittest.TestCase):
             use_blob=use_blob)
 
         expected_columns = (
-            "TM1py_unittest_element_dimension",
+            self.dimension_name,
             "Type",
             "A_Next Year:s",
             "A_Previous Year:s",
@@ -517,7 +520,7 @@ class TestElementService(unittest.TestCase):
             use_blob=use_blob)
 
         expected_columns = (
-            "TM1py_unittest_element_dimension",
+            self.dimension_name,
             "ElementType",
             "Next Year",
             "Previous Year",

--- a/Tests/ElementService_test.py
+++ b/Tests/ElementService_test.py
@@ -77,9 +77,8 @@ class TestElementService(unittest.TestCase):
         self.tm1.dimensions.delete(self.dimension_name)
         self.tm1.dimensions.delete(self.dimension_with_hierarchies_name)
 
-    @classmethod
-    def create_or_update_dimension_with_hierarchies(cls):
-        dimension = Dimension(cls.dimension_with_hierarchies_name)
+    def create_or_update_dimension_with_hierarchies(self):
+        dimension = Dimension(self.dimension_with_hierarchies_name)
         dimension.add_hierarchy(
             Hierarchy(
                 name="Hierarchy1",
@@ -100,7 +99,7 @@ class TestElementService(unittest.TestCase):
                           Element("Cons3", "Consolidated")],
                 edges={("Cons3", "Elem5"): 1}),
         )
-        cls.tm1.dimensions.update_or_create(dimension)
+        self.tm1.dimensions.update_or_create(dimension)
 
     def test_create_and_delete_element(self):
         element = Element(self.extra_year, "String")

--- a/Tests/ElementService_test.py
+++ b/Tests/ElementService_test.py
@@ -12,14 +12,6 @@ from Tests.Utils import skip_if_insufficient_version, skip_if_no_pandas
 class TestElementService(unittest.TestCase):
     tm1: TM1Service
 
-    prefix = 'TM1py_unittest_element'
-    dimension_name = f"{prefix}_dimension"
-    dimension_with_hierarchies_name = f"{prefix}_dimension_with_hierarchies"
-    hierarchy_name = dimension_name
-    attribute_cube_name = '}ElementAttributes_' + dimension_name
-    dimension_does_not_exist_name = f"{prefix}_dimension_does_not_exist"
-    hierarchy_does_not_exist_name = dimension_does_not_exist_name
-
     @classmethod
     def setUpClass(cls):
         """
@@ -32,6 +24,15 @@ class TestElementService(unittest.TestCase):
         cls.tm1 = TM1Service(**cls.config['tm1srv01'])
 
     def setUp(self):
+        prefix = 'TM1py_unittest_element'
+        pure_dimension_name = f"{prefix}_dimension"
+        self.dimension_name = pure_dimension_name
+        self.dimension_with_hierarchies_name = pure_dimension_name + '_with_hierarchies'
+        self.hierarchy_name = pure_dimension_name
+        self.attribute_cube_name = '}ElementAttributes_' + pure_dimension_name
+        self.dimension_does_not_exist_name = pure_dimension_name + "_does_not_exist"
+        self.hierarchy_does_not_exist_name = self.dimension_does_not_exist_name
+
         # create dimension with a default hierarchy
         d = Dimension(self.dimension_name)
         h = Hierarchy(self.dimension_name, self.hierarchy_name)

--- a/Tests/_readme.md
+++ b/Tests/_readme.md
@@ -1,6 +1,6 @@
 # Setup TM1py Tests
 
-- `pip install pytest`
+- `pip install "tm1py[dev]"`
 
 - Use a TM1 development environment
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,11 @@ setup(
         'mdxpy>=1.3.1',
         'networkx'],
     extras_require={
-        "pandas": ["pandas"]
+        "pandas": ["pandas"],
+        "dev": [
+            "pytest",
+            "pytest-xdist"
+        ]
     },
     python_requires='>=3.6',
 )


### PR DESCRIPTION
This PR includes:

* Added `delete_edges` test
* Made dimension name unique for every test case
* Added dev dependencies

With unique dimension names and `pytest-xdist`, it is now possible to run the tests in parallel:

`pytest -n auto .\Tests\ElementService_test.py`

This speeds up the test significantly.