### PR TITLE
Feature/simplify execute set mdx migration

### DIFF
--- a/TM1py/Services/DimensionService.py
+++ b/TM1py/Services/DimensionService.py
@@ -168,7 +168,7 @@ class DimensionService(ObjectService):
         :return: List of Element names
         """
 
-        warnings.warn("execute_mdx() will be deprecated; use ElementService execute_set_mdx.", DeprecationWarning,
+        warnings.warn("execute_mdx() will be deprecated; use ElementService execute_set_mdx_element_names().", DeprecationWarning,
                       stacklevel=2)
 
         mdx_skeleton = "SELECT " \

--- a/TM1py/Services/ElementService.py
+++ b/TM1py/Services/ElementService.py
@@ -1011,6 +1011,23 @@ class ElementService(ObjectService):
         get_members(consolidation_tree)
         return members
 
+    def execute_set_mdx_element_names(
+        self, mdx: str, top_records: Optional[int] = None, **kwargs
+    ) -> List:
+        """
+        :method to execute an MDX statement against a dimension and get a list with element names back
+        :param mdx: valid dimension mdx statement
+        :param top_records: number of records to return, default: all elements no limit
+        :return: list of element names
+        """
+        elements = self.execute_set_mdx(
+            mdx,
+            member_properties=["Name"],
+            parent_properties=None,
+            element_properties=None,
+        )
+        return [element[0]["Name"] for element in elements]
+
     def execute_set_mdx(
             self,
             mdx: str,

--- a/Tests/ElementService_test.py
+++ b/Tests/ElementService_test.py
@@ -1072,6 +1072,11 @@ class TestElementService(unittest.TestCase):
                 self.dimension_name,
                 [element_attribute])
 
+    def test_execute_set_mdx_element_names(self):
+        mdx = f"{{[{self.dimension_name}].[1990]}}"
+        members = self.tm1.elements.execute_set_mdx_element_names(mdx=mdx)
+        self.assertEqual(members, ['1990'])
+
     def test_execute_set_mdx(self):
         mdx = f"{{[{self.dimension_name}].[1990]}}"
         members = self.tm1.elements.execute_set_mdx(

--- a/Tests/SecurityService_test.py
+++ b/Tests/SecurityService_test.py
@@ -197,7 +197,7 @@ class TestSecurityService(unittest.TestCase):
     def test_get_users_from_group(self):
         users = [user.name for user in self.tm1.security.get_users_from_group("AdMiN")]
         mdx = "{ FILTER ( { [}Clients].Members } , [}ClientGroups].([}Groups].[ADMIN]) = 'ADMIN' ) }"
-        clients = self.tm1.dimensions.execute_mdx("}Clients", mdx)
+        clients = self.tm1.elements.execute_set_mdx_element_names(mdx)
         self.assertGreater(len(users), 0)
         self.assertGreater(len(clients), 0)
         self.assertEqual(sorted(users), sorted(clients))
@@ -206,7 +206,7 @@ class TestSecurityService(unittest.TestCase):
         users = self.tm1.security.get_user_names_from_group(self.group_name1)
         mdx = "{ FILTER ( { [}Clients].Members } , [}ClientGroups].([}Groups].[" + self.group_name1 + "]) = '" + \
               self.group_name1.replace("'", "''") + "' ) }"
-        clients = self.tm1.dimensions.execute_mdx("}Clients", mdx)
+        clients = self.tm1.elements.execute_set_mdx_element_names(mdx)
         self.assertGreater(len(users), 0)
         self.assertGreater(len(clients), 0)
         self.assertEqual(sorted(users), sorted(clients))


### PR DESCRIPTION
# Description

To simplify the migration from the deprecated `DimensionService::execute_mdx` method to `ElementService::execute_set_mdx`, this PR introduces a new method, `get_element_names_by_mdx`, which simulates the old behavior. This new function utilizes execute_set_mdx under the hood.

Last but not least, the *SecurityService_test.py* has been migrated to use the new function.

# Example

For example, we have the following line:

```
elements = self.tm1.dimensions.execute_mdx(dim, mdx)
```

With the changes from this PR, the new call looks like this:

```
elements = self.tm1.elements.get_element_names_by_mdx(mdx)
```

Without these changes, you must write the following to achieve the old behavior:

```
elements = [
    element[0]["Name"]
    for element in self.tm1.elements.execute_set_mdx(
        mdx, member_properties=["Name"], parent_properties=None, element_properties=None
    )
]
```

