### PR TITLE
Fix 1174: Bug fix to compare and allow case and space insensitivity for remove_edges_under_consolidation()

### DIFF
--- a/TM1py/Services/HierarchyService.py
+++ b/TM1py/Services/HierarchyService.py
@@ -22,7 +22,7 @@ from TM1py.Services.RestService import RestService
 from TM1py.Services.SubsetService import SubsetService
 from TM1py.Utils.Utils import case_and_space_insensitive_equals, format_url, CaseAndSpaceInsensitiveDict, \
     CaseAndSpaceInsensitiveSet, CaseAndSpaceInsensitiveTuplesDict, require_pandas, require_data_admin, \
-    require_ops_admin, verify_version
+    lower_and_drop_spaces, require_ops_admin, verify_version
 
 
 class HierarchyService(ObjectService):
@@ -356,9 +356,10 @@ class HierarchyService(ObjectService):
         elements_under_consolidations = element_service.get_members_under_consolidation(dimension_name, hierarchy_name,
                                                                                         consolidation_element)
         elements_under_consolidations.append(consolidation_element)
+        elements_under_consolidations = [lower_and_drop_spaces(member) for member in elements_under_consolidations]
         remove_edges = []
         for (parent, component) in hierarchy.edges:
-            if parent in elements_under_consolidations and component in elements_under_consolidations:
+            if lower_and_drop_spaces(parent) in elements_under_consolidations and lower_and_drop_spaces(component) in elements_under_consolidations:
                 remove_edges.append((parent, component))
         hierarchy.remove_edges(remove_edges)
         return self.update(hierarchy, **kwargs)

--- a/TM1py/Services/HierarchyService.py
+++ b/TM1py/Services/HierarchyService.py
@@ -353,13 +353,12 @@ class HierarchyService(ObjectService):
         hierarchy = self.get(dimension_name, hierarchy_name)
         from TM1py.Services import ElementService
         element_service = ElementService(self._rest)
-        elements_under_consolidations = element_service.get_members_under_consolidation(dimension_name, hierarchy_name,
-                                                                                        consolidation_element)
-        elements_under_consolidations.append(consolidation_element)
-        elements_under_consolidations = [lower_and_drop_spaces(member) for member in elements_under_consolidations]
+        elements_under_consolidations = CaseAndSpaceInsensitiveSet(element_service.get_members_under_consolidation(dimension_name, hierarchy_name,
+                                                                                        consolidation_element))
+        elements_under_consolidations.add(consolidation_element)
         remove_edges = []
         for (parent, component) in hierarchy.edges:
-            if lower_and_drop_spaces(parent) in elements_under_consolidations and lower_and_drop_spaces(component) in elements_under_consolidations:
+            if parent in elements_under_consolidations and component in elements_under_consolidations:
                 remove_edges.append((parent, component))
         hierarchy.remove_edges(remove_edges)
         return self.update(hierarchy, **kwargs)


### PR DESCRIPTION
`remove_edges_under_consolidation()` is not case and space insensitive at the moment, this fix would allow the function to be case and space insensitive. 

e.g. Element name "**Parent1**", "**parent 1**", "**Parent   1**", "**PARENT1**" would be treated in the same way.

Added/modified coding in **HierarchyService.py** to allow the function to work in case and space insensitive nature.

```
from TM1py.Utils.Utils import case_and_space_insensitive_equals, format_url, CaseAndSpaceInsensitiveDict, \
    CaseAndSpaceInsensitiveSet, CaseAndSpaceInsensitiveTuplesDict, require_pandas, require_data_admin, \
    lower_and_drop_spaces, require_ops_admin, verify_version
```
...
```

    def remove_edges_under_consolidation(self, dimension_name: str, hierarchy_name: str,
                                         consolidation_element: str, **kwargs) -> List[Response]:
        """
        :param dimension_name: Name of the dimension
        :param hierarchy_name: Name of the hierarchy
        :param consolidation_element: Name of the Consolidated element
        :return: response
        """
        hierarchy = self.get(dimension_name, hierarchy_name)
        from TM1py.Services import ElementService
        element_service = ElementService(self._rest)
        elements_under_consolidations = element_service.get_members_under_consolidation(dimension_name, hierarchy_name,
                                                                                        consolidation_element)                                                            
        elements_under_consolidations.append(consolidation_element)
        elements_under_consolidations = [lower_and_drop_spaces(member) for member in elements_under_consolidations]
        remove_edges = []
        for (parent, component) in hierarchy.edges:
            if lower_and_drop_spaces(parent) in elements_under_consolidations and lower_and_drop_spaces(component) in elements_under_consolidations:
                remove_edges.append((parent, component))
        hierarchy.remove_edges(remove_edges)
        return self.update(hierarchy, **kwargs)

```