### PR TITLE
Fix: Improve version checks FileService

### DIFF
--- a/TM1py/Exceptions/Exceptions.py
+++ b/TM1py/Exceptions/Exceptions.py
@@ -15,12 +15,17 @@ class TM1pyTimeout(Exception):
 
 
 class TM1pyVersionException(Exception):
-    def __init__(self, function: str, required_version):
+    def __init__(self, function: str, required_version, feature: str = None):
         self.function = function
         self.required_version = required_version
+        self.feature = feature
 
     def __str__(self):
-        return f"Function '{self.function}' requires TM1 server version >= '{self.required_version}'"
+        require_string = f"requires TM1 server version >= '{self.required_version}'"
+        if self.feature:
+            return f"'{self.feature}' feature of function '{self.function}' {require_string}"
+        else:
+            return f"Function '{self.function}' {require_string}"
 
 
 class TM1pyVersionDeprecationException(Exception):

--- a/TM1py/Services/FileService.py
+++ b/TM1py/Services/FileService.py
@@ -26,7 +26,7 @@ class FileService(ObjectService):
 
     def get_names(self, **kwargs) -> bytes:
         warnings.warn(
-            f"Function get_names will be deprecated. Use get_all_names instead",
+            "Function get_names will be deprecated. Use get_all_names instead",
             DeprecationWarning,
             stacklevel=2)
 
@@ -221,7 +221,7 @@ class FileService(ObjectService):
         url = self._construct_content_url(
             path=Path(path),
             exclude_path_end=False,
-            extension="Contents?$select=Name&$filter={}".format(f" and ".join(name_filters)))
+            extension="Contents?$select=Name&$filter={}".format(" and ".join(name_filters)))
         response = self._rest.GET(url, **kwargs).content
 
         return list(file['Name'] for file in json.loads(response)['value'])

--- a/TM1py/Services/FileService.py
+++ b/TM1py/Services/FileService.py
@@ -7,7 +7,7 @@ from typing import List, Iterable, Union
 from TM1py.Services import RestService
 from TM1py.Services.ObjectService import ObjectService
 from TM1py.Utils import format_url
-from TM1py.Utils.Utils import verify_version
+from TM1py.Utils.Utils import verify_version, require_version
 
 
 class FileService(ObjectService):
@@ -24,6 +24,7 @@ class FileService(ObjectService):
         else:
             self.version_content_path = 'Blobs'
 
+    @require_version(version="11.4")
     def get_names(self, **kwargs) -> bytes:
         warnings.warn(
             "Function get_names will be deprecated. Use get_all_names instead",
@@ -35,7 +36,8 @@ class FileService(ObjectService):
             version_content_path=self.version_content_path)
 
         return self._rest.GET(url, **kwargs).content
-
+    
+    @require_version(version="11.4")
     def get_all_names(self, path: Union[str, Path] = "", **kwargs) -> List[str]:
         """ return list of blob file names
 
@@ -46,7 +48,8 @@ class FileService(ObjectService):
 
         response = self._rest.GET(url, **kwargs).content
         return [file['Name'] for file in json.loads(response)['value']]
-
+    
+    @require_version(version="11.4")
     def get(self, file_name: str, **kwargs) -> bytes:
         """ Get file
 
@@ -101,7 +104,8 @@ class FileService(ObjectService):
             **parent_folders)
 
         return url.rstrip("/")
-
+    
+    @require_version(version="11.4")
     def create(self, file_name: Union[str, Path], file_content: bytes, **kwargs):
         """ Create file
 
@@ -133,7 +137,8 @@ class FileService(ObjectService):
             data=file_content,
             headers=self.binary_http_header,
             **kwargs)
-
+    
+    @require_version(version="11.4")
     def update(self, file_name: Union[str, Path], file_content: bytes, **kwargs):
         """ Update existing file
 
@@ -150,7 +155,8 @@ class FileService(ObjectService):
             data=file_content,
             headers=self.binary_http_header,
             **kwargs)
-
+    
+    @require_version(version="11.4")
     def update_or_create(self, file_name: Union[str, Path], file_content: bytes, **kwargs):
         """ Create file or update file if it already exists
 
@@ -161,7 +167,8 @@ class FileService(ObjectService):
             return self.update(file_name, file_content, **kwargs)
 
         return self.create(file_name, file_content, **kwargs)
-
+    
+    @require_version(version="11.4")
     def exists(self, file_name: Union[str, Path], **kwargs):
         """ Check if file exists
 
@@ -173,7 +180,8 @@ class FileService(ObjectService):
             extension="")
 
         return self._exists(url, **kwargs)
-
+    
+    @require_version(version="11.4")
     def delete(self, file_name: Union[str, Path], **kwargs):
         """ Delete file
 
@@ -185,7 +193,8 @@ class FileService(ObjectService):
             extension="")
 
         return self._rest.DELETE(url, **kwargs)
-
+    
+    @require_version(version="11.4")
     def search_string_in_name(self, name_startswith: str = None, name_contains: Iterable = None,
                               name_contains_operator: str = 'and', path: Union[Path, str] = "",
                               **kwargs) -> List[str]:

--- a/TM1py/Services/FileService.py
+++ b/TM1py/Services/FileService.py
@@ -8,6 +8,7 @@ from TM1py.Services import RestService
 from TM1py.Services.ObjectService import ObjectService
 from TM1py.Utils import format_url
 from TM1py.Utils.Utils import verify_version, require_version
+from TM1py.Exceptions import TM1pyVersionException
 
 
 class FileService(ObjectService):
@@ -55,8 +56,11 @@ class FileService(ObjectService):
 
         :param file_name: file name in root or path to file
         """
+        path = Path(file_name)
+        self._check_subfolder_support(path = path, function="FileService.get")
+        
         url = self._construct_content_url(
-            path=Path(file_name),
+            path=path,
             exclude_path_end=False,
             extension="Content")
 
@@ -105,6 +109,11 @@ class FileService(ObjectService):
 
         return url.rstrip("/")
     
+    def _check_subfolder_support(self, path: Path, function: str) -> None:
+        REQUIRED_VERSION = "12"
+        if len(path.parts) > 1 and not verify_version(required_version=REQUIRED_VERSION, version=self.version):
+            raise TM1pyVersionException(function=function, required_version=REQUIRED_VERSION , feature='Subfolder')
+    
     @require_version(version="11.4")
     def create(self, file_name: Union[str, Path], file_content: bytes, **kwargs):
         """ Create file
@@ -115,6 +124,7 @@ class FileService(ObjectService):
         :param file_content: file_content as bytes or BytesIO
         """
         path = Path(file_name)
+        self._check_subfolder_support(path = path, function = "FileService.create")
 
         # Create folder structure iteratively
         if path.parents:
