### PR TITLE
Feature: Allow a list of consolidations to be unwound for update_or_create_hierarchy_from_dataframe()

### DIFF
--- a/TM1py/Services/ElementService.py
+++ b/TM1py/Services/ElementService.py
@@ -1,367 +1,1125 @@
 # -*- coding: utf-8 -*-
+import json
+from enum import Enum
+from io import StringIO
+from typing import List, Union, Iterable, Optional, Dict, Tuple
+
+
+from TM1py import Subset, Process
 
 try:
     import pandas as pd
+    import numpy as np
 
     _has_pandas = True
 except ImportError:
     _has_pandas = False
 
-import json
-import math
-from typing import Dict, Tuple, List, Optional
-
-import networkx as nx
+from mdxpy import MdxHierarchySet, Member, MdxLevelExpression
 from requests import Response
 
-from TM1py.Exceptions import TM1pyRestException
-from TM1py.Objects import Hierarchy, Element, ElementAttribute, Dimension
-from TM1py.Services.ElementService import ElementService
+from TM1py.Exceptions import TM1pyRestException, TM1pyException
+from TM1py.Objects import ElementAttribute, Element
 from TM1py.Services.ObjectService import ObjectService
 from TM1py.Services.RestService import RestService
-from TM1py.Services.SubsetService import SubsetService
-from TM1py.Utils.Utils import case_and_space_insensitive_equals, format_url, CaseAndSpaceInsensitiveDict, \
-    CaseAndSpaceInsensitiveSet, CaseAndSpaceInsensitiveTuplesDict, require_pandas, require_data_admin, \
-    require_ops_admin, verify_version
+from TM1py.Utils import CaseAndSpaceInsensitiveDict, format_url, CaseAndSpaceInsensitiveSet, require_data_admin, \
+    dimension_hierarchy_element_tuple_from_unique_name, require_pandas, require_version
+from TM1py.Utils import build_element_unique_names, CaseAndSpaceInsensitiveTuplesDict, verify_version
+from itertools import islice
+from collections import OrderedDict
+
+class MDXDrillMethod(Enum):
+    TM1DRILLDOWNMEMBER = 1
+    DESCENDANTS = 2
 
 
-class HierarchyService(ObjectService):
-    """ Service to handle Object Updates for TM1 Hierarchies
+class ElementService(ObjectService):
+    """ Service to handle Object Updates for TM1 Dimension (resp. Hierarchy) Elements
 
     """
 
-    # Tuple with TM1 Versions where Edges need to be created through TI, due to bug:
-    # https://www.ibm.com/developerworks/community/forums/html/topic?id=75f2b99e-6961-4c71-9364-1d5e1e083eff
-    EDGES_WORKAROUND_VERSIONS = ('11.0.002', '11.0.003', '11.1.000')
-
     def __init__(self, rest: RestService):
         super().__init__(rest)
-        self.subsets = SubsetService(rest)
-        self.elements = ElementService(rest)
 
-    @staticmethod
-    def _validate_edges(df: 'pd.DataFrame'):
-        graph = nx.DiGraph()
-        for _, *record in df.itertuples():
-            child = record[0]
-            for parent in record[1:]:
-                if not parent:
-                    continue
-                if isinstance(parent, float) and math.isnan(parent):
-                    continue
-                graph.add_edge(child, parent)
-                child = parent
-
-        cycles = list(nx.simple_cycles(graph))
-        if cycles:
-            raise ValueError(f"Circular reference{'s' if len(cycles) > 1 else ''} found in edges: {cycles}")
-
-    @staticmethod
-    def _validate_alias_uniqueness(df: 'pd.DataFrame'):
-        # map alias values against their principal element name
-        seen_values = CaseAndSpaceInsensitiveDict()
-
-        for row in df.itertuples(index=False):
-            normalized_row = tuple(col.strip().lower() for col in row)
-            element_name, *alias_values = normalized_row
-            # Register e.g. 'Deutschand' -> 'Deutschand'
-            seen_values[element_name] = element_name
-
-            for value in alias_values:
-                if not value:
-                    continue
-
-                if value in seen_values:
-                    # Duplicate entries
-                    if case_and_space_insensitive_equals(element_name, seen_values[value]):
-                        continue
-
-                    raise ValueError(f"Invalid alias value found in record {tuple(row)}")
-                # Register e.g. 'Deutschand' -> 'Germany'
-                seen_values[value] = element_name
-
-    def create(self, hierarchy: Hierarchy, **kwargs):
-        """ Create a hierarchy in an existing dimension
-
-        :param hierarchy:
-        :return:
-        """
-        url = format_url("/Dimensions('{}')/Hierarchies", hierarchy.dimension_name)
-        response = self._rest.POST(url, hierarchy.body, **kwargs)
-
-        self.update_element_attributes(hierarchy, **kwargs)
-
-        return response
-
-    def get(self, dimension_name: str, hierarchy_name: str, **kwargs) -> Hierarchy:
-        """ get hierarchy
-
-        :param dimension_name: name of the dimension
-        :param hierarchy_name: name of the hierarchy
-        :return:
-        """
+    def get(self, dimension_name: str, hierarchy_name: str, element_name: str, **kwargs) -> Element:
         url = format_url(
-            "/Dimensions('{}')/Hierarchies('{}')?$expand=Edges,Elements,ElementAttributes,Subsets,DefaultMember",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements('{}')?$expand=*",
+            dimension_name, hierarchy_name, element_name)
+        response = self._rest.GET(url, **kwargs)
+        return Element.from_dict(response.json())
+
+    def create(self, dimension_name: str, hierarchy_name: str, element: Element, **kwargs) -> Response:
+        url = format_url(
+            "/Dimensions('{}')/Hierarchies('{}')/Elements",
             dimension_name,
             hierarchy_name)
-        response = self._rest.GET(url, **kwargs)
-        return Hierarchy.from_dict(response.json())
+        return self._rest.POST(url, element.body, **kwargs)
 
-    def get_all_names(self, dimension_name: str, **kwargs) -> List[str]:
-        """ get all names of existing Hierarchies in a dimension
+    def update(self, dimension_name: str, hierarchy_name: str, element: Element, **kwargs) -> Response:
+        url = format_url(
+            "/Dimensions('{}')/Hierarchies('{}')/Elements('{}')",
+            dimension_name,
+            hierarchy_name,
+            element.name)
+        return self._rest.PATCH(url, element.body, **kwargs)
 
-        :param dimension_name:
-        :return:
-        """
-        url = format_url("/Dimensions('{}')/Hierarchies?$select=Name", dimension_name)
-        response = self._rest.GET(url, **kwargs)
-        return [hierarchy["Name"] for hierarchy in response.json()["value"]]
+    def exists(self, dimension_name: str, hierarchy_name: str, element_name: str, **kwargs) -> bool:
+        url = format_url(
+            "/Dimensions('{}')/Hierarchies('{}')/Elements('{}')",
+            dimension_name,
+            hierarchy_name,
+            element_name)
+        return self._exists(url, **kwargs)
 
-    def update(self, hierarchy: Hierarchy, keep_existing_attributes=False, **kwargs) -> List[Response]:
-        """ update a hierarchy. It's a two step process:
-        1. Update Hierarchy
-        2. Update Element-Attributes
+    def update_or_create(self, dimension_name: str, hierarchy_name: str, element: Element, **kwargs) -> Response:
+        if self.exists(dimension_name=dimension_name, hierarchy_name=hierarchy_name, element_name=element.name, **kwargs):
+            return self.update(dimension_name=dimension_name, hierarchy_name=hierarchy_name, element=element, **kwargs)
 
