### PR TITLE
Implement Lazy Initialization to Prevent Warnings for Deprecated Services

### DIFF
--- a/TM1py/Services/TM1Service.py
+++ b/TM1py/Services/TM1Service.py
@@ -87,10 +87,11 @@ class TM1Service:
         self.audit_logs = AuditLogService(self._tm1_rest)
 
         #higher level modules
-        self.server = ServerService(self._tm1_rest)
-        self.monitoring = MonitoringService(self._tm1_rest)
         self.power_bi = PowerBiService(self._tm1_rest)
         self.loggers = LoggerService(self._tm1_rest)
+
+        self._server = None
+        self._monitoring = None
 
     def logout(self, **kwargs):
         self._tm1_rest.logout(**kwargs)
@@ -103,6 +104,18 @@ class TM1Service:
             self.logout()
         except Exception as e:
             warnings.warn(f"Logout Failed due to Exception: {e}")
+    
+    @property
+    def server(self):
+        if not self._server:
+             self._server = ServerService(self._tm1_rest)
+        return self._server
+    
+    @property
+    def monitoring(self):
+        if not self._monitoring:
+            self._monitoring = MonitoringService(self._tm1_rest)
+        return self._monitoring
 
     @property
     def whoami(self):

--- a/Tests/DimensionService_test.py
+++ b/Tests/DimensionService_test.py
@@ -1,5 +1,6 @@
 import configparser
 import unittest
+import warnings
 from pathlib import Path
 
 from TM1py.Objects import Dimension, Hierarchy, Element
@@ -179,12 +180,17 @@ class TestDimensionService(unittest.TestCase):
 
     def test_execute_mdx(self):
         mdx = "{TM1SubsetAll(" + self.dimension_name + ")}"
-        elements = self.tm1.dimensions.execute_mdx(self.dimension_name, mdx)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            elements = self.tm1.dimensions.execute_mdx(self.dimension_name, mdx)
         self.assertEqual(len(elements), 1001)
 
         mdx = "{ Tm1FilterByLevel ( {TM1SubsetAll(" + self.dimension_name + ")}, 0) }"
-        elements = self.tm1.dimensions.execute_mdx(self.dimension_name, mdx)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            elements = self.tm1.dimensions.execute_mdx(self.dimension_name, mdx)
         self.assertEqual(len(elements), 1000)
+        
         for element in elements:
             self.assertTrue(element.startswith("Element"))
 

--- a/Tests/MonitoringService_test.py
+++ b/Tests/MonitoringService_test.py
@@ -1,5 +1,6 @@
 import configparser
 import unittest
+import warnings
 from pathlib import Path
 
 from TM1py.Services import TM1Service
@@ -20,6 +21,9 @@ class TestMonitoringService(unittest.TestCase):
         cls.config = configparser.ConfigParser()
         cls.config.read(Path(__file__).parent.joinpath('config.ini'))
         cls.tm1 = TM1Service(**cls.config['tm1srv01'])
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            cls.tm1.monitoring
 
     @skip_if_version_higher_or_equal_than(version="12.0.0")
     def test_get_threads(self):


### PR DESCRIPTION
# Description

This Pull Request introduces lazy initialization for MonitoringService and ServerService, effectively reducing the occurrence of warnings related to these deprecated services. By instantiating these services in TM1Service only when they are actually needed, we minimize the warnings for the majority of use cases where these services are not used.

Furthermore, this PR suppresses expected warnings in tests: This allows the tests to run without cluttering the output with warnings that were anticipated.

# Benefits

* Cleaner Output: By avoiding unnecessary warnings, the console output during development and testing is cleaner and easier to read.

* Focus on warnings where developer action is required.

# Thread Safety Consideration

Please note that this implementation is not thread-safe. If needed, we have to rewrite some parts of the PR.