### PR TITLE
Fix: setUpV12 should only be called for v12, otherwise every test is …

### DIFF
--- a/Tests/FileService_test.py
+++ b/Tests/FileService_test.py
@@ -3,7 +3,7 @@ import unittest
 from pathlib import Path
 
 from TM1py import TM1Service
-from .Utils import skip_if_insufficient_version
+from .Utils import skip_if_insufficient_version, verify_version
 
 
 class TestFileService(unittest.TestCase):
@@ -26,7 +26,8 @@ class TestFileService(unittest.TestCase):
         if self.tm1.files.exists(self.FILE_NAME2):
             self.tm1.files.delete(self.FILE_NAME2)
 
-        self.setUpV12()
+        if verify_version(required_version="12", version=self.tm1.version):
+            self.setUpV12()
 
     @skip_if_insufficient_version(version="12")
     def setUpV12(self):


### PR DESCRIPTION
At the moment only FileService tests for version 12 run because `setUpV12()` is called in `setUp()`. But `setUpV12()` will skip the whole test if it's an version lower than 12. This PR address this issue and  `setUpV12()` is only called if the version is 12 or higher. 
