### PR TITLE
Added ssl_context param that allows to define custom ssl context for tm1 connection

### DIFF
--- a/TM1py/Services/RestService.py
+++ b/TM1py/Services/RestService.py
@@ -465,7 +465,6 @@ class RestService:
             pool_connections=int(self._connection_pool_size or self.DEFAULT_CONNECTION_POOL_SIZE),
             pool_maxsize=int(self._connection_pool_size),
             ssl_context=self._ssl_context)
-        self._s.mount('https://', adapter),
         self._s.mount(self._base_url, adapter)
 
     def __enter__(self):

--- a/TM1py/Services/TM1Service.py
+++ b/TM1py/Services/TM1Service.py
@@ -60,6 +60,7 @@ class TM1Service:
         :param re_connect_on_session_timeout: attempt to reconnect once if session is timed out
         :param proxies: pass a dictionary with proxies e.g.
                 {'http': 'http://proxy.example.com:8080', 'https': 'http://secureproxy.example.com:8090'}
+        :param ssl_context: pass a user defined ssl context
         """
         self._tm1_rest = RestService(**kwargs)
         self.annotations = AnnotationService(self._tm1_rest)

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -1735,10 +1735,13 @@ def utc_localize_time(timestamp):
 class HTTPAdapterWithSocketOptions(HTTPAdapter):
     def __init__(self, *args, **kwargs):
         self.socket_options = kwargs.pop("socket_options", None)
+        self.ssl_context = kwargs.pop("ssl_context", None)
         super(HTTPAdapterWithSocketOptions, self).__init__(*args, **kwargs)
 
     def init_poolmanager(self, *args, **kwargs):
         # must use hasattr here, as socket_options may be not-set in case TM1Service was created with restore_from_file
         if hasattr(self, "socket_options"):
             kwargs["socket_options"] = self.socket_options
+        if hasattr(self, "ssl_context"):
+            kwargs['ssl_context'] = self.ssl_context
         super(HTTPAdapterWithSocketOptions, self).init_poolmanager(*args, **kwargs)


### PR DESCRIPTION
Usage: 

```python
# define ssl context object that you need
context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
context.check_hostname = False
context.options |= ssl.OP_NO_SSLv3
ciphers = "HIGH:!aNULL:!MD5"
context.set_ciphers(ciphers)

# add ssl_context param to TM1Service constructor
tm1_params = {
    "address": "localhost",
    "port": 12354,
    "user": "admin",
    "password": "apple",
    "ssl": True,
    "ssl_context": context # new parameter for custom ssl
}

# Use it in TM1 Connection
with (TM1Service(**tm1_params)) as tm1:
    server_name = tm1.server.get_server_name()
    print(server_name)
```