-        Function caters for Bug with Edge Creation:
-        https://www.ibm.com/developerworks/community/forums/html/topic?id=75f2b99e-6961-4c71-9364-1d5e1e083eff
-
-        :param hierarchy: instance of TM1py.Hierarchy
-        :param keep_existing_attributes: True to make sure existing attributes are not removed
-        :return: list of responses
-        """
-        # functions returns multiple responses
-        responses = list()
-        # 1. Update Hierarchy
-        url = format_url("/Dimensions('{}')/Hierarchies('{}')", hierarchy.dimension_name, hierarchy.name)
-        # Workaround EDGES: Handle Issue, that Edges cant be created in one batch with the Hierarchy in certain versions
-        hierarchy_body = hierarchy.body_as_dict
-        if self.version[0:8] in self.EDGES_WORKAROUND_VERSIONS:
-            del hierarchy_body["Edges"]
-        responses.append(self._rest.PATCH(url, json.dumps(hierarchy_body), **kwargs))
-
-        # 2. Update Attributes
-        responses.append(self.update_element_attributes(
-            hierarchy=hierarchy,
-            keep_existing_attributes=keep_existing_attributes,
-            **kwargs))
-
-        # Workaround EDGES
-        if self.version[0:8] in self.EDGES_WORKAROUND_VERSIONS:
-            from TM1py.Services import ProcessService
-            process_service = ProcessService(self._rest)
-            ti_function = "HierarchyElementComponentAdd('{}', '{}', '{}', '{}', {});"
-            ti_statements = [ti_function.format(hierarchy.dimension_name, hierarchy.name,
-                                                edge[0],
-                                                edge[1],
-                                                hierarchy.edges[(edge[0], edge[1])])
-                             for edge
-                             in hierarchy.edges]
-            responses.append(process_service.execute_ti_code(lines_prolog=ti_statements, **kwargs))
-
-        return responses
-
-    def update_or_create(self, hierarchy: Hierarchy, **kwargs):
-        """ update if exists else create
-
-        :param hierarchy:
-        :return:
-        """
-        if self.exists(dimension_name=hierarchy.dimension_name, hierarchy_name=hierarchy.name, **kwargs):
-            self.update(hierarchy=hierarchy, **kwargs)
-        else:
-            self.create(hierarchy=hierarchy, **kwargs)
-
-    def exists(self, dimension_name: str, hierarchy_name: str, **kwargs) -> bool:
-        """
-
-        :param dimension_name:
-        :param hierarchy_name:
-        :return:
-        """
-        url = format_url("/Dimensions('{}')/Hierarchies?$select=Name", dimension_name)
-
-        try:
-            response = self._rest.GET(url, **kwargs)
-        except TM1pyRestException as e:
-            if e.status_code == 404:
-                return False
-            raise e
-
-        existing_hierarchies = CaseAndSpaceInsensitiveSet([
-            hierarchy["Name"]
-            for hierarchy
-            in response.json()["value"]])
-        return hierarchy_name in existing_hierarchies
-
-    def delete(self, dimension_name: str, hierarchy_name: str, **kwargs) -> Response:
-        url = format_url("/Dimensions('{}')/Hierarchies('{}')", dimension_name, hierarchy_name)
+        return self.create(dimension_name=dimension_name, hierarchy_name=hierarchy_name, element=element, **kwargs)   
+        
+    def delete(self, dimension_name: str, hierarchy_name: str, element_name: str, **kwargs) -> Response:
+        url = format_url(
+            "/Dimensions('{}')/Hierarchies('{}')/Elements('{}')",
+            dimension_name,
+            hierarchy_name,
+            element_name)
         return self._rest.DELETE(url, **kwargs)
 
-    def get_hierarchy_summary(self, dimension_name: str, hierarchy_name: str, **kwargs) -> Dict[str, int]:
-        hierarchy_properties = ("Elements", "Edges", "ElementAttributes", "Members", "Levels")
+    @require_version("11.4")
+    def delete_elements(self, dimension_name: str, hierarchy_name: str, element_names: List[str] = None,
+                        use_ti: bool = False, **kwargs):
+        if use_ti:
+            return self.delete_elements_use_ti(dimension_name, hierarchy_name, element_names, **kwargs)
+
+        h_service = self._get_hierarchy_service()
+        h = h_service.get(dimension_name, hierarchy_name, **kwargs)
+        for ele in element_names:
+            h.remove_element(ele)
+        h_service.update(h, **kwargs)
+
+    def delete_elements_use_ti(self, dimension_name: str, hierarchy_name: str, element_names: List[str] = None,
+                               **kwargs):
+        subset_service = self._get_subset_service()
+        unbound_process_name = subset_name = self.suggest_unique_object_name()
+        subset = Subset(subset_name, dimension_name, hierarchy_name, elements=element_names)
+        subset_service.update_or_create(subset, private=False, **kwargs)
+        try:
+            process_service = self._get_process_service()
+            process = Process(
+                name=unbound_process_name,
+                prolog_procedure=f"HierarchyDeleteElements('{dimension_name}', '{hierarchy_name}', '{subset_name}');")
+            success, status, error_log_file = process_service.execute_process_with_return(process, **kwargs)
+            if not success:
+                raise TM1pyException(f"Failed to delete elements through unbound process. Error: '{error_log_file}'")
+
+        finally:
+            subset_service.delete(subset_name, dimension_name, hierarchy_name, private=False, **kwargs)
+
+    @require_version("11.4")
+    def delete_edges(self, dimension_name: str, hierarchy_name: str, edges: Iterable[Tuple[str, str]] = None,
+                     use_ti: bool = False, **kwargs):
+        if use_ti:
+            return self.delete_edges_use_ti(dimension_name, hierarchy_name, edges, **kwargs)
+
+        h_service = self._get_hierarchy_service()
+        h = h_service.get(dimension_name, hierarchy_name, **kwargs)
+        for edge in edges:
+            h.remove_edge(parent=edge[0], component=edge[1])
+        h_service.update(h, **kwargs)
+
+    def delete_edges_use_ti(self, dimension_name: str, hierarchy_name: str, edges: List[str] = None, **kwargs):
+        if not edges:
+            return
+
+        def escape_single_quote(text):
+            return text.replace("'", "''")
+
+        statements = [
+            f"HierarchyElementComponentDelete('{dimension_name}', '{hierarchy_name}', "
+            f"'{escape_single_quote(parent)}', '{escape_single_quote(child)}');"
+            for (parent, child)
+            in edges
+        ]
+
+        unbound_process_name = self.suggest_unique_object_name()
+
+        process_service = self._get_process_service()
+        process = Process(
+            name=unbound_process_name,
+            prolog_procedure="\r\n".join(statements))
+        success, status, error_log_file = process_service.execute_process_with_return(process, **kwargs)
+        if not success:
+            raise TM1pyException(f"Failed to delete edges through unbound process. Error: '{error_log_file}'")
+
+    def get_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[Element]:
         url = format_url(
-            "/Dimensions('{}')/Hierarchies('{}')?$expand=Edges/$count,Elements/$count,"
-            "ElementAttributes/$count,Members/$count,Levels/$count&$select=Cardinality",
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?select=Name,Type",
             dimension_name,
             hierarchy_name)
-        hierary_summary_raw = self._rest.GET(url, **kwargs).json()
+        response = self._rest.GET(url, **kwargs)
+        return [Element.from_dict(element) for element in response.json()["value"]]
 
-        return {hierarchy_property: hierary_summary_raw[hierarchy_property + "@odata.count"]
-                for hierarchy_property
-                in hierarchy_properties}
-
-    def update_element_attributes(self, hierarchy: Hierarchy, keep_existing_attributes=False, **kwargs):
-        """ Update the elementattributes of a hierarchy
-
-        :param hierarchy: Instance of TM1py.Hierarchy
-        :param keep_existing_attributes: True to make sure existing attributes are not removed
-        :return:
+    @require_pandas
+    def get_elements_dataframe(self, dimension_name: str = None, hierarchy_name: str = None,
+                               elements: Union[str, Iterable[str]] = None,
+                               skip_consolidations: bool = True, attributes: Iterable[str] = None,
+                               attribute_column_prefix: str = "", skip_parents: bool = False,
+                               level_names: List[str] = None, parent_attribute: str = None,
+                               skip_weights: bool = False, use_blob: bool = False, allow_empty_alias: bool = True,
+                               attribute_suffix: bool = False, element_type_column: str = 'Type',
+                               **kwargs) -> 'pd.DataFrame':
         """
-        # get existing attributes first
-        existing_element_attributes = self.elements.get_element_attributes(
-            dimension_name=hierarchy.dimension_name,
-            hierarchy_name=hierarchy.name,
-            **kwargs)
-        existing_element_attributes = CaseAndSpaceInsensitiveDict({ea.name: ea for ea in existing_element_attributes})
 
-        attributes_to_create = list()
-        attributes_to_delete = list()
-        attributes_to_update = list()
+        :param dimension_name: Name of the dimension. Can be derived from elements MDX
+        :param hierarchy_name: Name of the hierarchy in the dimension.Can be derived from elements MDX
+        :param elements: Selection of members. Iterable or valid MDX string
+        :param skip_consolidations: Boolean flag to skip consolidations
+        :param attributes: Selection of attributes. Iterable. If None retrieve all.
+        :param attribute_column_prefix: string to prefix attribute colums to avoid name conflicts
+        :param level_names: List of labels for parent columns. If None use level names from TM1.
+        :param skip_parents: Boolean Flag to skip parent columns.
+        :param parent_attribute: Attribute to be displayed in parent columns. If None, parent name is used.
+        :param skip_weights: include weight columns
+        :param use_blob: Up to 40% better performance and lower memory footprint in any case. Requires admin permissions
+        :param allow_empty_alias: False if empty alias values should be substituted with element names instead
+        :param attribute_suffix: True if attribute columns should have ':a', ':s' or ':n' suffix
+        :param element_type_column: The column name in the df which specifies which element is which type.
+        :return: pandas DataFrame
+        """
 
-        for element_attribute in hierarchy.element_attributes:
-            if element_attribute.name not in existing_element_attributes:
-                attributes_to_create.append(element_attribute)
-                continue
+        if isinstance(elements, str) and not all([dimension_name, hierarchy_name]):
+            record = self.execute_set_mdx(
+                mdx=elements,
+                top_records=1,
+                member_properties=["UniqueName"],
+                parent_properties=None,
+                element_properties=None)
 
-            existing_element_attribute = existing_element_attributes[element_attribute.name]
-            if not existing_element_attribute.attribute_type == element_attribute.attribute_type:
-                attributes_to_update.append(element_attribute)
-                continue
+            if not record:
+                raise ValueError(f"member_selection invalid: '{elements}'")
 
-        if not keep_existing_attributes:
-            for existing_element_attribute in existing_element_attributes:
-                if existing_element_attribute not in CaseAndSpaceInsensitiveSet(
-                        [ea.name for ea in hierarchy.element_attributes]):
-                    attributes_to_delete.append(existing_element_attribute)
+            unique_name = record[0][0]['UniqueName']
+            dimension_name, hierarchy_name, _ = dimension_hierarchy_element_tuple_from_unique_name(unique_name)
 
