### PR TITLE
Fixing #1126 and#1128 - timeout is an explicit parameter hence kwargs(timeout) does not work, adding request_async_id in execute_process_with_return

### DIFF
--- a/TM1py/Services/ProcessService.py
+++ b/TM1py/Services/ProcessService.py
@@ -264,12 +264,13 @@ class ProcessService(ObjectService):
 
     @require_version(version="11.3")
     def execute_process_with_return(self, process: Process, timeout: float = None, cancel_at_timeout: bool = False,
-                                    **kwargs) -> Tuple[bool, str, str]:
+                                    return_async_id: bool = False, **kwargs) -> Tuple[bool, str, str]:
         """Run unbound TI code directly.
 
         :param process: a TI Process Object
         :param timeout: Number of seconds that the client will wait to receive the first byte.
         :param cancel_at_timeout: Abort operation in TM1 when timeout is reached
+        :param return_async_id: return async_id instead of (success, status, error_log_file)
         :param kwargs: dictionary of process parameters and values
         :return: success (boolean), status (String), error_log_file (String)
         """
@@ -288,7 +289,11 @@ class ProcessService(ObjectService):
             data=json.dumps(payload, ensure_ascii=False),
             timeout=timeout,
             cancel_at_timeout=cancel_at_timeout,
+            return_async_id=return_async_id,
             **kwargs)
+
+        if return_async_id:
+            return response
 
         return self._execute_with_return_parse_response(response)
 

--- a/TM1py/Services/RestService.py
+++ b/TM1py/Services/RestService.py
@@ -244,6 +244,8 @@ class RestService:
             data=data,
             encoding=encoding)
 
+        timeout = timeout if timeout else self._timeout
+
         try:
             if return_async_id:
                 async_requests_mode = True
@@ -280,7 +282,7 @@ class RestService:
                 if return_async_id:
                     return async_id
 
-                for wait in RestService.wait_time_generator(kwargs.get('timeout', self._timeout)):
+                for wait in RestService.wait_time_generator(timeout):
                     response = self.retrieve_async_response(async_id)
                     if response.status_code in [200, 201]:
                         break
@@ -310,14 +312,14 @@ class RestService:
         except Timeout:
             if cancel_at_timeout or (cancel_at_timeout is None and self._cancel_at_timeout):
                 self.cancel_running_operation()
-            raise TM1pyTimeout(method=method, url=url, timeout=kwargs.get('timeout', self._timeout))
+            raise TM1pyTimeout(method=method, url=url, timeout=timeout)
 
         except ConnectionError as e:
             # cater for issue in requests library: https://github.com/psf/requests/issues/5430
             if re.search('Read timed out', str(e), re.IGNORECASE):
                 if cancel_at_timeout or (cancel_at_timeout is None and self._cancel_at_timeout):
                     self.cancel_running_operation()
-                raise TM1pyTimeout(method=method, url=url, timeout=kwargs.get('timeout', self._timeout))
+                raise TM1pyTimeout(method=method, url=url, timeout=timeout)
 
             # A connection error that requires attention (e.g. SSL)
             raise e


### PR DESCRIPTION
**1126:**
Timeout is a parameter in the  request function, therefore the kwargs.get('timeout', self._timeout) would never get the specified value.

Also for consistency adding the timeout parser to default it to the class._timeout value if not provided.


**1128:** 
Adding the return_async_id to the **execute_process_with_return** so that it has the same functionality and signature as the **execute_with_return**

linkages for github:
this fixes #1126 and adds #1128 as well.