### PR TITLE
Add "all_procedures" to property Process in Process.py

### DIFF
--- a/TM1py/Objects/Process.py
+++ b/TM1py/Objects/Process.py
@@ -222,7 +222,11 @@ class Process(TM1Object):
     @epilog_procedure.setter
     def epilog_procedure(self, value: str):
         self._epilog_procedure = Process.add_generated_string_to_code(value)
-
+    
+    @property
+    def all_procedures(self) -> str:
+        return self._prolog_procedure + self._metadata_procedure + self._data_procedure + self._epilog_procedure
+    
     @property
     def datasource_type(self) -> str:
         return self._datasource_type


### PR DESCRIPTION
Added a property "all_procedures". This property is not mandatory, but a helpful shorthand. I imagine many people want the entire TI code in one string, and so have to write something like `<Process>.prologue_procedure + <Process>.metadata_procedure + <Process>.data_procedure + <Process>.epilogue_procedure` which when done frequently seems unnecessarily clunky. This change provides minimal impact on TM1py while providing the user a cleaner option.