-        for element_attribute in attributes_to_create:
-            self.elements.create_element_attribute(
-                dimension_name=hierarchy.dimension_name,
-                hierarchy_name=hierarchy.name,
-                element_attribute=element_attribute,
+        if elements is None or not any(elements):
+            elements = f"{{ [{dimension_name}].[{hierarchy_name}].Members }}"
+            if skip_consolidations:
+                elements = f"{{ Tm1FilterByLevel({elements}, 0) }}"
+
+        if not isinstance(elements, str):
+            if isinstance(elements, Iterable):
+                elements = "{" + ",".join(
+                    f"[{dimension_name}].[{hierarchy_name}].[{member}]" for member in elements) + "}"
+            else:
+                raise ValueError("Argument 'element_selection' must be None or str")
+
+        if not self.attribute_cube_exists(dimension_name):
+            raise RuntimeError(self.ELEMENT_ATTRIBUTES_PREFIX + dimension_name + " cube must exist")
+
+        members = [tupl[0] for tupl in self.execute_set_mdx(
+            mdx=elements,
+            element_properties=None,
+            member_properties=("Name", "UniqueName"),
+            parent_properties=None)]
+
+        element_types = self.get_element_types(
+            dimension_name=dimension_name,
+            hierarchy_name=hierarchy_name,
+            skip_consolidations=skip_consolidations)
+
+        df = pd.DataFrame(
+            data=[(member["Name"], element_types[member["Name"]])
+                  for member
+                  in members
+                  if member["Name"] in element_types],
+            dtype=str,
+            columns=[dimension_name, element_type_column])
+
+        calculated_members_definition = list()
+        calculated_members_selection = list()
+        levels_dict = {}
+        if not skip_parents:
+            levels = self.get_levels_count(dimension_name, hierarchy_name)
+
+            # Generic Level names can't be used directly as a Calculated Member name as they conflict with an internal name
+            # Therefore, we create a map that relates the level name to the calculated member name L000 = level000
+            if not level_names:
+                level_names = self.get_level_names(dimension_name, hierarchy_name, descending=True)
+                level_calculated_member_names = []
+
+                # Create a map of MDX Calculated Member Names and Desired Pandas Names
+                for level in reversed(range(levels)):
+                    level_calculated_member_names.append(f"L{str(level).zfill(3)}")
+                all_level_dict = OrderedDict(zip(level_calculated_member_names, level_names))
+
+            # if a specific parent names are provided the calculated member name is = to the data frame column name
+            else:
+                all_level_dict = OrderedDict(zip(level_names, level_names))
+
+            # Remove the highest level (leafs) to create proper MDX calculated members
+            levels_dict = {k: all_level_dict[k] for k in list(all_level_dict)[1:]}
+
+            # iterate the map of levels to create an MDX calculation and a related column axis definition
+            parent_members = list()
+            weight_members = list()
+            depth = 0
+            for calculated_name, level_name in levels_dict.items():
+                depth += 1
+                name_or_attribute = f"Properties('{parent_attribute}')" if parent_attribute else "NAME"
+                if not verify_version(required_version='12', version=self.version):
+                    member = f"""
+                    MEMBER [{self.ELEMENT_ATTRIBUTES_PREFIX + dimension_name}].[{calculated_name}] 
+                    AS [{dimension_name}].[{hierarchy_name}].CurrentMember.{'Parent.' * depth}{name_or_attribute}
+                    """
+                else:
+                    member = f"""
+                    MEMBER [{self.ELEMENT_ATTRIBUTES_PREFIX + dimension_name}].[{calculated_name}] 
+                    AS [{dimension_name}].[{hierarchy_name}].CurrentMember.{'Parent.' * depth}PROPERTIES('{name_or_attribute}')
+                    """
+                calculated_members_definition.append(member)
+
+                parent_members.append(f"[{self.ELEMENT_ATTRIBUTES_PREFIX + dimension_name}].[{calculated_name}]")
+
+                if not skip_weights:
+                    if not verify_version(required_version='12', version=self.version):
+                        member_weight = f"""
+                        MEMBER [{self.ELEMENT_ATTRIBUTES_PREFIX + dimension_name}].[{level_name}_Weight] 
+                        AS IIF(
+                        [{dimension_name}].[{hierarchy_name}].CurrentMember.{'Parent.' * (depth - 1)}Properties('MEMBER_WEIGHT') = '',
+                        0,
+                        [{dimension_name}].[{hierarchy_name}].CurrentMember.{'Parent.' * (depth - 1)}Properties('MEMBER_WEIGHT'))
+                        """
+                    else:
+                        member_weight = f"""
+                        MEMBER [{self.ELEMENT_ATTRIBUTES_PREFIX + dimension_name}].[{level_name}_Weight]
+                        AS IIF(
+                        [{dimension_name}].[{hierarchy_name}].CurrentMember.{'Parent.' * ( depth - 1)}Properties('MEMBER_WEIGHT') = '',
+                        0,
+                        [{dimension_name}].[{hierarchy_name}].CurrentMember.{'Parent.' * ( depth - 1)}Properties('MEMBER_WEIGHT'))
+                        """
+                    calculated_members_definition.append(member_weight)
+
+                    weight_members.append(
+                        f"[{self.ELEMENT_ATTRIBUTES_PREFIX + dimension_name}].[{level_name}_Weight]")
+
+            calculated_members_selection.extend(weight_members)
+            calculated_members_selection.extend(parent_members)
+
+        if attributes is None:
+            column_selection = "{Tm1SubsetAll([" + self.ELEMENT_ATTRIBUTES_PREFIX + dimension_name + "])}"
+        else:
+            column_selection = "{" + ",".join(
+                "[" + self.ELEMENT_ATTRIBUTES_PREFIX + dimension_name + "].[" + attribute + "]"
+                for attribute
+                in attributes) + "}"
+
+        if calculated_members_selection:
+            if column_selection == "{}":
+                column_selection = "{" + ",".join(calculated_members_selection) + "}"
+            else:
+                column_selection = column_selection + " + {" + ",".join(calculated_members_selection) + "}"
+
+        mdx_with_block = ""
+        if calculated_members_definition:
+            mdx_with_block = "WITH " + " ".join(calculated_members_definition)
+
+        mdx = f"""
+        {mdx_with_block}
+        SELECT
+        {{ {elements} }} ON ROWS,
+        {{ {column_selection} }} ON COLUMNS
+        FROM [{self.ELEMENT_ATTRIBUTES_PREFIX + dimension_name}]  
+        """
+
+        cell_service = self._get_cell_service()
+
+        # responses are similar but not equivalent.
+        # Therefor only use execute_mdx_dataframe when use_blob is True
+        if use_blob:
+            raw_csv = cell_service.execute_mdx_csv(
+                mdx=mdx,
+                skip_zeros=False,
+                skip_consolidated_cells=False,
+                skip_rule_derived_cells=False,
+                line_separator="\r\n",
+                value_separator="~",
+                use_blob=True,
                 **kwargs)
 
-        for element_attribute in attributes_to_delete:
-            self.elements.delete_element_attribute(
-                dimension_name=hierarchy.dimension_name,
-                hierarchy_name=hierarchy.name,
-                element_attribute=element_attribute,
-                **kwargs)
+            df_data = pd.read_csv(StringIO(raw_csv), sep='~', na_filter=False, dtype={0: str})
 
-        for element_attribute in attributes_to_update:
-            self.elements.delete_element_attribute(
-                dimension_name=hierarchy.dimension_name,
-                hierarchy_name=hierarchy.name,
-                element_attribute=element_attribute.name,
-                **kwargs)
-            self.elements.create_element_attribute(
-                dimension_name=hierarchy.dimension_name,
-                hierarchy_name=hierarchy.name,
-                element_attribute=element_attribute,
-                **kwargs)
+            # Use _group to avoid aggregation of multiple members into one df record
+            # example: element A is part of multiple consolidations resulting df must have multiple records for A
+            unique_values_count = df_data['}ElementAttributes_' + dimension_name].nunique()
+            df_data['_group'] = (df_data.index // unique_values_count) + 1
 
-    def get_default_member(self, dimension_name: str, hierarchy_name: str = None, **kwargs) -> Optional[str]:
-        """ Get the defined default_member for a Hierarchy.
-        Will return the element with index 1, if default member is not specified explicitly in }HierarchyProperty Cube
+            # pivot the dataframe
+            df_data = df_data.pivot_table(
+                index=[dimension_name, '_group'],
+                columns='}ElementAttributes_' + dimension_name,
+                values='Value',
+                aggfunc='first',
+                sort=False).reset_index()
+
+            # Drop the group key
+            df_data = df_data.fillna("").drop(columns='_group')
+
+        else:
+            df_data = cell_service.execute_mdx_dataframe_shaped(mdx, **kwargs)
+
+        if levels_dict:
+            # rename level names to conform sto standard levels "1" -> "level001"
+            df_data.rename(columns=levels_dict, inplace=True)
+
+        # format weights
+        # Find columns with certain names
+        cols_to_format = [col for col in df_data.columns if '_Weight' in col]
+
+        # format the columns
+        df_data[cols_to_format] = df_data[cols_to_format].apply(pd.to_numeric)
+        df_data[cols_to_format] = df_data[cols_to_format].applymap(lambda x: '{:.6f}'.format(x))
+
+        # override colum types
+        element_attributes = self.get_element_attributes(dimension_name, hierarchy_name)
+        attribute_column_types = {
+            ea.name: 'float' if ea.attribute_type == 'Numeric' else 'str'
+            for ea
+            in element_attributes
+            if ea.name in df_data.columns}
+        df_data = df_data.astype(attribute_column_types)
+
+        # substitute empty strings with element name if empty alias is not allowed
+        if not allow_empty_alias:
+            alias_attributes = [
+                ea.name
+                for ea in element_attributes
+                if ea.attribute_type == 'Alias' and ea.name in df_data.columns]
+
+            for col in alias_attributes:
+                df_data[col] = np.where(df_data[col] == '', df_data[dimension_name], df_data[col])
+
+        # override column names. hierarchy name with dimension and prefix attributes
+        column_renaming = dict()
+        if attribute_column_prefix or attribute_suffix:
+            column_renaming = {
+                ea.name: f"{attribute_column_prefix}{ea.name}" + (
+                    f":{ea.attribute_type.lower()[0]}"
+                    if attribute_suffix
+                    else "")
+                for ea
+                in element_attributes}
+
+        column_renaming[hierarchy_name] = dimension_name
+
+        df_data.rename(columns=column_renaming, inplace=True)
+
+        # shift levels to right hand side
+        if not skip_parents:
+            # skip max level (= leaves)
+            level_columns = level_names[1:]
+
+            # iterative approach
+            for _ in level_columns:
+
+                rows_to_shift = df_data[df_data[level_columns[-1]].isin(['', None])].index
+                if rows_to_shift.empty:
+                    break
+                shifted_cols = df_data.iloc[rows_to_shift, -len(level_columns):].shift(1, axis=1)
+                df_data.iloc[rows_to_shift, -len(level_columns):] = shifted_cols
+
+                # also shift weight columns
+                if not skip_weights:
+                    shifted_cols = df_data.iloc[
+                                   rows_to_shift,
+                                   -len(level_columns) * 2:-len(level_columns)].shift(1, axis=1)
+
+                    df_data.iloc[rows_to_shift, -len(level_columns) * 2:-len(level_columns)] = shifted_cols
+
+            df_data.iloc[:, -len(level_columns):] = df_data.iloc[:, -len(level_columns):].fillna('')
+            if not skip_weights:
+                df_data.iloc[:, -len(level_columns) * 2:-len(level_names)] = df_data.iloc[
+                                                                             :,
+                                                                             -len(level_columns) * 2:
+                                                                             -len(level_names)].fillna(0)
+
+        return pd.merge(df, df_data, on=dimension_name).drop_duplicates()
+
+    def get_edges(self, dimension_name: str, hierarchy_name: str, **kwargs) -> Dict[Tuple[str, str], int]:
+        url = format_url(
+            "/Dimensions('{}')/Hierarchies('{}')/Edges?select=ParentName,ComponentName,Weight",
+            dimension_name,
+            hierarchy_name)
+        response = self._rest.GET(url, **kwargs)
+
+        return {(edge["ParentName"], edge["ComponentName"]): edge["Weight"] for edge in response.json()["value"]}
+
+    def get_leaf_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[Element]:
+        url = format_url(
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type ne 3",
+            dimension_name,
+            hierarchy_name)
+        response = self._rest.GET(url, **kwargs)
+        return [Element.from_dict(element) for element in response.json()["value"]]
+
+    def get_leaf_element_names(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[str]:
+        url = format_url("/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type ne 3",
+                         dimension_name,
+                         hierarchy_name)
+        response = self._rest.GET(url, **kwargs)
+        return [e["Name"] for e in response.json()['value']]
+
+    def get_consolidated_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[Element]:
+        url = format_url(
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type eq 3",
+            dimension_name,
+            hierarchy_name)
+        response = self._rest.GET(url, **kwargs)
+        return [Element.from_dict(element) for element in response.json()["value"]]
+
+    def get_consolidated_element_names(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[str]:
+        url = format_url("/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type eq 3",
+                         dimension_name,
+                         hierarchy_name)
+        response = self._rest.GET(url, **kwargs)
+        return [e["Name"] for e in response.json()['value']]
+
+    def get_numeric_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[Element]:
+        url = format_url(
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type eq 1",
+            dimension_name,
+            hierarchy_name)
+        response = self._rest.GET(url, **kwargs)
+        return [Element.from_dict(element) for element in response.json()["value"]]
+
+    def get_numeric_element_names(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[str]:
+        url = format_url("/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type eq 1",
+                         dimension_name,
+                         hierarchy_name)
+        response = self._rest.GET(url, **kwargs)
+        return [e["Name"] for e in response.json()['value']]
+
+    def get_string_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[Element]:
+        url = format_url(
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?$expand=*&$filter=Type eq 2",
+            dimension_name,
+            hierarchy_name)
+        response = self._rest.GET(url, **kwargs)
+        return [Element.from_dict(element) for element in response.json()["value"]]
+
+    def get_string_element_names(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[str]:
+        url = format_url("/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Type eq 2",
+                         dimension_name,
+                         hierarchy_name)
+        response = self._rest.GET(url, **kwargs)
+        return [e["Name"] for e in response.json()['value']]
+
+    def get_element_names(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[str]:
+        """ Get all element names
 
         :param dimension_name:
         :param hierarchy_name:
-        :return: String, name of Member
+        :return: Generator of element-names
         """
         url = format_url(
-            "/Dimensions('{dimension}')/Hierarchies('{hierarchy}')/DefaultMember",
-            dimension=dimension_name,
-            hierarchy=hierarchy_name if hierarchy_name else dimension_name)
-        response = self._rest.GET(url=url, **kwargs)
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name",
+            dimension_name,
+            hierarchy_name)
+        response = self._rest.GET(url, **kwargs)
+        return [e["Name"] for e in response.json()['value']]
 
-        if not response.text:
-            return None
-        return response.json()["Name"]
+    def get_number_of_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> int:
+        url = format_url(
+            "/Dimensions('{}')/Hierarchies('{}')/Elements/$count",
+            dimension_name,
+            hierarchy_name)
+        response = self._rest.GET(url, **kwargs)
+        return int(response.text)
 
-    def _update_default_member_via_props_cube(self, dimension_name: str, hierarchy_name: str = None,
-                                              member_name: str = "",
-                                              **kwargs) -> Response:
-        from TM1py import ProcessService, CellService
-        if hierarchy_name and not case_and_space_insensitive_equals(dimension_name, hierarchy_name):
-            dimension = "{}:{}".format(dimension_name, hierarchy_name)
-        else:
-            dimension = dimension_name
-        cells = {(dimension, 'hierarchy0', 'defaultMember'): member_name}
+    def get_number_of_consolidated_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> int:
+        url = format_url(
+            "/Dimensions('{}')/Hierarchies('{}')/Elements/$count?$filter=Type eq 3",
+            dimension_name,
+            hierarchy_name)
+        response = self._rest.GET(url, **kwargs)
+        return int(response.text)
 
-        CellService(self._rest).write_values(
-            cube_name="}HierarchyProperties",
-            cellset_as_dict=cells,
-            dimensions=('}Dimensions', '}Hierarchies', '}HierarchyProperties'),
-            **kwargs)
+    def get_number_of_leaf_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> int:
+        url = format_url(
+            "/Dimensions('{}')/Hierarchies('{}')/Elements/$count?$filter=Type ne 3",
+            dimension_name,
+            hierarchy_name)
+        response = self._rest.GET(url, **kwargs)
+        return int(response.text)
 
-        return ProcessService(self._rest).execute_ti_code(
-            lines_prolog=format_url("RefreshMdxHierarchy('{}');", dimension_name),
-            **kwargs)
+    def get_number_of_numeric_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> int:
+        url = format_url(
+            "/Dimensions('{}')/Hierarchies('{}')/Elements/$count?$filter=Type eq 1",
+            dimension_name,
+            hierarchy_name)
+        response = self._rest.GET(url, **kwargs)
+        return int(response.text)
 
-    def _update_default_member_via_api(self, dimension_name: str, hierarchy_name: str = None, member_name: str = "",
-                                       **kwargs) -> Response:
+    def get_number_of_string_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> int:
+        url = format_url(
+            "/Dimensions('{}')/Hierarchies('{}')/Elements/$count?$filter=Type eq 2",
+            dimension_name,
+            hierarchy_name)
+        response = self._rest.GET(url, **kwargs)
+        return int(response.text)
 
-        url = format_url("/Dimensions('{dimension}')/Hierarchies('{hierarchy}')",
-                         dimension=dimension_name,
-                         hierarchy=hierarchy_name if hierarchy_name else dimension_name)
-
-        payload = {"DefaultMemberName": member_name}
-
-        return self._rest.PATCH(url=url, data=json.dumps(payload))
-
-    def update_default_member(self, dimension_name: str, hierarchy_name: str = None, member_name: str = "",
-                              **kwargs) -> Response:
-        """ Update the default member of a hierarchy.
+    def get_all_leaf_element_identifiers(self, dimension_name: str, hierarchy_name: str,
+                                         **kwargs) -> CaseAndSpaceInsensitiveSet:
+        """ Get all element names and alias values for leaf elements in a hierarchy
 
         :param dimension_name:
         :param hierarchy_name:
-        :param member_name:
         :return:
         """
-        if verify_version(required_version='12', version=self.version):
-            return self._update_default_member_via_api(dimension_name, hierarchy_name, member_name)
-        else:
-            return self._update_default_member_via_props_cube(dimension_name, hierarchy_name, member_name)
+        mdx_elements = f"{{ Tm1FilterByLevel ( {{ Tm1SubsetAll ([{dimension_name}].[{hierarchy_name}]) }} , 0 ) }}"
+        return self.get_element_identifiers(dimension_name, hierarchy_name, mdx_elements, **kwargs)
 
-    def remove_all_edges(self, dimension_name: str, hierarchy_name: str = None, **kwargs) -> Response:
-        if not hierarchy_name:
-            hierarchy_name = dimension_name
-        url = format_url("/Dimensions('{}')/Hierarchies('{}')", dimension_name, hierarchy_name)
-        body = {
-            "Edges": []
-        }
-        return self._rest.PATCH(url=url, data=json.dumps(body), **kwargs)
+    def get_elements_by_level(self, dimension_name: str, hierarchy_name: str, level: int, **kwargs) -> List[str]:
+        """ Get all element names by level in a hierarchy
 
-    def remove_edges_under_consolidation(self, dimension_name: str, hierarchy_name: str,
-                                         consolidation_element: str, **kwargs) -> List[Response]:
-        """
         :param dimension_name: Name of the dimension
         :param hierarchy_name: Name of the hierarchy
-        :param consolidation_element: Name of the Consolidated element
+        :param level: Level to filter
+        :return: List of element names
+        """
+        url = format_url(
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=Level eq {}",
+            dimension_name,
+            hierarchy_name,
+            str(level))
+        response = self._rest.GET(url, **kwargs)
+        return [e["Name"] for e in response.json()['value']]
+
+    def get_elements_filtered_by_wildcard(self, dimension_name: str, hierarchy_name: str,
+                                          wildcard: str, level: int = None, **kwargs) -> List[str]:
+        """ Get all element names filtered by wildcard (CaseAndSpaceInsensitive) and level in a hierarchy
+
+        :param dimension_name: Name of the dimension
+        :param hierarchy_name: Name of the hierarchy
+        :param wildcard: wildcard to filter
+        :param level: Level to filter
+        :return: List of element names
+        """
+        filter_elements = format_url("contains(tolower(replace(Name,' ','')),tolower(replace('{}',' ', '')))", wildcard)
+        if level is not None:
+            filter_elements = filter_elements + f" and Level eq {level}"
+        url = format_url(
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name&$filter=" + filter_elements,
+            dimension_name,
+            hierarchy_name)
+        response = self._rest.GET(url, **kwargs)
+        return [e["Name"] for e in response.json()['value']]
+
+    def get_all_element_identifiers(self, dimension_name: str, hierarchy_name: str,
+                                    **kwargs) -> CaseAndSpaceInsensitiveSet:
+        """ Get all element names and alias values in a hierarchy
+
+        :param dimension_name:
+        :param hierarchy_name:
+        :return:
+        """
+
+        mdx_elements = f"{{ Tm1SubsetAll ([{dimension_name}].[{hierarchy_name}]) }}"
+        return self.get_element_identifiers(dimension_name, hierarchy_name, mdx_elements, **kwargs)
+
+    def get_element_identifiers(self, dimension_name: str, hierarchy_name: str,
+                                elements: Union[str, List[str]], **kwargs) -> CaseAndSpaceInsensitiveSet:
+        """ Get all element names and alias values for a set of elements in a hierarchy
+
+        :param dimension_name:
+        :param hierarchy_name:
+        :param elements: MDX (Set) expression or iterable of elements
+        :return:
+        """
+
+        alias_attributes = self.get_alias_element_attributes(dimension_name, hierarchy_name, **kwargs)
+
+        if isinstance(elements, str):
+            mdx_element_selection = elements
+        else:
+            mdx_element_selection = ",".join(build_element_unique_names(
+                [dimension_name] * len(elements),
+                elements,
+                [hierarchy_name] * len(elements)))
+
+        if not alias_attributes:
+            result = self.execute_set_mdx(
+                mdx=mdx_element_selection,
+                member_properties=["Name"],
+                parent_properties=None,
+                element_properties=None)
+            return CaseAndSpaceInsensitiveSet([record[0]["Name"] for record in result])
+
+        mdx = """
+             SELECT
+             {{ {elem_mdx} }} ON ROWS, 
+             {{ {attr_mdx} }} ON COLUMNS
+             FROM [}}ElementAttributes_{dim}]
+             """.format(
+            elem_mdx=mdx_element_selection,
+            attr_mdx=",".join(build_element_unique_names(
+                ["}ElementAttributes_" + dimension_name] * len(alias_attributes), alias_attributes)),
+            dim=dimension_name)
+        return self._retrieve_mdx_rows_and_cell_values_as_string_set(mdx, **kwargs)
+
+    def get_attribute_of_elements(self, dimension_name: str, hierarchy_name: str, attribute: str,
+                                  elements: Union[str, List[str]] = None, exclude_empty_cells: bool = True,
+                                  element_unique_names: bool = False) -> dict:
+        """
+         Get element name and attribute value for a set of elements in a hierarchy
+
+        :param dimension_name:
+        :param hierarchy_name:
+        :param attribute: Name of the Attribute
+        :param elements:  MDX (Set) expression or iterable of elements
+        :param exclude_empty_cells: Boolean
+        :param element_unique_names: Boolean
+        :return: Dict {'01':'Jan', '02':'Feb'}
+        """
+        if elements is None or not any(elements):
+            elements = self.get_element_names(dimension_name=dimension_name, hierarchy_name=hierarchy_name)
+
+        if isinstance(elements, str):
+            mdx_element_selection = elements
+        else:
+            mdx_element_selection = ",".join(build_element_unique_names(
+                [dimension_name] * len(elements),
+                elements,
+                [hierarchy_name] * len(elements)))
+        mdx = """
+             SELECT
+             {{ {elem_mdx} }} ON ROWS, 
+             {{ {attr_mdx} }} ON COLUMNS
+             FROM [}}ElementAttributes_{dim}]
+             """.format(
+            elem_mdx=mdx_element_selection,
+            attr_mdx="[}ElementAttributes_" + dimension_name + "].[" + attribute + "]",
+            dim=dimension_name)
+        rows_and_values = self._retrieve_mdx_rows_and_values(mdx, element_unique_names=element_unique_names)
+        return self._extract_dict_from_rows_and_values(rows_and_values, exclude_empty_cells=exclude_empty_cells)
+
+    @require_version("11.8.023")
+    def element_lock(self, dimension_name: str, hierarchy_name: str, element_name: str, **kwargs) -> Response:
+        """ Lock element
+        :param dimension_name: Name of dimension.
+        :param hierarchy_name: Name of hierarchy.
+        :param element_name: Name of element to lock.
         :return: response
         """
-        hierarchy = self.get(dimension_name, hierarchy_name)
-        from TM1py.Services import ElementService
-        element_service = ElementService(self._rest)
-        elements_under_consolidations = element_service.get_members_under_consolidation(dimension_name, hierarchy_name,
-                                                                                        consolidation_element)
-        elements_under_consolidations.append(consolidation_element)
-        remove_edges = []
-        for (parent, component) in hierarchy.edges:
-            if parent in elements_under_consolidations and component in elements_under_consolidations:
-                remove_edges.append((parent, component))
-        hierarchy.remove_edges(remove_edges)
-        return self.update(hierarchy, **kwargs)
+        url = format_url(
+            "/Dimensions('{}')/Hierarchies('{}')/Elements('{}')/tm1.Lock",
+            dimension_name,
+            hierarchy_name,
+            element_name)
+        return self._rest.POST(url, '', **kwargs)
+
+    @require_version("11.8.023")
+    def element_unlock(self, dimension_name: str, hierarchy_name: str, element_name: str, **kwargs) -> Response:
+        """ Unlock element
+        :param dimension_name: Name of dimension.
+        :param hierarchy_name: Name of hierarchy.
+        :param element_name: Name of element to unlock.
+        :return: response
+        """
+        url = format_url(
+            "/Dimensions('{}')/Hierarchies('{}')/Elements('{}')/tm1.Unlock",
+            dimension_name,
+            hierarchy_name,
+            element_name)
+        return self._rest.POST(url, '', **kwargs)
+    
+    @staticmethod
+    def _extract_dict_from_rows_and_values(
+            rows_and_values: CaseAndSpaceInsensitiveTuplesDict,
+            exclude_empty_cells: bool = True) -> dict:
+        """ Helper function for get_element_by_attribute method
+
+        :param rows_and_values:
+        :param exclude_empty_cells: Boolean
+        :return: Dictionary of Element:Attribute_Value
+        """
+        result_set = dict()
+        for row_elements, cell_values in rows_and_values.items():
+            for row_element in row_elements:
+                for cell_value in cell_values:
+                    if cell_value or not exclude_empty_cells:
+                        result_set[row_element] = cell_value
+        return result_set
+
+    def get_level_names(self, dimension_name: str, hierarchy_name: str, descending: bool = True, **kwargs) -> List[str]:
+        url = format_url(
+            "/Dimensions('{}')/Hierarchies('{}')/Levels?$select=Name",
+            dimension_name,
+            hierarchy_name)
+        response = self._rest.GET(url, **kwargs)
+        if descending:
+            return [level["Name"] for level in reversed(response.json()["value"])]
+        else:
+            return [level["Name"] for level in response.json()["value"]]
+
+    def get_levels_count(self, dimension_name: str, hierarchy_name: str, **kwargs) -> int:
+        url = format_url("/Dimensions('{}')/Hierarchies('{}')/Levels/$count", dimension_name, hierarchy_name)
+        response = self._rest.GET(url, **kwargs)
+        return int(response.text)
+
+    def get_element_types(self, dimension_name: str, hierarchy_name: str,
+                          skip_consolidations: bool = False, **kwargs) -> CaseAndSpaceInsensitiveDict:
+        url = format_url(
+            "/Dimensions('{}')/Hierarchies('{}')/Elements?$select=Name,Type",
+            dimension_name,
+            hierarchy_name)
+        if skip_consolidations:
+            url += "&$filter=Type ne 3"
+        response = self._rest.GET(url, **kwargs)
+
+        result = CaseAndSpaceInsensitiveDict()
+        for element in response.json()["value"]:
+            result[element['Name']] = element["Type"]
+        return result
+
+    def get_element_types_from_all_hierarchies(
+            self, dimension_name: str, skip_consolidations: bool = False, **kwargs) -> CaseAndSpaceInsensitiveDict:
+        url = format_url(
+            "/Dimensions('{}')?$expand=Hierarchies($select=Elements;$expand=Elements($select=Name,Type",
+            dimension_name)
+        url += ";$filter=Type ne 3))" if skip_consolidations else "))"
+        response = self._rest.GET(url, **kwargs)
+
+        result = CaseAndSpaceInsensitiveDict()
+        for hierarchy in response.json()["Hierarchies"]:
+            for element in hierarchy["Elements"]:
+                result[element['Name']] = element["Type"]
+        return result
+
+    def attribute_cube_exists(self, dimension_name: str, **kwargs) -> bool:
+        url = format_url("/Cubes('{}')", self.ELEMENT_ATTRIBUTES_PREFIX + dimension_name)
+        return self._exists(url, **kwargs)
+
+    def _retrieve_mdx_rows_and_cell_values_as_string_set(self, mdx: str, exclude_empty_cells=True, **kwargs):
+        from TM1py import CellService
+        return CellService(self._rest).execute_mdx_rows_and_values_string_set(mdx, exclude_empty_cells, **kwargs)
+
+    def _retrieve_mdx_rows_and_values(self, mdx: str, **kwargs):
+        from TM1py import CellService
+        return CellService(self._rest).execute_mdx_rows_and_values(mdx, **kwargs)
+
+    def get_alias_element_attributes(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[str]:
+        """
+
+        :param dimension_name:
+        :param hierarchy_name:
+        :return:
+        """
+        attributes = self.get_element_attributes(dimension_name, hierarchy_name, **kwargs)
+        return [attr.name
+                for attr
+                in attributes if attr.attribute_type == 'Alias']
+
+    def get_element_attributes(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[ElementAttribute]:
+        """ Get element attributes from hierarchy
+
+        :param dimension_name:
+        :param hierarchy_name:
+        :return:
+        """
+        url = format_url(
+            "/Dimensions('{}')/Hierarchies('{}')/ElementAttributes",
+            dimension_name,
+            hierarchy_name)
+        response = self._rest.GET(url, **kwargs)
+        element_attributes = [ElementAttribute.from_dict(ea) for ea in response.json()['value']]
+        return element_attributes
+
+    def get_element_attribute_names(self, dimension_name: str, hierarchy_name: str, **kwargs) -> List[str]:
+        """ Get element attributes from hierarchy
+
+        :param dimension_name:
+        :param hierarchy_name:
+        :return:
+        """
+        url = format_url(
+            "/Dimensions('{}')/Hierarchies('{}')/ElementAttributes?$select=Name",
+            dimension_name,
+            hierarchy_name)
+        response = self._rest.GET(url, **kwargs)
+        return [ea["Name"] for ea in response.json()['value']]
+
+    def get_elements_filtered_by_attribute(self, dimension_name: str, hierarchy_name: str, attribute_name: str,
+                                           attribute_value: Union[str, float], **kwargs) -> List[str]:
+        """ Get all elements from a hierarchy with given attribute value
+
+        :param dimension_name:
+        :param hierarchy_name:
+        :param attribute_name:
+        :param attribute_value:
+        :return: List of element names
+        """
+        if not self.exists(f"}}ElementAttributes_{dimension_name}",
+                           f"}}ElementAttributes_{dimension_name}",
+                           attribute_name):
+            raise RuntimeError(f"Attribute '{attribute_name}' does not exist in Dimension '{dimension_name}'")
+
+        if isinstance(attribute_value, str):
+            mdx = (
+                f"{{FILTER({{TM1SUBSETALL([{dimension_name}].[{hierarchy_name}])}},"
+                f"[{dimension_name}].[{hierarchy_name}].CURRENTMEMBER.PROPERTIES(\"{attribute_name}\") = \"{attribute_value}\")}}")
+        else:
+            mdx = (
+                f"{{FILTER({{TM1SUBSETALL([{dimension_name}].[{hierarchy_name}])}},"
+                f"(IIF([{dimension_name}].[{hierarchy_name}].CURRENTMEMBER.PROPERTIES(\"{attribute_name}\")=\"\", 0.0," 
+                f"STRTOVALUE([{dimension_name}].[{hierarchy_name}].CURRENTMEMBER.PROPERTIES(\"{attribute_name}\"))) = 1))}}"
+            )
+
+        elems = self.execute_set_mdx(
+            mdx=mdx,
+            member_properties=["Name"],
+            parent_properties=None,
+            element_properties=None)
+        return [elem[0]["Name"] for elem in elems]
+
+    def create_element_attribute(self, dimension_name: str, hierarchy_name: str, element_attribute: ElementAttribute,
+                                 **kwargs) -> Response:
+        """ like AttrInsert
+
+        :param dimension_name:
+        :param hierarchy_name:
+        :param element_attribute: instance of TM1py.ElementAttribute
+        :return:
+        """
+        url = format_url(
+            "/Dimensions('{}')/Hierarchies('{}')/ElementAttributes",
+            dimension_name,
+            hierarchy_name)
+        return self._rest.POST(url, element_attribute.body, **kwargs)
+
+    def delete_element_attribute(self, dimension_name: str, hierarchy_name: str, element_attribute: str,
+                                 **kwargs) -> Response:
+        """ like AttrDelete
+
+        :param dimension_name:
+        :param hierarchy_name:
+        :param element_attribute: instance of TM1py.ElementAttribute
+        :return:
+        """
+        url = format_url(
+            "/Dimensions('}}ElementAttributes_{}')/Hierarchies('}}ElementAttributes_{}')/Elements('{}')",
+            dimension_name,
+            hierarchy_name,
+            element_attribute)
+        try:
+            return self._rest.DELETE(url, **kwargs)
+
+        # Fail silently if attribute hierarchy or attribute doesn't exist
+        except TM1pyRestException as ex:
+            if not ex.status_code == 404:
+                raise ex
+
+    def get_leaves_under_consolidation(self, dimension_name: str, hierarchy_name: str, consolidation: str,
+                                       max_depth: int = None, **kwargs) -> List[str]:
+        """ Get all leaves under a consolidated element
+
+        :param dimension_name: name of dimension
+        :param hierarchy_name: name of hierarchy
+        :param consolidation: name of consolidated Element
+        :param max_depth: 99 if not passed
+        :return:
+        """
+        return self.get_members_under_consolidation(dimension_name, hierarchy_name, consolidation, max_depth, True,
+                                                    **kwargs)
+
+    def get_edges_under_consolidation(self, dimension_name: str, hierarchy_name: str, consolidation: str,
+                                      max_depth: int = None, **kwargs) -> List[str]:
+        """ Get all members under a consolidated element
+
+        :param dimension_name: name of dimension
+        :param hierarchy_name: name of hierarchy
+        :param consolidation: name of consolidated Element
+        :param max_depth: 99 if not passed
+        :return:
+        """
+        depth = max_depth or 99
+
+        # edges to return
+        edges = CaseAndSpaceInsensitiveTuplesDict()
+
+        # build url
+        bare_url = "/Dimensions('{}')/Hierarchies('{}')/Elements('{}')?"
+        url = format_url(bare_url, dimension_name, hierarchy_name, consolidation)
+        for d in range(depth):
+            if d == 0:
+                url += "$select=Edges&$expand=Edges($expand=Component("
+            else:
+                url += "$select=Edges;$expand=Edges($expand=Component("
+
+        url = url[:-1] + ")" * (depth * 2 - 1)
+
+        response = self._rest.GET(url, **kwargs)
+        consolidation_tree = response.json()
+
+        # recursive function to parse consolidation sub_tree
+        def get_edges(sub_trees):
+            for sub_tree in sub_trees:
+                edges[sub_tree["ParentName"], sub_tree["ComponentName"]] = sub_tree["Weight"]
+
+                if "Edges" not in sub_tree["Component"]:
+                    continue
+
+                get_edges(sub_trees=sub_tree["Component"]["Edges"])
+
+        get_edges(consolidation_tree["Edges"])
+        return edges
+
+    def get_members_under_consolidation(self, dimension_name: str, hierarchy_name: str, consolidation: str,
+                                        max_depth: int = None, leaves_only: bool = False, **kwargs) -> List[str]:
+        """ Get all members under a consolidated element
+
+        :param dimension_name: name of dimension
+        :param hierarchy_name: name of hierarchy
+        :param consolidation: name of consolidated Element
+        :param max_depth: 99 if not passed
+        :param leaves_only: Only Leaf Elements or all Elements
+        :return:
+        """
+        depth = max_depth - 1 if max_depth else 99
+        # members to return
+        members = []
+        # build url
+        bare_url = "/Dimensions('{}')/Hierarchies('{}')/Elements('{}')?$select=Name,Type&$expand=Components("
+        url = format_url(bare_url, dimension_name, hierarchy_name, consolidation)
+        for _ in range(depth):
+            url += "$select=Name,Type;$expand=Components("
+        url = url[:-1] + ")" * depth
+
+        response = self._rest.GET(url, **kwargs)
+        consolidation_tree = response.json()
+
+        # recursive function to parse consolidation_tree
+        def get_members(element):
+            if element["Type"] == "Numeric":
+                members.append(element["Name"])
+            elif element["Type"] == "Consolidated":
+                if "Components" in element:
+                    for component in element["Components"]:
+                        if not leaves_only and component["Type"] == "Consolidated":
+                            members.append(component["Name"])
+                        get_members(component)
+
+        get_members(consolidation_tree)
+        return members
+
+    def execute_set_mdx_element_names(
+        self, mdx: str, top_records: Optional[int] = None, **kwargs
+    ) -> List:
+        """
+        :method to execute an MDX statement against a dimension and get a list with element names back
+        :param mdx: valid dimension mdx statement
+        :param top_records: number of records to return, default: all elements no limit
+        :return: list of element names
+        """
+        elements = self.execute_set_mdx(
+            mdx,
+            member_properties=["Name"],
+            parent_properties=None,
+            element_properties=None,
+        )
+        return [element[0]["Name"] for element in elements]
+
+    def execute_set_mdx(
+            self,
+            mdx: str,
+            top_records: Optional[int] = None,
+            member_properties: Optional[Iterable[str]] = ('Name', 'Weight'),
+            parent_properties: Optional[Iterable[str]] = ('Name', 'UniqueName'),
+            element_properties: Optional[Iterable[str]] = ('Type', 'Level'),
+            **kwargs) -> List:
+        """
+        :method to execute an MDX statement against a dimension
+        :param mdx: valid dimension mdx statement
+        :param top_records: number of records to return, default: all elements no limit
+        :param member_properties: list of member properties (e.g., Name, UniqueName, Type, Weight, Attributes/Color)
+        to return, will always return the Name property
+        :param parent_properties: list of parent properties (e.g., Name, UniqueName, Type, Weight, Attributes/Color)
+         to return, can be None or empty
+        :param element_properties: list of element properties (e.g., Name, UniqueName, Type, Level, Index,
+        Attributes/Color) to return, can be empty
+        :return: dictionary of members, unique names, weights, types, and parents
+        """
+
+        top = f"$top={top_records};" if top_records else ""
+
+        if not member_properties:
+            member_properties = ['Name']
+
+        # drop spaces in Attribute names
+        else:
+            member_properties = [
+                member_property.replace(' ', '') if member_property.startswith('Attributes/') else member_property
+                for member_property
+                in member_properties]
+
+        if element_properties:
+            element_properties = [
+                element_property.replace(' ', '') if element_property.startswith('Attributes/') else element_property
+                for element_property
+                in element_properties]
+
+        if parent_properties:
+            parent_properties = [
+                parent_property.replace(' ', '') if parent_property.startswith('Attributes/') else parent_property
+                for parent_property
+                in parent_properties]
+
+        member_properties = ",".join(member_properties)
+        select_member_properties = f'$select={member_properties}'
+
+        properties_to_expand = []
+        if parent_properties:
+            parent_properties = ",".join(parent_properties)
+            select_parent_properties = f'Parent($select={parent_properties})'
+            properties_to_expand.append(select_parent_properties)
+
+        if element_properties:
+            element_properties = ",".join(element_properties)
+            select_element_properties = f'Element($select={element_properties})'
+            properties_to_expand.append(select_element_properties)
+
+        if properties_to_expand:
+            expand_properties = f';$expand={",".join(properties_to_expand)}'
+        else:
+            expand_properties = ""
+
+        url = f'/ExecuteMDXSetExpression?$expand=Tuples({top}' \
+              f'$expand=Members({select_member_properties}' \
+              f'{expand_properties}))'
+
+        payload = {"MDX": mdx}
+        response = self._rest.POST(url, json.dumps(payload, ensure_ascii=False), **kwargs)
+        raw_dict = response.json()
+        return [tuples['Members'] for tuples in raw_dict['Tuples']]
+
+    def remove_edge(self, dimension_name: str, hierarchy_name: str, parent: str, component: str, **kwargs) -> Response:
+        """ Remove one edge from hierarchy. Fails if parent or child element doesn't exist.
+
+        :param dimension_name:
+        :param hierarchy_name:
+        :param parent:
+        :param component:
+        :return:
+        """
+
+        url = format_url(
+            "/Dimensions('{}')/Hierarchies('{}')/Elements('{}')/Edges(ParentName='{}',ComponentName='{}')",
+            dimension_name,
+            hierarchy_name,
+            parent,
+            parent,
+            component)
+
+        return self._rest.DELETE(url=url, **kwargs)
 
     def add_edges(self, dimension_name: str, hierarchy_name: str = None, edges: Dict[Tuple[str, str], int] = None,
                   **kwargs) -> Response:
@@ -372,9 +1130,17 @@ class HierarchyService(ObjectService):
         :param edges:
         :return:
         """
