### PR TITLE
Fix hier from dataframe existing consol

### DIFF
--- a/TM1py/Services/HierarchyService.py
+++ b/TM1py/Services/HierarchyService.py
@@ -555,7 +555,7 @@ class HierarchyService(ObjectService):
             element_name: Element.Types(element_type)
             for element_name, element_type
             in df.loc[
-                ~df[element_column].isin(existing_element_identifiers),
+                ~df[element_column].str.lower().str.replace(' ', '').isin(existing_element_identifiers._store.keys()),
                 (element_column, element_type_column)
             ].itertuples(index=False)
         })

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -909,6 +909,8 @@ def build_cellset_from_pandas_dataframe(
 
 
 def aggregate_duplicate_intersections(df, dimension_headers, value_header):
+    for col in dimension_headers:
+        df[col] = df[col].str.lower().str.replace(' ', '')
     return df.groupby([*dimension_headers])[value_header].sum().reset_index()
 
 

--- a/Tests/HierarchyService_test.py
+++ b/Tests/HierarchyService_test.py
@@ -514,6 +514,46 @@ class TestHierarchyService(unittest.TestCase):
             hierarchy_name=self.region_dimension_name)
         self._verify_region_dimension(hierarchy)
 
+    def test_update_or_create_hierarchy_from_dataframe_consol_exists(self):
+        columns = [self.region_dimension_name, "ElementType", "Alias:a", "Currency:s", "population:n", "level001",
+                   "level000", "level001_weight", "level000_weight"]
+        data = [
+            ['France', "Numeric", "Frankreich", "EUR", 60_000_000, "Europe", "World", 1, 1],
+            ['Switzerland', 'Numeric', "Schweiz", "CHF", 9_000_000, "Europe", "World", 1, 1],
+            ['Germany', 'Numeric', "Deutschland", "EUR", 84_000_000, "Europe", "World", 1, 1],
+        ]
+        df = DataFrame(data=data, columns=columns)
+
+        self.tm1.hierarchies.update_or_create_hierarchy_from_dataframe(
+            dimension_name=self.region_dimension_name,
+            hierarchy_name=self.region_dimension_name,
+            df=df,
+            element_column=self.region_dimension_name,
+            element_type_column="ElementType",
+            unwind_all=True
+        )
+
+        data = [
+            ['france', "Numeric", "Frankreich", "EUR", 60_000_000, "Europe", "World", 1, 1],
+            ['switz  erland', 'Numeric', "Schweiz", "CHF", 9_000_000, "Europe", "World", 1, 1],
+            ['GerMANY', 'Numeric', "Deutschland", "EUR", 84_000_000, "Europe", "World", 1, 1],
+        ]
+        df = DataFrame(data=data, columns=columns)
+
+        self.tm1.hierarchies.update_or_create_hierarchy_from_dataframe(
+            dimension_name=self.region_dimension_name,
+            hierarchy_name=self.region_dimension_name,
+            df=df,
+            element_column=self.region_dimension_name,
+            element_type_column="ElementType",
+            unwind_all=True
+        )
+
+        hierarchy = self.tm1.hierarchies.get(
+            dimension_name=self.region_dimension_name,
+            hierarchy_name=self.region_dimension_name)
+        self._verify_region_dimension(hierarchy)
+
     def test_update_or_create_hierarchy_from_dataframe_non_standard_level_order(self):
         columns = [self.region_dimension_name, "ElementType", "Alias:a", "Currency:s", "population:n", "Level001",
                    "level000", "level001_weight", "level000_weight"]


### PR DESCRIPTION
Fix #1133 update_or_create_hierarchy_from_dataframe fails when consolidated element exists