### PR TITLE
Fix dtype inference and session cookie handling

### DIFF
--- a/TM1py/Services/RestService.py
+++ b/TM1py/Services/RestService.py
@@ -786,8 +786,22 @@ class RestService:
         finally:
             # If the TM1 REST API is routed through a reverse proxy that alters the expected URL,
             # we explicitly re-set the 'TM1SessionId' cookie to maintain session continuity.
-            session_id = self._s.cookies.pop('TM1SessionId', None)
-            if session_id is not None:
+            session_id = None
+            for cookie in self._s.cookies:
+                if cookie.name == 'TM1SessionId':
+                    session_id = cookie.value
+                    # break  # Use the first match
+
+            # Clear all TM1SessionId cookies to prevent duplicates
+            cookies_to_remove = [
+                (cookie.domain, cookie.path)
+                for cookie in self._s.cookies
+                if cookie.name == 'TM1SessionId'
+            ]
+            for domain, path in cookies_to_remove:
+                self._s.cookies.clear(domain=domain, path=path, name='TM1SessionId')
+
+            if session_id:
                 self._s.cookies.set('TM1SessionId', session_id)
 
             # After we have session cookie, drop the Authorization Header

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -545,7 +545,7 @@ def build_dataframe_from_csv(raw_csv, sep='~', shaped: bool = False,
 
     # make sure all element names are strings and values column is derived from data
     if 'dtype' not in kwargs:
-        kwargs['dtype'] = {'Value': None, **{col: str for col in range(999)}}
+        kwargs['dtype'] = {'Value': str, **{col: str for col in range(999)}}
     try:
         df = pd.read_csv(StringIO(raw_csv), sep=sep, na_values={'Value': ['None']}, keep_default_na=False, **kwargs)
 


### PR DESCRIPTION
- Set default dtype to `str` in `pd.read_csv` to avoid misinterpreting values like '2025' as floats.
- Fixed issue with multiple 'TM1SessionId' cookies causing CookieConflictError during session start.
```
File "C:\Dev\share_service\venv\lib\site-packages\TM1py\Services\RestService.py", line 789, in _start_session
    session_id = self._s.cookies.pop('TM1SessionId', None)
  File "C:\Program Files\Python310\lib\_collections_abc.py", line 954, in pop
    value = self[key]
  File "C:\Dev\share_service\venv\lib\site-packages\requests\cookies.py", line 334, in __getitem__
    return self._find_no_duplicates(name)
  File "C:\Dev\share_service\venv\lib\site-packages\requests\cookies.py", line 405, in _find_no_duplicates
    raise CookieConflictError(
requests.cookies.CookieConflictError: There are multiple cookies with name, 'TM1SessionId'
```