-        return self.elements.add_edges(dimension_name, hierarchy_name, edges, **kwargs)
+        if not hierarchy_name:
+            hierarchy_name = dimension_name
 
-    def add_elements(self, dimension_name: str, hierarchy_name: str, elements: List[Element], **kwargs):
+        url = format_url("/Dimensions('{}')/Hierarchies('{}')/Edges", dimension_name, hierarchy_name)
+        body = [{"ParentName": parent, "ComponentName": component, "Weight": float(weight)}
+                for (parent, component), weight
+                in edges.items()]
+
+        return self._rest.POST(url=url, data=json.dumps(body), **kwargs)
+
+    def add_elements(self, dimension_name: str, hierarchy_name: str, elements: Iterable[Element], **kwargs):
         """ Add elements to hierarchy. Fails if one element already exists.
 
         :param dimension_name:
@@ -382,7 +1148,10 @@ class HierarchyService(ObjectService):
         :param elements:
         :return:
         """
-        return self.elements.add_elements(dimension_name, hierarchy_name, elements, **kwargs)
+        url = format_url("/Dimensions('{}')/Hierarchies('{}')/Elements", dimension_name, hierarchy_name)
+        body = [element.body_as_dict for element in elements]
+
+        return self._rest.POST(url=url, data=json.dumps(body), **kwargs)
 
     def add_element_attributes(self, dimension_name: str, hierarchy_name: str,
                                element_attributes: List[ElementAttribute], **kwargs):