@@ -145,8 +155,11 @@ class FileService(ObjectService):
         :param file_name: file name in root or path to file
         :param file_content: file_content as bytes or BytesIO
         """
+        path = Path(file_name)
+        self._check_subfolder_support(path = path, function = "FileService.update")
+
         url = self._construct_content_url(
-            path=Path(file_name),
+            path=path,
             exclude_path_end=False,
             extension="Content")
 
@@ -187,8 +200,11 @@ class FileService(ObjectService):
 
         :param file_name: file name in root or path to file
         """
+        path = Path(file_name)
+        self._check_subfolder_support(path = path, function = "FileService.delete")
+
         url = self._construct_content_url(
-            path=Path(file_name),
+            path=path,
             exclude_path_end=False,
             extension="")
 
@@ -226,6 +242,9 @@ class FileService(ObjectService):
 
             else:
                 raise ValueError("'name_contains' must be str or iterable")
+            
+        path = Path(path)
+        self._check_subfolder_support(path = path, function = "FileService.search_string_in_name")
 
         url = self._construct_content_url(
             path=Path(path),

--- a/Tests/ApplicationService_test.py
+++ b/Tests/ApplicationService_test.py
@@ -8,7 +8,7 @@ from TM1py import TM1Service, Element, ElementAttribute, Hierarchy, Dimension, C
     Subset, Process, Chore, ChoreStartTime, ChoreFrequency, ChoreTask
 from TM1py.Objects.Application import CubeApplication, ApplicationTypes, ChoreApplication, DimensionApplication, \
     FolderApplication, LinkApplication, ProcessApplication, SubsetApplication, ViewApplication, DocumentApplication
-from .Utils import skip_if_insufficient_version, verify_version
+from .Utils import skip_if_version_lower_than, verify_version
 
 
 class TestApplicationService(unittest.TestCase):
@@ -242,11 +242,11 @@ class TestApplicationService(unittest.TestCase):
     def test_dimension_application_private(self):
         self.run_dimension_application(private=True)
 
-    @skip_if_insufficient_version(version="11.4")
+    @skip_if_version_lower_than(version="11.4")
     def test_dimension_application_public(self):
         self.run_dimension_application(private=False)
 
-    @skip_if_insufficient_version(version="11.4")
+    @skip_if_version_lower_than(version="11.4")
     def run_document_application(self, private):
         with open(Path(__file__).parent.joinpath('resources', 'document.xlsx'), "rb") as file:
             app = DocumentApplication(path=self.tm1py_app_folder, name=self.document_name, content=file.read())

--- a/Tests/CellService_test.py
+++ b/Tests/CellService_test.py
@@ -12,7 +12,7 @@ from TM1py.Objects import (AnonymousSubset, Cube, Dimension, Element,
 from TM1py.Services import TM1Service
 from TM1py.Utils import Utils, element_names_from_element_unique_names, CaseAndSpaceInsensitiveDict, \
     CaseAndSpaceInsensitiveTuplesDict, verify_version
-from .Utils import skip_if_insufficient_version, skip_if_no_pandas, skip_if_deprecated_in_version
+from .Utils import skip_if_version_lower_than, skip_if_no_pandas, skip_if_version_higher_or_equal_than
 
 try:
     import pandas as pd
@@ -1610,12 +1610,12 @@ class TestCellService(unittest.TestCase):
             self.assertIn("[TM1py_Tests_Cell_Dimension2].", coordinates[1])
             self.assertIn("[TM1py_Tests_Cell_Dimension3].", coordinates[2])
 
-    @skip_if_deprecated_in_version(version="12")
+    @skip_if_version_higher_or_equal_than(version="12")
     # v12 does not support empty row sets
     def test_execute_mdx_with_empty_rows(self):
         self.run_test_execute_mdx_with_empty_rows(max_workers=1)
 
-    @skip_if_deprecated_in_version(version="12")
+    @skip_if_version_higher_or_equal_than(version="12")
     # v12 does not support empty row sets
     def test_execute_mdx_with_empty_rows_async(self):
         self.run_test_execute_mdx_with_empty_rows(max_workers=4)
@@ -1644,11 +1644,11 @@ class TestCellService(unittest.TestCase):
             self.assertIn("[TM1py_Tests_Cell_Dimension2].", coordinates[1])
             self.assertIn("[TM1py_Tests_Cell_Dimension3].", coordinates[2])
 
-    @skip_if_deprecated_in_version(version="12")
+    @skip_if_version_higher_or_equal_than(version="12")
     def test_execute_mdx_with_empty_columns(self):
         self.run_test_execute_mdx_with_empty_columns(max_workers=1)
 
-    @skip_if_deprecated_in_version(version="12")
+    @skip_if_version_higher_or_equal_than(version="12")
     def test_execute_mdx_with_empty_columns_async(self):
         self.run_test_execute_mdx_with_empty_columns(max_workers=4)
 
@@ -4052,7 +4052,7 @@ class TestCellService(unittest.TestCase):
         values = self.tm1.cells.execute_mdx_values(mdx)
         self.assertEqual(values[0], 1.5)
 
-    @skip_if_deprecated_in_version(version='12')
+    @skip_if_version_higher_or_equal_than(version='12')
     def test_write_values_through_cellset_deactivate_transaction_log(self):
         query = MdxBuilder.from_cube(self.cube_name)
         query = query.add_hierarchy_set_to_row_axis(
@@ -4069,7 +4069,7 @@ class TestCellService(unittest.TestCase):
 
         self.assertFalse(self.tm1.cells.transaction_log_is_active(self.cube_name))
 
-    @skip_if_deprecated_in_version(version='12')
+    @skip_if_version_higher_or_equal_than(version='12')
     def test_write_values_through_cellset_deactivate_transaction_log_reactivate_transaction_log(self):
         mdx = MdxBuilder.from_cube(self.cube_name) \
             .add_hierarchy_set_to_row_axis(MdxHierarchySet.member(Member.of(self.dimension_names[0], "element2"))) \
@@ -4089,7 +4089,7 @@ class TestCellService(unittest.TestCase):
         self.assertEqual(values[0], 1.5)
         self.assertTrue(self.tm1.cells.transaction_log_is_active(self.cube_name))
 
-    @skip_if_deprecated_in_version(version='12')
+    @skip_if_version_higher_or_equal_than(version='12')
     def test_deactivate_transaction_log(self):
         self.tm1.cells.write_value(value="YES",
                                    cube_name="}CubeProperties",
@@ -4098,7 +4098,7 @@ class TestCellService(unittest.TestCase):
         value = self.tm1.cells.get_value("}CubeProperties", "{},LOGGING".format(self.cube_name))
         self.assertEqual("NO", value.upper())
 
-    @skip_if_deprecated_in_version(version='12')
+    @skip_if_version_higher_or_equal_than(version='12')
     def test_activate_transaction_log(self):
         self.tm1.cells.write_value(value="NO",
                                    cube_name="}CubeProperties",
@@ -4158,7 +4158,7 @@ class TestCellService(unittest.TestCase):
         values = self.tm1.cells.execute_mdx_values(mdx=mdx, encoding="latin-1")
         self.assertNotEqual(self.latin_1_encoded_text, values[0])
 
-    @skip_if_insufficient_version(version="11.7")
+    @skip_if_version_lower_than(version="11.7")
     def test_clear_with_mdx_happy_case(self):
         cells = {("Element17", "Element21", "Element15"): 1}
         self.tm1.cells.write_values(self.cube_name, cells)
@@ -4174,7 +4174,7 @@ class TestCellService(unittest.TestCase):
         value = self.tm1.cells.execute_mdx_values(mdx=mdx)[0]
         self.assertEqual(value, None)
 
-    @skip_if_insufficient_version(version="11.7")
+    @skip_if_version_lower_than(version="11.7")
     def test_clear_with_mdx_all_on_axis0(self):
         cells = {("Element19", "Element11", "Element31"): 1}
         self.tm1.cells.write_values(self.cube_name, cells)
@@ -4189,7 +4189,7 @@ class TestCellService(unittest.TestCase):
         value = self.tm1.cells.execute_mdx_values(mdx=mdx)[0]
         self.assertEqual(value, None)
 
-    @skip_if_insufficient_version(version="11.7")
+    @skip_if_version_lower_than(version="11.7")
     def test_clear_happy_case(self):
         cells = {("Element12", "Element17", "Element32"): 1}
         self.tm1.cells.write_values(self.cube_name, cells)
@@ -4210,8 +4210,8 @@ class TestCellService(unittest.TestCase):
         value = self.tm1.cells.execute_mdx_values(mdx=mdx)[0]
         self.assertEqual(value, None)
 
-    @skip_if_insufficient_version(version="11.7")
-    @skip_if_deprecated_in_version(version="12")
+    @skip_if_version_lower_than(version="11.7")
+    @skip_if_version_higher_or_equal_than(version="12")
     # skip if version 12 as invalid element names do not raise an exception
     def test_clear_invalid_element_name(self):
 
@@ -4227,7 +4227,7 @@ class TestCellService(unittest.TestCase):
             '\\"NotExistingElement\\" :',
             str(e.exception.message))
 
-    @skip_if_insufficient_version(version="11.7")
+    @skip_if_version_lower_than(version="11.7")
     def test_clear_with_mdx_invalid_query(self):
         with self.assertRaises(TM1pyException) as e:
             mdx = f"""
@@ -4260,7 +4260,7 @@ class TestCellService(unittest.TestCase):
 
         self.tm1._tm1_rest.set_version()
 
-    @skip_if_insufficient_version(version="11.7")
+    @skip_if_version_lower_than(version="11.7")
     def test_clear_with_dataframe_happy_case(self):
         cells = {("Element17", "Element21", "Element15"): 1}
         self.tm1.cells.write_values(self.cube_name, cells)
@@ -4282,7 +4282,7 @@ class TestCellService(unittest.TestCase):
         value = self.tm1.cells.execute_mdx_values(mdx=mdx)[0]
         self.assertEqual(value, None)
 
-    @skip_if_insufficient_version(version="11.7")
+    @skip_if_version_lower_than(version="11.7")
     def test_clear_with_dataframe_dimension_mapping(self):
         cells = {("Element17", "Element21", "Element15"): 1}
         self.tm1.cells.write_values(self.cube_name, cells)
@@ -4341,19 +4341,19 @@ class TestCellService(unittest.TestCase):
         elements = element_names_from_element_unique_names(list(cells.keys())[0])
         self.assertEqual(elements, ("Element 2", "Element 1", "Element 1"))
 
-    @skip_if_deprecated_in_version(version='12')
+    @skip_if_version_higher_or_equal_than(version='12')
     def test_transaction_log_is_active_false(self):
         self.tm1.cells.deactivate_transactionlog(self.cube_name)
 
         self.assertFalse(self.tm1.cells.transaction_log_is_active(self.cube_name))
 
-    @skip_if_deprecated_in_version(version='12')
+    @skip_if_version_higher_or_equal_than(version='12')
     def test_transaction_log_is_active_true(self):
         self.tm1.cells.activate_transactionlog(self.cube_name)
 
         self.assertTrue(self.tm1.cells.transaction_log_is_active(self.cube_name))
 
-    @skip_if_deprecated_in_version(version='12')
+    @skip_if_version_higher_or_equal_than(version='12')
     def test_manage_transaction_log_deactivate_reactivate(self):
         self.tm1.cells.write_values(
             self.cube_name,
@@ -4363,7 +4363,7 @@ class TestCellService(unittest.TestCase):
 
         self.assertTrue(self.tm1.cells.transaction_log_is_active(self.cube_name))
 
-    @skip_if_deprecated_in_version(version='12')
+    @skip_if_version_higher_or_equal_than(version='12')
     def test_manage_transaction_log_not_deactivate_not_reactivate(self):
         pre_state = self.tm1.cells.transaction_log_is_active(self.cube_name)
 
@@ -4375,7 +4375,7 @@ class TestCellService(unittest.TestCase):
 
         self.assertEqual(pre_state, self.tm1.cells.transaction_log_is_active(self.cube_name))
 
-    @skip_if_deprecated_in_version(version='12')
+    @skip_if_version_higher_or_equal_than(version='12')
     def test_manage_transaction_log_deactivate_not_reactivate(self):
         self.tm1.cells.write_values(
             self.cube_name,

--- a/Tests/ChoreService_test.py
+++ b/Tests/ChoreService_test.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from TM1py.Objects import Chore, ChoreStartTime, ChoreFrequency, ChoreTask, Process
 from TM1py.Services import TM1Service
-from .Utils import skip_if_insufficient_version
+from .Utils import skip_if_version_lower_than
 
 
 class TestChoreService(unittest.TestCase):
@@ -93,7 +93,7 @@ class TestChoreService(unittest.TestCase):
         if self.tm1.chores.exists(self.chore_name4):
             self.tm1.chores.delete(self.chore_name4)
 
-    @skip_if_insufficient_version(version="11.7.00002.1")
+    @skip_if_version_lower_than(version="11.7.00002.1")
     def test_create_chore_with_dst_multi_commit(self):
         # create chores
         c4 = Chore(name=self.chore_name4,

--- a/Tests/CubeService_test.py
+++ b/Tests/CubeService_test.py
@@ -8,7 +8,7 @@ from TM1py.Exceptions.Exceptions import TM1pyRestException
 from TM1py.Objects import Cube
 from TM1py.Objects import Rules
 from TM1py.Services import TM1Service
-from .Utils import skip_if_insufficient_version, skip_if_deprecated_in_version
+from .Utils import skip_if_version_lower_than, skip_if_version_higher_or_equal_than
 
 
 class TestCubeService(unittest.TestCase):
@@ -157,7 +157,7 @@ class TestCubeService(unittest.TestCase):
         self.assertNotEqual(self.tm1.cubes.get_all_names_without_rules(),
                             self.tm1.cubes.get_all_names_without_rules(skip_control_cubes=True))
 
-    @skip_if_insufficient_version(version="11.4")
+    @skip_if_version_lower_than(version="11.4")
     def test_get_storage_dimension_order(self):
         dimensions = self.tm1.cubes.get_storage_dimension_order(cube_name=self.cube_name)
         self.assertEqual(dimensions, self.dimension_names)
@@ -204,12 +204,12 @@ class TestCubeService(unittest.TestCase):
         cubes = self.tm1.cubes.search_for_dimension_substring(substring="}cubes", skip_control_cubes=True)
         self.assertEqual({}, cubes)
 
-    @skip_if_deprecated_in_version(version="12")
+    @skip_if_version_higher_or_equal_than(version="12")
     def test_search_for_dimension_substring_skip_control_cubes_false_v11(self):
         cubes = self.tm1.cubes.search_for_dimension_substring(substring="}cubes", skip_control_cubes=False)
         self.assertEqual(cubes['}CubeProperties'], ['}Cubes'])
 
-    @skip_if_insufficient_version(version="12")
+    @skip_if_version_lower_than(version="12")
     def test_search_for_dimension_substring_skip_control_cubes_false_v12(self):
         cubes = self.tm1.cubes.search_for_dimension_substring(substring="}cubes", skip_control_cubes=False)
         self.assertEqual(cubes['}CubeSecurity'], ['}Cubes'])
@@ -218,7 +218,7 @@ class TestCubeService(unittest.TestCase):
         number_of_cubes = self.tm1.cubes.get_number_of_cubes()
         self.assertIsInstance(number_of_cubes, int)
 
-    @skip_if_insufficient_version(version="11.4")
+    @skip_if_version_lower_than(version="11.4")
     def test_update_storage_dimension_order(self):
         self.tm1.cubes.update_storage_dimension_order(
             cube_name=self.cube_name,
@@ -228,14 +228,14 @@ class TestCubeService(unittest.TestCase):
             list(reversed(dimensions)),
             self.dimension_names)
 
-    @skip_if_insufficient_version(version="11.6")
-    @skip_if_deprecated_in_version(version="12")
+    @skip_if_version_lower_than(version="11.6")
+    @skip_if_version_higher_or_equal_than(version="12")
     def test_load(self):
         response = self.tm1.cubes.load(cube_name=self.cube_name)
         self.assertTrue(response.ok)
 
-    @skip_if_insufficient_version(version="11.6")
-    @skip_if_deprecated_in_version(version="12")
+    @skip_if_version_lower_than(version="11.6")
+    @skip_if_version_higher_or_equal_than(version="12")
     def test_unload(self):
         response = self.tm1.cubes.unload(cube_name=self.cube_name)
         self.assertTrue(response.ok)

--- a/Tests/ElementService_test.py
+++ b/Tests/ElementService_test.py
@@ -9,7 +9,7 @@ from mdxpy import MdxBuilder
 from TM1py.Exceptions import TM1pyRestException, TM1pyException
 from TM1py.Objects import Dimension, Hierarchy, Element, ElementAttribute
 from TM1py.Services import TM1Service
-from Tests.Utils import skip_if_insufficient_version, skip_if_no_pandas
+from Tests.Utils import skip_if_version_lower_than, skip_if_no_pandas
 
 
 class TestElementService(unittest.TestCase):
@@ -1105,7 +1105,7 @@ class TestElementService(unittest.TestCase):
         }
         self.assertEqual(expected, element_types)
 
-    @skip_if_insufficient_version(version="11.8.023")
+    @skip_if_version_lower_than(version="11.8.023")
     def test_element_lock_and_unlock(self):
         self.tm1.elements.element_lock(dimension_name=self.dimension_name, 
                                        hierarchy_name=self.hierarchy_name, 
@@ -1184,7 +1184,7 @@ class TestElementService(unittest.TestCase):
         edges = self.tm1.elements.get_edges(self.dimension_name, self.dimension_name)
         self.assertNotIn(("Total Years", "1989"), edges)
     
-    @skip_if_insufficient_version(version="11.4")
+    @skip_if_version_lower_than(version="11.4")
     def test_delete_edges(self):
         self.tm1.elements.delete_edges(
             dimension_name=self.dimension_name,

--- a/Tests/FileService_test.py
+++ b/Tests/FileService_test.py
@@ -3,7 +3,7 @@ import unittest
 from pathlib import Path
 
 from TM1py import TM1Service
-from .Utils import skip_if_insufficient_version
+from .Utils import skip_if_insufficient_version, verify_version
 
 
 class TestFileService(unittest.TestCase):
@@ -26,7 +26,8 @@ class TestFileService(unittest.TestCase):
         if self.tm1.files.exists(self.FILE_NAME2):
             self.tm1.files.delete(self.FILE_NAME2)
 
-        self.setUpV12()
+        if verify_version(required_version="12", version=self.tm1.version):
+            self.setUpV12()
 
     @skip_if_insufficient_version(version="12")
     def setUpV12(self):

--- a/Tests/FileService_test.py
+++ b/Tests/FileService_test.py
@@ -4,9 +4,11 @@ from pathlib import Path
 
 from TM1py import TM1Service
 from TM1py.Exceptions import TM1pyVersionException
-from .Utils import skip_if_insufficient_version, verify_version
-from .Utils import skip_if_deprecated_in_version as skip_if_version_is_at_least
-
+from .Utils import (
+    skip_if_version_lower_than,
+    skip_if_version_higher_or_equal_than,
+    verify_version,
+)
 
 class TestFileService(unittest.TestCase):
     tm1: TM1Service
@@ -31,7 +33,7 @@ class TestFileService(unittest.TestCase):
         if verify_version(required_version="12", version=self.tm1.version):
             self.setUpV12()
 
-    @skip_if_insufficient_version(version="12")
+    @skip_if_version_lower_than(version="12")
     def setUpV12(self):
         with open(Path(__file__).parent.joinpath('resources', 'file.csv'), "rb") as file:
             self.tm1.files.update_or_create(self.FILE_NAME1_IN_FOLDER, file.read())
@@ -39,7 +41,7 @@ class TestFileService(unittest.TestCase):
         if self.tm1.files.exists(self.FILE_NAME2_IN_FOLDER):
             self.tm1.files.delete(self.FILE_NAME2_IN_FOLDER)
 
-    @skip_if_insufficient_version(version="11.4")
+    @skip_if_version_lower_than(version="11.4")
     def test_create_get(self):
         with open(Path(__file__).parent.joinpath('resources', 'file.csv'), "rb") as original_file:
             self.tm1.files.update_or_create(self.FILE_NAME1, original_file.read())
@@ -49,7 +51,7 @@ class TestFileService(unittest.TestCase):
         with open(Path(__file__).parent.joinpath('resources', 'file.csv'), "rb") as original_file:
             self.assertEqual(original_file.read(), created_file)
 
-    @skip_if_insufficient_version(version="12")
+    @skip_if_version_lower_than(version="12")
     def test_create_get_in_folder(self):
         with open(Path(__file__).parent.joinpath('resources', 'file.csv'), "rb") as original_file:
             self.tm1.files.update_or_create(self.FILE_NAME1_IN_FOLDER, original_file.read())
@@ -59,15 +61,15 @@ class TestFileService(unittest.TestCase):
         with open(Path(__file__).parent.joinpath('resources', 'file.csv'), "rb") as original_file:
             self.assertEqual(original_file.read(), created_file)
 
-    @skip_if_insufficient_version(version="11.4")
-    @skip_if_version_is_at_least(version="12")
+    @skip_if_version_lower_than(version="11.4")
+    @skip_if_version_higher_or_equal_than(version="12")
     def test_create_in_folder_exception(self):
         with open(Path(__file__).parent.joinpath('resources', 'file.csv'), "rb") as original_file:
             with self.assertRaises(TM1pyVersionException) as e:
                 self.tm1.files.update_or_create(self.FILE_NAME1_IN_FOLDER, original_file.read())
             self.assertEqual(str(e.exception), "'Subfolder' feature of function 'FileService.create' requires TM1 server version >= '12'")
 
-    @skip_if_insufficient_version(version="11.4")
+    @skip_if_version_lower_than(version="11.4")
     def test_update_get(self):
         with open(Path(__file__).parent.joinpath('resources', 'file.csv'), "rb") as original_file:
             self.tm1.files.update(self.FILE_NAME1, original_file.read())
@@ -77,7 +79,7 @@ class TestFileService(unittest.TestCase):
         with open(Path(__file__).parent.joinpath('resources', 'file.csv'), "rb") as original_file:
             self.assertEqual(original_file.read(), created_file)
 
-    @skip_if_insufficient_version(version="12")
+    @skip_if_version_lower_than(version="12")
     def test_update_get_in_folder(self):
         with open(Path(__file__).parent.joinpath('resources', 'file.csv'), "rb") as original_file:
             self.tm1.files.update(self.FILE_NAME1_IN_FOLDER, original_file.read())
@@ -87,38 +89,38 @@ class TestFileService(unittest.TestCase):
         with open(Path(__file__).parent.joinpath('resources', 'file.csv'), "rb") as original_file:
             self.assertEqual(original_file.read(), created_file)
     
-    @skip_if_insufficient_version(version="11.4")
-    @skip_if_version_is_at_least(version="12")
+    @skip_if_version_lower_than(version="11.4")
+    @skip_if_version_higher_or_equal_than(version="12")
     def test_update_in_folder_exception(self):
         with open(Path(__file__).parent.joinpath('resources', 'file.csv'), "rb") as original_file:
             with self.assertRaises(TM1pyVersionException) as e:
                 self.tm1.files.update(self.FILE_NAME1_IN_FOLDER, original_file.read())
             self.assertEqual(str(e.exception), "'Subfolder' feature of function 'FileService.update' requires TM1 server version >= '12'")
 
-    @skip_if_insufficient_version(version="11.4")
+    @skip_if_version_lower_than(version="11.4")
     def test_get_all_names(self):
         result = self.tm1.files.get_all_names()
         self.assertIn(self.FILE_NAME1, result)
 
-    @skip_if_insufficient_version(version="12")
+    @skip_if_version_lower_than(version="12")
     def test_get_all_names_in_folder(self):
         result = self.tm1.files.get_all_names(path=self.FILE_NAME1_IN_FOLDER.parent)
         self.assertIn(self.FILE_NAME1, result)
 
-    @skip_if_insufficient_version(version="11.4")
+    @skip_if_version_lower_than(version="11.4")
     def test_search_string_in_name__name_startswith(self):
         result = self.tm1.files.search_string_in_name(name_startswith=self.FILE_NAME1)
         self.assertEqual([self.FILE_NAME1], result)
 
-    @skip_if_insufficient_version(version="12")
+    @skip_if_version_lower_than(version="12")
     def test_search_string_in_name__name_startswith_in_folder(self):
         result = self.tm1.files.search_string_in_name(
             name_startswith=self.FILE_NAME1,
             path=self.FILE_NAME1_IN_FOLDER.parent)
         self.assertEqual([self.FILE_NAME1], result)
 
-    @skip_if_insufficient_version(version="11.4")
-    @skip_if_version_is_at_least(version="12")
+    @skip_if_version_lower_than(version="11.4")
+    @skip_if_version_higher_or_equal_than(version="12")
     def test_search_string_in_name__name_startswith_in_folder_exception(self):
         with self.assertRaises(TM1pyVersionException) as e:
             self.tm1.files.search_string_in_name(
@@ -126,29 +128,29 @@ class TestFileService(unittest.TestCase):
             )
             self.assertEqual(str(e.exception), "'Subfolder' feature of function 'FileService.search_string_in_name' requires TM1 server version >= '12'")
 
-    @skip_if_insufficient_version(version="11.4")
+    @skip_if_version_lower_than(version="11.4")
     def test_search_string_in_name__name_startswith_not_existing(self):
         result = self.tm1.files.search_string_in_name(name_startswith='not_the_file_im_looking_for')
         self.assertEqual([], result)
 
-    @skip_if_insufficient_version(version="11.4")
+    @skip_if_version_lower_than(version="11.4")
     def test_search_string_in_name__name_contains_both_existing(self):
         result = self.tm1.files.search_string_in_name(name_contains=[self.FILE_NAME1[:5], self.FILE_NAME1[-5:]])
         self.assertEqual([self.FILE_NAME1], result)
 
-    @skip_if_insufficient_version(version="11.4")
+    @skip_if_version_lower_than(version="11.4")
     def test_search_string_in_name__name_contains_mixed_existing_and(self):
         result = self.tm1.files.search_string_in_name(name_contains=[self.FILE_NAME1[:5], 'NotFound'])
         self.assertEqual([], result)
 
-    @skip_if_insufficient_version(version="11.4")
+    @skip_if_version_lower_than(version="11.4")
     def test_search_string_in_name__name_contains_mixed_existing_or(self):
         result = self.tm1.files.search_string_in_name(
             name_contains=[self.FILE_NAME1, 'NotFound'],
             name_contains_operator='OR')
         self.assertEqual([self.FILE_NAME1], result)
 
-    @skip_if_insufficient_version(version="11.4")
+    @skip_if_version_lower_than(version="11.4")
     def test_delete_exists(self):
         self.assertTrue(self.tm1.files.exists(self.FILE_NAME1))
 
@@ -156,7 +158,7 @@ class TestFileService(unittest.TestCase):
 
         self.assertFalse(self.tm1.files.exists(self.FILE_NAME1))
 
-    @skip_if_insufficient_version(version="12")
+    @skip_if_version_lower_than(version="12")
     def test_delete_exists_in_folder(self):
         self.assertTrue(self.tm1.files.exists(self.FILE_NAME1_IN_FOLDER))
 
@@ -164,8 +166,8 @@ class TestFileService(unittest.TestCase):
 
         self.assertFalse(self.tm1.files.exists(self.FILE_NAME1_IN_FOLDER))
 
-    @skip_if_insufficient_version(version="11.4")
-    @skip_if_version_is_at_least(version="12")
+    @skip_if_version_lower_than(version="11.4")
+    @skip_if_version_higher_or_equal_than(version="12")
     def test_delete_in_folder_exception(self):
         with self.assertRaises(TM1pyVersionException) as e:
             self.tm1.files.delete(self.FILE_NAME1_IN_FOLDER)

--- a/Tests/FileService_test.py
+++ b/Tests/FileService_test.py
@@ -3,7 +3,9 @@ import unittest
 from pathlib import Path
 
 from TM1py import TM1Service
+from TM1py.Exceptions import TM1pyVersionException
 from .Utils import skip_if_insufficient_version, verify_version
+from .Utils import skip_if_deprecated_in_version as skip_if_version_is_at_least
 
 
 class TestFileService(unittest.TestCase):
@@ -58,6 +60,14 @@ class TestFileService(unittest.TestCase):
             self.assertEqual(original_file.read(), created_file)
 
     @skip_if_insufficient_version(version="11.4")
+    @skip_if_version_is_at_least(version="12")
+    def test_create_in_folder_exception(self):
+        with open(Path(__file__).parent.joinpath('resources', 'file.csv'), "rb") as original_file:
+            with self.assertRaises(TM1pyVersionException) as e:
+                self.tm1.files.update_or_create(self.FILE_NAME1_IN_FOLDER, original_file.read())
+            self.assertEqual(str(e.exception), "'Subfolder' feature of function 'FileService.create' requires TM1 server version >= '12'")
+
+    @skip_if_insufficient_version(version="11.4")
     def test_update_get(self):
         with open(Path(__file__).parent.joinpath('resources', 'file.csv'), "rb") as original_file:
             self.tm1.files.update(self.FILE_NAME1, original_file.read())
@@ -76,6 +86,14 @@ class TestFileService(unittest.TestCase):
 
         with open(Path(__file__).parent.joinpath('resources', 'file.csv'), "rb") as original_file:
             self.assertEqual(original_file.read(), created_file)
+    
+    @skip_if_insufficient_version(version="11.4")
+    @skip_if_version_is_at_least(version="12")
+    def test_update_in_folder_exception(self):
+        with open(Path(__file__).parent.joinpath('resources', 'file.csv'), "rb") as original_file:
+            with self.assertRaises(TM1pyVersionException) as e:
+                self.tm1.files.update(self.FILE_NAME1_IN_FOLDER, original_file.read())
+            self.assertEqual(str(e.exception), "'Subfolder' feature of function 'FileService.update' requires TM1 server version >= '12'")
 
     @skip_if_insufficient_version(version="11.4")
     def test_get_all_names(self):
@@ -98,6 +116,15 @@ class TestFileService(unittest.TestCase):
             name_startswith=self.FILE_NAME1,
             path=self.FILE_NAME1_IN_FOLDER.parent)
         self.assertEqual([self.FILE_NAME1], result)
+
+    @skip_if_insufficient_version(version="11.4")
+    @skip_if_version_is_at_least(version="12")
+    def test_search_string_in_name__name_startswith_in_folder_exception(self):
+        with self.assertRaises(TM1pyVersionException) as e:
+            self.tm1.files.search_string_in_name(
+                name_startswith=self.FILE_NAME1, path=self.FILE_NAME1_IN_FOLDER.parent
+            )
+            self.assertEqual(str(e.exception), "'Subfolder' feature of function 'FileService.search_string_in_name' requires TM1 server version >= '12'")
 
     @skip_if_insufficient_version(version="11.4")
     def test_search_string_in_name__name_startswith_not_existing(self):
@@ -136,6 +163,13 @@ class TestFileService(unittest.TestCase):
         self.tm1.files.delete(self.FILE_NAME1_IN_FOLDER)
 
         self.assertFalse(self.tm1.files.exists(self.FILE_NAME1_IN_FOLDER))
+
+    @skip_if_insufficient_version(version="11.4")
+    @skip_if_version_is_at_least(version="12")
+    def test_delete_in_folder_exception(self):
+        with self.assertRaises(TM1pyVersionException) as e:
+            self.tm1.files.delete(self.FILE_NAME1_IN_FOLDER)
+            self.assertEqual(str(e.exception), "'Subfolder' feature of function 'FileService.delete' requires TM1 server version >= '12'")
 
     def tearDown(self) -> None:
         if self.tm1.files.exists(self.FILE_NAME1):

--- a/Tests/ManageService_test.py
+++ b/Tests/ManageService_test.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import time
 
 from TM1py.Services import ManageService, TM1Service
-from .Utils import skip_if_insufficient_version
+from .Utils import skip_if_version_lower_than
 from .Utils import verify_version
 
 

--- a/Tests/MonitoringService_test.py
+++ b/Tests/MonitoringService_test.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from TM1py.Services import TM1Service
 from TM1py.Utils import case_and_space_insensitive_equals
-from .Utils import skip_if_deprecated_in_version
+from .Utils import skip_if_version_higher_or_equal_than
 
 
 class TestMonitoringService(unittest.TestCase):
@@ -21,7 +21,7 @@ class TestMonitoringService(unittest.TestCase):
         cls.config.read(Path(__file__).parent.joinpath('config.ini'))
         cls.tm1 = TM1Service(**cls.config['tm1srv01'])
 
-    @skip_if_deprecated_in_version(version="12.0.0")
+    @skip_if_version_higher_or_equal_than(version="12.0.0")
     def test_get_threads(self):
         threads = self.tm1.monitoring.get_threads()
         self.assertTrue(any(thread["Function"] == "GET /api/v1/Threads" for thread in threads)
@@ -43,7 +43,7 @@ class TestMonitoringService(unittest.TestCase):
     def test_disconnect_all_users(self):
         self.tm1.monitoring.disconnect_all_users()
 
-    @skip_if_deprecated_in_version(version="12.0.0")
+    @skip_if_version_higher_or_equal_than(version="12.0.0")
     def test_cancel_all_running_threads(self):
         self.tm1.monitoring.cancel_all_running_threads()
 

--- a/Tests/ProcessService_test.py
+++ b/Tests/ProcessService_test.py
@@ -10,7 +10,7 @@ from TM1py.Exceptions import TM1pyException, TM1pyTimeout
 from TM1py.Objects import Process, Subset, ProcessDebugBreakpoint, BreakPointType, HitMode
 from TM1py.Services import TM1Service
 from TM1py.Utils import verify_version
-from .Utils import skip_if_insufficient_version, skip_if_deprecated_in_version
+from .Utils import skip_if_version_lower_than, skip_if_version_higher_or_equal_than
 
 
 class TestProcessService(unittest.TestCase):
@@ -151,7 +151,7 @@ class TestProcessService(unittest.TestCase):
         # without arguments
         self.tm1.processes.execute(self.p_bedrock_server_wait.name)
 
-    @skip_if_insufficient_version(version="11.4")
+    @skip_if_version_lower_than(version="11.4")
     def test_execute_with_return_success(self):
         process = self.p_bedrock_server_wait
         self.tm1.processes.update_or_create(process)
@@ -219,7 +219,7 @@ class TestProcessService(unittest.TestCase):
 
         self.tm1.processes.delete(process.name)
 
-    @skip_if_insufficient_version(version="11.4")
+    @skip_if_version_lower_than(version="11.4")
     def test_execute_with_return_with_process_break(self):
         process = Process(name=str(uuid.uuid4()))
         process.prolog_procedure = "sText = 'Something'; ProcessBreak;"
@@ -236,7 +236,7 @@ class TestProcessService(unittest.TestCase):
 
         self.tm1.processes.delete(process.name)
 
-    @skip_if_insufficient_version(version="11.4")
+    @skip_if_version_lower_than(version="11.4")
     def test_execute_with_return_with_process_quit(self):
         process = Process(name=str(uuid.uuid4()))
         process.prolog_procedure = "sText = 'Something'; ProcessQuit;"
@@ -272,7 +272,7 @@ class TestProcessService(unittest.TestCase):
         self.assertIn("\"dimsize\"", errors[0]["Message"])
         self.tm1.processes.delete(p_bad.name)
 
-    @skip_if_insufficient_version(version="11.4")
+    @skip_if_version_lower_than(version="11.4")
     def test_execute_process_with_return_success(self):
         process = Process(name=str(uuid.uuid4()))
         process.prolog_procedure = "Sleep(100);"
@@ -284,7 +284,7 @@ class TestProcessService(unittest.TestCase):
         if not verify_version(required_version="12", version=self.tm1.version):
             self.assertIsNone(error_log_file)
 
-    @skip_if_insufficient_version(version="11.3")
+    @skip_if_version_lower_than(version="11.3")
     def test_execute_process_with_return_returns_async_id(self):
         process = Process(name=str(uuid.uuid4()))
         process.prolog_procedure = "Sleep(100);"
@@ -292,7 +292,7 @@ class TestProcessService(unittest.TestCase):
         async_id = self.tm1.processes.execute_process_with_return(process, return_async_id=True)
         self.assertGreater(len(async_id), 5)
 
-    @skip_if_insufficient_version(version="11.3")
+    @skip_if_version_lower_than(version="11.3")
     def test_execute_process_with_return_returns_timeout(self):
         process = Process(name=str(uuid.uuid4()))
         process.prolog_procedure = "Sleep(3000);"
@@ -317,7 +317,7 @@ class TestProcessService(unittest.TestCase):
         self.assertEqual(status, "CompletedWithMessages")
         self.assertIsNotNone(error_log_file)
 
-    @skip_if_insufficient_version(version="11.4")
+    @skip_if_version_lower_than(version="11.4")
     def test_execute_process_with_return_with_process_break(self):
         process = Process(name=str(uuid.uuid4()))
         process.prolog_procedure = "sText = 'Something'; ProcessBreak;"
@@ -329,7 +329,7 @@ class TestProcessService(unittest.TestCase):
         if not verify_version(required_version="12", version=self.tm1.version):
             self.assertIsNone(error_log_file)
 
-    @skip_if_insufficient_version(version="11.4")
+    @skip_if_version_lower_than(version="11.4")
     def test_execute_process_with_return_with_process_quit(self):
         process = Process(name=str(uuid.uuid4()))
         process.prolog_procedure = "sText = 'Something'; ProcessQuit;"
@@ -380,7 +380,7 @@ class TestProcessService(unittest.TestCase):
         p4._ui_data = p_subset_orig._ui_data = None
         self.assertEqual(p_subset_orig.body, p4.body)
 
-    @skip_if_deprecated_in_version("12")
+    @skip_if_version_higher_or_equal_than("12")
     def test_get_process_odbc(self):
         p_odbc_orig = copy.deepcopy(self.p_odbc)
 
@@ -420,7 +420,7 @@ class TestProcessService(unittest.TestCase):
 
         self.tm1.processes.delete(process.name)
 
-    @skip_if_deprecated_in_version(version='12')
+    @skip_if_version_higher_or_equal_than(version='12')
     def test_get_last_message_from_processerrorlog(self):
         process = Process(name=str(uuid.uuid4()))
         process.epilog_procedure = "ItemReject('Not Relevant');"

--- a/Tests/SecurityService_test.py
+++ b/Tests/SecurityService_test.py
@@ -8,7 +8,7 @@ from TM1py.Objects import User
 from TM1py.Objects.User import UserType
 from TM1py.Services import TM1Service
 from TM1py.Utils.Utils import CaseAndSpaceInsensitiveSet, case_and_space_insensitive_equals, verify_version
-from .Utils import skip_if_deprecated_in_version, skip_if_insufficient_version
+from .Utils import skip_if_version_higher_or_equal_than, skip_if_version_lower_than
 
 
 class TestSecurityService(unittest.TestCase):
@@ -127,7 +127,7 @@ class TestSecurityService(unittest.TestCase):
         user = User("not_relevant", groups=["OperationsAdmin"], user_type=None)
         self.assertEqual(user.user_type, UserType.OperationsAdmin)
 
-    @skip_if_deprecated_in_version(version='12')
+    @skip_if_version_higher_or_equal_than(version='12')
     def test_update_user_properties(self):
         # get user
         u = self.tm1.security.get_user(self.user_name)
@@ -148,7 +148,7 @@ class TestSecurityService(unittest.TestCase):
         self.assertEqual(u.user_type, UserType.DataAdmin)
         self.assertIn("DataAdmin", u.groups)
 
-    @skip_if_deprecated_in_version(version='12')
+    @skip_if_version_higher_or_equal_than(version='12')
     def test_update_user_properties_with_type_as_str(self):
         # get user
         u = self.tm1.security.get_user(self.user_name)
@@ -229,7 +229,7 @@ class TestSecurityService(unittest.TestCase):
         response = self.tm1.security.security_refresh()
         self.assertTrue(response.ok)
 
-    @skip_if_deprecated_in_version(version="12")
+    @skip_if_version_higher_or_equal_than(version="12")
     def test_auth_with_exotic_characters_in_password(self):
         exotic_password = "d'8!?:Y4"
 
@@ -272,7 +272,7 @@ class TestSecurityService(unittest.TestCase):
         self.assertIn(group, groups_before_delete)
         self.assertNotIn(group, groups_after_delete)
 
-    @skip_if_deprecated_in_version(version='12')
+    @skip_if_version_higher_or_equal_than(version='12')
     def test_tm1service_with_encrypted_password_decode_b64_as_string(self):
         user_name = "TM1py user name"
         user = User(name=user_name, groups=["ADMIN"], password="apple")
@@ -291,7 +291,7 @@ class TestSecurityService(unittest.TestCase):
 
         self.tm1.security.delete_user(user.name)
 
-    @skip_if_deprecated_in_version(version='12')
+    @skip_if_version_higher_or_equal_than(version='12')
     def test_tm1service_without_encrypted_password(self):
         user_name = "TM1py user name"
         user = User(name=user_name, groups=["ADMIN"], password="apple")
@@ -310,7 +310,7 @@ class TestSecurityService(unittest.TestCase):
 
         self.tm1.security.delete_user(user.name)
 
-    @skip_if_deprecated_in_version(version='12')
+    @skip_if_version_higher_or_equal_than(version='12')
     def test_tm1service_with_encrypted_password(self):
         user_name = "TM1py user name"
         user = User(name=user_name, groups=["ADMIN"], password="apple")
@@ -329,7 +329,7 @@ class TestSecurityService(unittest.TestCase):
 
         self.tm1.security.delete_user(user.name)
 
-    @skip_if_deprecated_in_version(version='12')
+    @skip_if_version_higher_or_equal_than(version='12')
     def test_tm1service_with_encrypted_password_fail(self):
         user_name = "TM1py user name"
         user = User(name=user_name, groups=["ADMIN"], password="apple")
@@ -346,7 +346,7 @@ class TestSecurityService(unittest.TestCase):
 
         self.tm1.security.delete_user(user.name)
 
-    @skip_if_deprecated_in_version(version='12')
+    @skip_if_version_higher_or_equal_than(version='12')
     def test_tm1service_with_plain_password(self):
         user_name = "TM1py user name"
         user = User(name=user_name, groups=["ADMIN"], password="apple")
@@ -363,7 +363,7 @@ class TestSecurityService(unittest.TestCase):
             pass
         self.tm1.security.delete_user(user.name)
 
-    @skip_if_deprecated_in_version(version='12')
+    @skip_if_version_higher_or_equal_than(version='12')
     def test_tm1service_with_plain_password_fail(self):
         user_name = "TM1py user name"
         user = User(name=user_name, groups=["ADMIN"], password="apple")
@@ -391,7 +391,7 @@ class TestSecurityService(unittest.TestCase):
     def test_group_exists_false(self):
         self.assertFalse(self.tm1.security.group_exists(group_name="NotAValidName"))
 
-    @skip_if_deprecated_in_version(version='12')
+    @skip_if_version_higher_or_equal_than(version='12')
     def test_impersonate(self):
         tm1 = TM1Service(**self.config['tm1srv01'])
         self.assertNotEqual(self.user_name, tm1.whoami.name)
@@ -413,14 +413,14 @@ class TestSecurityService(unittest.TestCase):
 
         self.assertNotIn("NotExistingGroup", CaseAndSpaceInsensitiveSet(*custom_groups))
 
-    @skip_if_deprecated_in_version(version='12')
+    @skip_if_version_higher_or_equal_than(version='12')
     def test_get_read_only_users(self):
         read_only_users = self.tm1.security.get_read_only_users()
 
         self.assertEqual(1, len(read_only_users))
         self.assertEqual(self.read_only_user_name, read_only_users[0])
 
-    @skip_if_deprecated_in_version(version='12')
+    @skip_if_version_higher_or_equal_than(version='12')
     def test_update_user_password(self):
         self.tm1.security.update_user_password(user_name=self.user.name, password="new_password123")
 

--- a/Tests/Utils.py
+++ b/Tests/Utils.py
@@ -20,9 +20,10 @@ def skip_if_no_pandas(func):
     return wrapper
 
 
-def skip_if_insufficient_version(version):
+def skip_if_version_lower_than(version):
     """ 
-    Checks whether TM1 version is high enough and skips the test if not
+    Checks whether TM1 version is lower than a certain version and skips the test 
+    if this is the case. This function is useful if a test needs a minimum required version.
     """
 
     def wrap(func):
@@ -40,9 +41,10 @@ def skip_if_insufficient_version(version):
     return wrap
 
 
-def skip_if_deprecated_in_version(version):
+def skip_if_version_higher_or_equal_than(version):
     """
-    Checks whether TM1 Function Has Been Deprecated
+    Checks whether TM1 version is higher or equal than a certain version and skips the test 
+    if this is the case. This function is useful if a test should not run for higher versions.
     """
 
     def wrap(func):

--- a/Tests/Utils_test.py
+++ b/Tests/Utils_test.py
@@ -12,7 +12,7 @@ from TM1py.Utils import (
     map_cell_properties_to_compact_json_response, frame_to_significant_digits, drop_dimension_properties
 )
 
-from .Utils import skip_if_deprecated_in_version
+from .Utils import skip_if_version_higher_or_equal_than
 
 class TestUtilsMethods(unittest.TestCase):
     tm1: TM1Service
@@ -28,7 +28,7 @@ class TestUtilsMethods(unittest.TestCase):
         cls.config.read(Path(__file__).parent.joinpath("config.ini"))
         cls.tm1 = TM1Service(**cls.config["tm1srv01"])
 
-    @skip_if_deprecated_in_version(version="12")
+    @skip_if_version_higher_or_equal_than(version="12")
     def test_get_instances_from_adminhost(self):
         servers = Utils.get_all_servers_from_adminhost(
             self.config["tm1srv01"]["address"]


### PR DESCRIPTION
This PR improves the version checks in `FileService.py` and is inspired by issue #1123  :

* Fix: setUpV12 should only be called for v12, otherwise every test is skipped in lower versions f12c49d6e8dcd6f20702d6459b4bc41152f5ae9d
*  Fix: Added minimum required versions to file service c13bf1cdb852fd27cabad13ef78933ff20e3c166
* Feature: Added optional feature parameter for explaining why TM1pyVersionException is raised bd33d2abbbfbbadd1ad3c0ed21035a6c4b9b7ffc
* Fix: Raise error if subfolder feature is not supported by version f24c52d9d34500ceceb6d04588711acee5070c64
*  Refactor: Clean up not necessary f-strings e4b4629f3f60447573b27c14919436088a306a92

I couldn't run the tests against a tm1 server v12.