@@ -393,350 +1162,167 @@ class HierarchyService(ObjectService):
         :param element_attributes:
         :return:
         """
-        return self.elements.add_element_attributes(dimension_name, hierarchy_name, element_attributes, **kwargs)
+        url = format_url("/Dimensions('{}')/Hierarchies('{}')/ElementAttributes", dimension_name, hierarchy_name)
+        body = [element_attribute.body_as_dict for element_attribute in element_attributes]
 
-    def is_balanced(self, dimension_name: str, hierarchy_name: str, **kwargs):
-        """ Check if hierarchy is balanced
+        return self._rest.POST(url=url, data=json.dumps(body), **kwargs)
 
-        :param dimension_name:
-        :param hierarchy_name:
-        :return:
-        """
+    def get_parents(self, dimension_name: str, hierarchy_name: str, element_name: str, **kwargs) -> List[str]:
         url = format_url(
-            "/Dimensions('{}')/Hierarchies('{}')/Structure/$value",
-            dimension_name,
-            hierarchy_name)
-        structure = int(self._rest.GET(url, **kwargs).text)
-        # 0 = balanced, 2 = unbalanced
-        if structure == 0:
-            return True
-        elif structure == 2:
-            return False
-        else:
-            raise RuntimeError(f"Unexpected return value from TM1 API request: {str(structure)}")
-
-    @require_pandas
-    @require_data_admin
-    @require_ops_admin
-    def update_or_create_hierarchy_from_dataframe(
-            self,
-            dimension_name: str,
-            hierarchy_name: str,
-            df: 'pd.DataFrame',
-            element_column: str = None,
-            verify_unique_elements: bool = False,
-            verify_edges: bool = True,
-            element_type_column: str = 'ElementType',
-            unwind_all: bool = False,
-            unwind_consolidation: list = None,
-            update_attribute_types: bool = False,
-            **kwargs):
-        """ Update or Create a hierarchy based on a dataframe, while never deleting existing elements.
-
-        :param dimension_name:
-            Name of the dimension
-        :param hierarchy_name:
-            Name of the hierarchy
-        :param df: pd.DataFrame the data frame. Example:
-            |    | Region  | ElementType | Alias:a     | Currency:s | population:n | level001 | level000 | level001_weight | level000_weight |
-            |---:|:--------|:------------|:------------|:-----------|-------------:|:---------|:---------|----------------:|----------------:|
-            |  0 | France  | Numeric     | Frankreich  | EUR        |     60000000 | Europe   | World    |               1 |               1 |
-            |  1 | Belgium | Numeric     | Schweiz     | CHF        |      9000000 | Europe   | World    |               1 |               1 |
-            |  2 | Germany | Numeric     | Deutschland | EUR        |     84000000 | Europe   | World    |               1 |               1 |
-
-            Names for the parent columns (level001, level000) are not configurable and `level000` is the top node.
-            All columns except for the element_column, element_type_colums and parent columns are attribute columns.
-            On attribute columns, you specify the type as a suffix. If no type is provided string attributes are created
-
-        :param element_type_column: str
-            The column name in the df which specifies which element is which type.
-            If None, all will be considered N level.
-        :param element_column: str
-            The column name of the element ID. If None, assumes first column is the element ID.
-        :param verify_unique_elements:
-            Abort early if element names are not unique
-        :param verify_edges:
-            Abort early if edges contain a circular reference
-        :param unwind_all: bool
-            Unwind hierarch before creating new edges
-        :param unwind_consolidation: list
-            Unwind a list specific consolidations in hierarch before creating new edges, if unwind_all is true, this list is ignored
-        :param update_attribute_types: bool
-            If True, function will delete and recreate attributes when a type change is requested.
-            By default, function will not delete attributes.
-
-        :return:
-
-        """
-        df = df.copy()
-
-        # element ID is in first column if not specified.
-        element_column = df.columns[0] if not element_column else element_column
-        df[element_column] = df[element_column].astype(str)
-
-        # assume all Numeric if no type is provided
-        if element_type_column not in df.columns:
-            df[element_type_column] = "Numeric"
-
-        # verify uniqueness of element names
-        if verify_unique_elements:
-            unique_element_names = len(set(df[element_column].str.lower().str.replace(' ', '')))
-            if df.shape[0] != unique_element_names:
-                raise ValueError("There must be no duplicates in the element column")
-
-        # verify alias uniqueness
-        alias_columns = tuple([col for col in df.columns if col.lower().endswith((":a", ":alias"))])
-        if len(alias_columns) > 0:
-            self._validate_alias_uniqueness(df=df[[element_column, *alias_columns]])
-            
-        # backward compatibility for unwind, the value for unwind would be assinged to unwind_all. expected type is bool
-        if "unwind" in kwargs:
-            unwind_all = kwargs["unwind"]
-        
-        # verify unwind_consolidation is a list
-        if unwind_consolidation is not None:
-            if not isinstance(unwind_consolidation, list):
-                raise ValueError(f"Inconsistent Type for 'unwind_consolidation': expected type-> list, current type-> '{type(unwind_consolidation)}'")
-
-        # identify and sort level columns
-        level_columns = []
-        level_weight_columns = []
-        # sort to assure right order of levels (e.g. Level003 -> level002 -> LEVEL001)
-        sorted_level_columns = sorted(
-            [col for col in df.columns if any(char.isdigit() for char in col)],  # Filter columns with digits
-            key=lambda x: int(''.join(filter(str.isdigit, x))),  # Sort based on numeric part
-            reverse=True  # Descending order
+            "/Dimensions('{dimension_name}')/Hierarchies('{hierarchy_name}')/Elements('{element_name}')/Parents"
+            f"?$select=Name",
+            dimension_name=dimension_name,
+            hierarchy_name=hierarchy_name,
+            element_name=element_name
         )
-        for column in sorted_level_columns:
-            if column.lower().startswith('level') and column[5:8].isdigit():
-                if len(column) == 8:  # "LevelXXX"
-                    level_columns.append(column)
-                elif len(column) == 15 and column.lower().endswith('_weight'):  # "LevelXXX_weight"
-                    level_weight_columns.append(column)
+        response = self._rest.GET(url=url, **kwargs)
 
-        # case: no level weight columns. All weights are 1
-        if len(level_weight_columns) == 0:
-            for level_column in level_columns:
-                level_weight_column = level_column + "_weight"
-                level_weight_columns.append(level_weight_column)
-                df[level_weight_column] = 1
+        return [record["Name"] for record in response.json()["value"]]
 
-        if not len(level_columns) == len(level_weight_columns):
-            raise ValueError("Number of level columns must be equal to number of level weight columns")
+    def get_parents_of_all_elements(self, dimension_name: str, hierarchy_name: str, **kwargs) -> Dict[str, List[str]]:
+        url = format_url(
+            f"/Dimensions('{dimension_name}')/Hierarchies('{hierarchy_name}')/Elements?$select=Name"
+            f"&$expand=Parents($select=Name)",
+        )
+        response = self._rest.GET(url=url, **kwargs)
 
-        if verify_edges:
-            self._validate_edges(df=df[[element_column, *level_columns]])
+        return {child["Name"]: [parent["Name"] for parent in child["Parents"]] for child in response.json()["value"]}
 
-        hierarchy_exists = self.exists(dimension_name, hierarchy_name)
+    def get_element_principal_name(self, dimension_name: str, hierarchy_name: str, element_name: str, **kwargs) -> str:
+        element = self.get(dimension_name, hierarchy_name, element_name, **kwargs)
+        return element.name
 
-        if not hierarchy_exists:
-            existing_element_identifiers = CaseAndSpaceInsensitiveSet()
-        else:
-            existing_element_identifiers = self.elements.get_all_element_identifiers(
-                dimension_name=dimension_name,
-                hierarchy_name=hierarchy_name)
-
-        if not hierarchy_exists:
-            hierarchy = Hierarchy(name=hierarchy_name, dimension_name=dimension_name)
-            dimension_service = self.get_dimension_service()
-            if not dimension_service.exists(dimension_name):
-                dimension = Dimension(name=dimension_name, hierarchies=[hierarchy])
-                dimension_service.create(dimension)
-            else:
-                hierarchy = Hierarchy(name=hierarchy_name, dimension_name=dimension_name)
-                self.create(hierarchy)
-
-        # determine new elements based on Element Name column
-        new_elements = CaseAndSpaceInsensitiveDict({
-            element_name: Element.Types(element_type)
-            for element_name, element_type
-            in df.loc[
-                ~df[element_column].isin(existing_element_identifiers),
-                (element_column, element_type_column)
-            ].itertuples(index=False)
-        })
-
-        # determine new consolidations based on level columns
-        for element_name in df[[*level_columns]].stack().unique():
-            if not element_name:
-                continue
-            if element_name in existing_element_identifiers:
-                continue
-            if element_name in new_elements and new_elements[element_name] != Element.Types.CONSOLIDATED:
-                raise ValueError(f"Inconsistent Type for element: '{element_name}' in hierarchy '{hierarchy_name}'")
-            new_elements[element_name] = Element.Types.CONSOLIDATED
-
-        if new_elements:
-            # add these elements to hierarchy in tm1
-            self.elements.add_elements(
-                dimension_name=dimension_name,
-                hierarchy_name=hierarchy_name,
-                elements=(
-                    Element(element_name, element_type)
-                    for element_name, element_type in
-                    new_elements.items()))
-
-        # define the attribute columns in df. Applies to all elements in df, not only new ones.
-        attribute_columns = df.columns.drop(
-            labels=[element_column] + [element_type_column] + level_columns + level_weight_columns,
-            errors='ignore')
-
-        # new attributes are created as strings if no type is provided
-        try:
-            existing_attributes = CaseAndSpaceInsensitiveDict({
-                ea.name: ElementAttribute.Types(ea.attribute_type)
-                for ea
-                in self.elements.get_element_attributes(dimension_name, hierarchy_name)
-            })
-
-        except TM1pyRestException as ex:
-            if ex.status_code == 404:
-                existing_attributes = set()
-            else:
-                raise ex
-
-        new_attributes = []
-        for attribute_column in attribute_columns:
-            if ':' in attribute_column:
-                attribute_name, attribute_type = attribute_column.rsplit(":", maxsplit=1)
-                attribute_type = self._attribute_type_from_code(attribute_type)
-
-            else:
-                attribute_name = attribute_column
-                attribute_type = ElementAttribute.Types.STRING
-
-            if attribute_name not in existing_attributes:
-                new_attributes.append(ElementAttribute(attribute_name, attribute_type))
-
-            if attribute_name in existing_attributes and update_attribute_types:
-                if attribute_type != existing_attributes[attribute_name]:
-                    self.elements.delete_element_attribute(dimension_name, dimension_name, attribute_name)
-                    new_attributes.append(ElementAttribute(attribute_name, attribute_type))
-
-        if new_attributes:
-            self.elements.add_element_attributes(
-                dimension_name=dimension_name,
-                hierarchy_name=hierarchy_name,
-                element_attributes=new_attributes)
-
-        # define attributes df with ID + attribute columns.
-        id_attribute_cols = [element_column] + list(attribute_columns.values)
-        attributes_df: pd.DataFrame = df.loc[:, id_attribute_cols]
-
-        # melt for write structure (ID, Attribute) : Attribute_value
-        attributes_df = attributes_df.melt(
-            id_vars=element_column,
-            value_vars=attribute_columns,
-            var_name='}ElementAttributes_' + dimension_name,
-            value_name='attribute_value', )
-        attributes_df.fillna('', inplace=True)
-
-        # drop ':' suffix in attribute column
-        attribute_column = '}ElementAttributes_' + dimension_name
-        attributes_df[attribute_column] = attributes_df[attribute_column].apply(lambda x: x.rsplit(':', 1)[0])
-
-        # write attributes to cube
-        if not attributes_df.empty:
-            cell_service = self.get_cell_service()
-            # explicitly reference hierarchy if dimension_name != hierarchy_name
-            if not case_and_space_insensitive_equals(dimension_name, hierarchy_name):
-                attributes_df.iloc[:, 0] = hierarchy_name + ":" + attributes_df.iloc[:, 0].astype(str)
-            cell_service.write_dataframe(
-                cube_name='}ElementAttributes_' + dimension_name,
-                data=attributes_df,
-                sum_numeric_duplicates=False,
-                use_blob=True)
-
-        if unwind_all:
-            self.remove_all_edges(dimension_name=dimension_name, hierarchy_name=hierarchy_name)
-        else:
-            if unwind_consolidation is not None:
-                edges = CaseAndSpaceInsensitiveTuplesDict()
-                for elem in unwind_consolidation:
-                    if self.elements.exists(dimension_name=dimension_name, hierarchy_name=hierarchy_name, element_name=elem):
-                        temp_edges = self.elements.get_edges_under_consolidation(
-                                            dimension_name=dimension_name, 
-                                            hierarchy_name=hierarchy_name, 
-                                            consolidation=elem)
-                        edges.join(temp_edges)
-                self.elements.delete_edges(
-                            dimension_name=dimension_name, 
-                            hierarchy_name=hierarchy_name,
-                            edges=edges,
-                            use_ti=self.is_admin)  
-
-        edges = CaseAndSpaceInsensitiveTuplesDict()
-        for element_name, *record in df[[element_column, *level_columns, *level_weight_columns]].itertuples(
-                index=False):
-            levels = record[:len(level_columns)]
-            level_weights = record[len(level_columns):]
-
-            previous_level = element_name
-            for level, weight in zip(levels, level_weights):
-                if not level:
-                    continue
-                if not isinstance(level, str) and math.isnan(level):
-                    continue
-                if level == previous_level:
-                    continue
-
-                edges[level, previous_level] = weight
-                previous_level = level
-
-        if edges:
-            try:
-                current_edges = self.elements.get_edges(
-                    dimension_name=dimension_name,
-                    hierarchy_name=hierarchy_name)
-            except TM1pyRestException as ex:
-                if ex.status_code == 404:
-                    current_edges = CaseAndSpaceInsensitiveTuplesDict()
-                else:
-                    raise ex
-
-            delete_edges = {
-                (k, v): w
-                for (k, v), w
-                in edges.items()
-                if w != current_edges.get((k, v), w)}
-            if delete_edges:
-                self.elements.delete_edges(
-                    dimension_name=dimension_name,
-                    hierarchy_name=hierarchy_name,
-                    edges=delete_edges.keys(),
-                    use_ti=self.is_admin)
-
-            new_edges = {
-                (k, v): w
-                for (k, v), w
-                in edges.items()
-                if (k, v) not in current_edges or w != current_edges[(k, v)]}
-            if new_edges:
-                self.elements.add_edges(dimension_name=dimension_name, hierarchy_name=hierarchy_name, edges=new_edges)
-
-    def get_dimension_service(self):
-        from TM1py import DimensionService
-        return DimensionService(self._rest)
-
-    def get_cell_service(self):
-        from TM1py import CellService
-        return CellService(self._rest)
+    def _get_mdx_set_cardinality(self, mdx: str) -> int:
+        url = format_url("/ExecuteMDXSetExpression?$select=Cardinality")
+        payload = {"MDX": mdx}
+        response = self._rest.POST(url, json.dumps(payload, ensure_ascii=False))
+        return (response.json()).get('Cardinality')
 
     @staticmethod
-    def _attribute_type_from_code(attribute_type: str) -> ElementAttribute.Types:
-        attribute_type = attribute_type.lower()
-        if attribute_type not in ["a", "s", "n"] and attribute_type not in ElementAttribute.Types:
-            raise ValueError(f"Attribute Type '{attribute_type}' is not a valid "
-                             f"value: 'a', 's', 'n', 'alias', 'string', 'numeric'")
+    def _build_drill_intersection_mdx(dimension_name: str, hierarchy_name: str, first_element_name: str,
+                                      second_element_name: str, mdx_method: str, recursive: bool) -> str:
 
-        if attribute_type == 'a':
-            return ElementAttribute.Types.ALIAS
+        first_member = Member.of(dimension_name, hierarchy_name, first_element_name)
+        second_member = Member.of(dimension_name, hierarchy_name, second_element_name)
 
-        if attribute_type == 's':
-            return ElementAttribute.Types.STRING
+        if MDXDrillMethod.TM1DRILLDOWNMEMBER.name == mdx_method.upper():
+            query = MdxHierarchySet.members([first_member]).tm1_drill_down_member(recursive=recursive)
 
-        if attribute_type == 'n':
-            return ElementAttribute.Types.NUMERIC
+        elif MDXDrillMethod.DESCENDANTS.name == mdx_method.upper():
+            query = MdxHierarchySet.descendants(
+                member=first_member,
+                level_or_depth=MdxLevelExpression.member_level(second_member),
+                desc_flag='SELF')
 
         else:
-            return ElementAttribute.Types(attribute_type)
+            raise TM1pyException("Invalid MDX Drill Method Specified, Options: 'TM1DrillDownMember' or 'Descendants'")
+
+        mdx = query.intersect(MdxHierarchySet.members([second_member]))
+        return mdx.to_mdx()
+
+    def element_is_parent(self, dimension_name: str, hierarchy_name: str, parent_name: str,
+                          element_name: str) -> bool:
+        """ Element is Parent
+        :Note, unlike the related function in TM1 (ELISPAR or ElementIsParent), this function will return False
+        :if an invalid element is passed;
+        :but will raise an exception if an invalid dimension, or hierarchy is passed
+        """
+        mdx = self._build_drill_intersection_mdx(dimension_name=dimension_name,
+                                                 hierarchy_name=hierarchy_name,
+                                                 first_element_name=parent_name,
+                                                 second_element_name=element_name,
+                                                 mdx_method='TM1DrillDownMember',
+                                                 recursive=False)
+
+        cardinality = self._get_mdx_set_cardinality(mdx)
+        return bool(cardinality)
+
+    def element_is_ancestor(self, dimension_name: str, hierarchy_name: str, ancestor_name: str,
+                            element_name: str, method: str = None) -> bool:
+        """ Element is Ancestor
+
+        :Note, unlike the related function in TM1 (`ELISANC` or `ElementIsAncestor`), this function will return False
+        if an invalid element is passed; but will raise an exception if an invalid dimension, or hierarchy is passed
+
+        For `method` you can pass 3 three values
+        value `TI` performs best, but requires admin permissions
+        Value 'TM1DrillDownMember' performs well when element is a leaf.
+        Value 'Descendants' performs well when `ancestor_name` and `element_name` are Consolidations.
+
+        If no value is passed, function defaults to 'TI' for user with admin permissions
+        and 'TM1DrillDownMember' for users without admin permissions
+        """
+        if not method:
+            method = 'TI' if self.is_admin else 'TM1DrillDownMember'
+
+        if method.upper() == "TI":
+            if self._element_is_ancestor_ti(dimension_name, hierarchy_name, element_name, ancestor_name):
+                return True
+
+            if self.hierarchy_exists(dimension_name, hierarchy_name):
+                return False
+
+            raise TM1pyException(f"Hierarchy: '{hierarchy_name}' does not exist in dimension: '{dimension_name}'")
+
+        # make sure DESCENDANTS behaves like default TM1DrillDownMember
+        if method.upper() == MDXDrillMethod.DESCENDANTS.name:
+            if not self.exists(dimension_name, hierarchy_name, element_name):
+
+                # case dimension or hierarchy doesn't exist
+                if not self.hierarchy_exists(dimension_name, hierarchy_name):
+                    raise TM1pyException(f"Hierarchy '{hierarchy_name}' does not exist in dimension '{dimension_name}'")
+
+                # case element or ancestor doesn't exist
+                return False
+
+        if method.upper() == "TM1DRILLDOWNMEMBER":
+            if not self.exists(dimension_name, hierarchy_name, element_name):
+
+                # case dimension or hierarchy doesn't exist
+                if not self.hierarchy_exists(dimension_name, hierarchy_name):
+                    raise TM1pyException(f"Hierarchy '{hierarchy_name}' does not exist in dimension '{dimension_name}'")
+
+                # case element or ancestor doesn't exist
+                return False
+
+        mdx = self._build_drill_intersection_mdx(
+            dimension_name=dimension_name,
+            hierarchy_name=hierarchy_name,
+            first_element_name=ancestor_name,
+            second_element_name=element_name,
+            mdx_method=method,
+            recursive=True)
+
+        cardinality = self._get_mdx_set_cardinality(mdx)
+        return bool(cardinality)
+
+    def hierarchy_exists(self, dimension_name, hierarchy_name):
+        hierarchy_service = self._get_hierarchy_service()
+        return hierarchy_service.exists(dimension_name, hierarchy_name)
+
+    @require_data_admin
+    def _element_is_ancestor_ti(self, dimension_name: str, hierarchy_name: str, element_name: str,
+                                ancestor_name: str) -> bool:
+        process_service = self.get_process_service()
+        code = f"ElementIsAncestor('{dimension_name}', '{hierarchy_name}', '{ancestor_name}', '{element_name}')=1"
+        return process_service.evaluate_boolean_ti_expression(code)
+
+    def get_process_service(self):
+        from TM1py import ProcessService
+        return ProcessService(self._rest)
+
+    def _get_hierarchy_service(self):
+        from TM1py import HierarchyService
+        return HierarchyService(self._rest)
+
+    def _get_subset_service(self):
+        from TM1py import SubsetService
+        return SubsetService(self._rest)
+
+    def _get_process_service(self):
+        from TM1py import ProcessService
+        return ProcessService(self._rest)
+
+    def _get_cell_service(self):
+        from TM1py import CellService
+        return CellService(self._rest)

--- a/TM1py/Services/HierarchyService.py
+++ b/TM1py/Services/HierarchyService.py
@@ -418,7 +418,7 @@ class HierarchyService(ObjectService):
     @require_pandas
     @require_data_admin
     @require_ops_admin
-     def update_or_create_hierarchy_from_dataframe(
+    def update_or_create_hierarchy_from_dataframe(
             self,
             dimension_name: str,
             hierarchy_name: str,

--- a/TM1py/Services/HierarchyService.py
+++ b/TM1py/Services/HierarchyService.py
@@ -651,18 +651,18 @@ class HierarchyService(ObjectService):
             self.remove_all_edges(dimension_name=dimension_name, hierarchy_name=hierarchy_name)
         else:
             if unwind_consolidation is not None:
-                edges = CaseAndSpaceInsensitiveTuplesDict()
+                all_edges = CaseAndSpaceInsensitiveTuplesDict()
                 for elem in unwind_consolidation:
                     if self.elements.exists(dimension_name=dimension_name, hierarchy_name=hierarchy_name, element_name=elem):
                         temp_edges = self.elements.get_edges_under_consolidation(
                                             dimension_name=dimension_name, 
                                             hierarchy_name=hierarchy_name, 
                                             consolidation=elem)
-                        edges.join(temp_edges)
+                        all_edges.join(temp_edges)
                 self.elements.delete_edges(
                             dimension_name=dimension_name, 
                             hierarchy_name=hierarchy_name,
-                            edges=edges,
+                            edges=all_edges,
                             use_ti=self.is_admin)
 
         edges = CaseAndSpaceInsensitiveTuplesDict()

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -1175,6 +1175,14 @@ class CaseAndSpaceInsensitiveTuplesDict(collections.abc.MutableMapping):
     def copy(self):
         return CaseAndSpaceInsensitiveTuplesDict(self._store.values())
 
+    # Join two dictionaries together
+    def join(self, other):
+        if isinstance(other, CaseAndSpaceInsensitiveTuplesDict):
+            for key,value in other.items():
+                self._store[tuple([lower_and_drop_spaces(item) for item in key])] = (key, value)
+        else:
+             raise ValueError("Other object is not of type CaseAndSpaceInsensitiveTuplesDict")
+
     def __repr__(self):
         return str(dict(self.items()))
 


### PR DESCRIPTION
## Feature ##

Currently `update_or_create_hierarchy_from_dataframe()` allows complete unwinding of hierarchy, but not specific unwinding for consolidations. The code change would allow a list of elements to be specified a parameter so selective unwinding is allowed.

This change would also replace the param _unwind_ with _unwind_all_, used for same purpose. Function is updated to be backward compatible so, using _unwind_ would map the value to _unwind_all_ and continue unwinding the entire hierarchy when **True**.

if _unwind_all_ is **True** , then entire hierarchy would be unwound irrespective of value provided to _unwind_consolidation_. If _unwind_all_ is **False**, and __unwind_consolidation__ is a valid list, then executing the function would unwind the elements specified in the list which exists in the hierarchy

## Code Update ##

**Param updates**


    def update_or_create_hierarchy_from_dataframe(
            self,
            dimension_name: str,
            hierarchy_name: str,
            df: 'pd.DataFrame',
            element_column: str = None,
            verify_unique_elements: bool = False,
            verify_edges: bool = True,
            element_type_column: str = 'ElementType',
            unwind_all: bool = False,
            unwind_consolidation: list = None,
            update_attribute_types: bool = False,
            **kwargs):


**Commentary Update**

        :param unwind_all: bool
            Unwind hierarch before creating new edges
        :param unwind_consolidation: list
            Unwind a list specific consolidations in hierarch before creating new edges, if unwind_all is true, this list is ignored

**Backward compatibility** 

        # backward compatibility for unwind, the value for unwind would be assinged to unwind_all. expected type is bool
        if "unwind" in kwargs:
            unwind_all = kwargs["unwind"]

**Param type validation**        

```
# verify unwind_consolidation is a list
        if unwind_consolidation is not None:
            if not isinstance(unwind_consolidation, list):
                raise ValueError(f"Inconsistent Type for 'unwind_consolidation': expected type-> list, current type-> '{type(unwind_consolidation)}'")
```

**Unwind logic**

```
        if unwind_all:
            self.remove_all_edges(dimension_name, hierarchy_name)
        else:
            if unwind_consolidation is not None:
                for elem in unwind_consolidation:
                    if self.elements.exists(dimension_name, hierarchy_name, elem):
                        self.remove_edges_under_consolidation(dimension_name, hierarchy_name, elem)
```
