### PR TITLE
Added support for JSON datasource in processes

### DIFF
--- a/TM1py/Objects/Process.py
+++ b/TM1py/Objects/Process.py
@@ -236,6 +236,10 @@ class Process(TM1Object):
         self._epilog_procedure = Process.add_generated_string_to_code(value)
 
     @property
+    def all_procedures(self) -> str:
+        return self._prolog_procedure + self._metadata_procedure + self._data_procedure + self._epilog_procedure
+
+    @property
     def datasource_type(self) -> str:
         return self._datasource_type
 

--- a/TM1py/Objects/Process.py
+++ b/TM1py/Objects/Process.py
@@ -61,7 +61,9 @@ class Process(TM1Object):
                  datasource_query: str = '',
                  datasource_uses_unicode: bool = True,
                  datasource_view: str = '',
-                 datasource_subset: str = ''):
+                 datasource_subset: str = '',
+                 datasource_json_root_pointer: str = '',
+                 datasource_json_variable_mapping: str = ''):
         """ Default construcor
 
         :param name: name of the process - mandatory
@@ -89,6 +91,8 @@ class Process(TM1Object):
         :param datasource_uses_unicode:
         :param datasource_view:
         :param datasource_subset:
+        :param datasource_json_root_pointer:
+        :param datasource_json_variable_mapping:
         """
         self._name = name
         self._has_security_access = has_security_access
@@ -119,6 +123,8 @@ class Process(TM1Object):
         self._datasource_uses_unicode = datasource_uses_unicode
         self._datasource_view = datasource_view
         self._datasource_subset = datasource_subset
+        self._datasource_json_root_pointer = datasource_json_root_pointer
+        self._datasource_json_variable_mapping = datasource_json_variable_mapping
 
     @classmethod
     def from_json(cls, process_as_json: str) -> 'Process':
@@ -161,11 +167,17 @@ class Process(TM1Object):
                    datasource_query=process_as_dict['DataSource'].get('query', ''),
                    datasource_uses_unicode=process_as_dict['DataSource'].get('usesUnicode', ''),
                    datasource_view=process_as_dict['DataSource'].get('view', ''),
-                   datasource_subset=process_as_dict['DataSource'].get('subset', ''))
+                   datasource_subset=process_as_dict['DataSource'].get('subset', ''),
+                   datasource_json_root_pointer=process_as_dict['DataSource'].get('jsonRootPointer', ''),
+                   datasource_json_variable_mapping=process_as_dict['DataSource'].get('jsonVariableMapping', ''))
 
     @property
     def body(self) -> str:
         return self._construct_body()
+
+    @property
+    def body_as_dict(self) -> str:
+        return self._construct_body_as_dict()
 
     @property
     def name(self) -> str:
@@ -222,11 +234,7 @@ class Process(TM1Object):
     @epilog_procedure.setter
     def epilog_procedure(self, value: str):
         self._epilog_procedure = Process.add_generated_string_to_code(value)
-    
-    @property
-    def all_procedures(self) -> str:
-        return self._prolog_procedure + self._metadata_procedure + self._data_procedure + self._epilog_procedure
-    
+
     @property
     def datasource_type(self) -> str:
         return self._datasource_type
@@ -347,6 +355,22 @@ class Process(TM1Object):
     def datasource_subset(self, value: str):
         self._datasource_subset = value
 
+    @property
+    def datasource_json_root_pointer(self) -> str:
+        return self._datasource_json_root_pointer
+
+    @datasource_json_root_pointer.setter
+    def datasource_json_root_pointer(self, value: str):
+        self._datasource_json_root_pointer = value
+
+    @property
+    def datasource_json_variable_mapping(self) -> str:
+        return self._datasource_json_variable_mapping
+
+    @datasource_json_variable_mapping.setter
+    def datasource_json_variable_mapping(self, value: str):
+        self._datasource_json_variable_mapping = value
+
     def add_variable(self, name: str, variable_type: str):
         """ add variable to the process
 
@@ -411,6 +435,9 @@ class Process(TM1Object):
 
     # construct self.body (json) from the class-attributes
     def _construct_body(self) -> str:
+        return json.dumps(self._construct_body_as_dict(), ensure_ascii=False)
+
+    def _construct_body_as_dict(self) -> Dict:
         # general parameters
         body_as_dict = {
             'Name': self._name,
@@ -469,4 +496,12 @@ class Process(TM1Object):
                 "dataSourceNameForServer": self._datasource_data_source_name_for_server,
                 "subset": self._datasource_subset
             }
-        return json.dumps(body_as_dict, ensure_ascii=False)
+        elif self._datasource_type == 'JSON':
+            body_as_dict['DataSource'] = {
+                "Type": self._datasource_type,
+                "dataSourceNameForClient": self._datasource_data_source_name_for_server,
+                "dataSourceNameForServer": self._datasource_data_source_name_for_server,
+                "jsonRootPointer": self._datasource_json_root_pointer,
+                "jsonVariableMapping": self._datasource_json_variable_mapping,
+            }
+        return body_as_dict

--- a/TM1py/Services/ProcessService.py
+++ b/TM1py/Services/ProcessService.py
@@ -46,7 +46,10 @@ class ProcessService(ObjectService):
             "DataSource/userName,"
             "DataSource/password,"
             "DataSource/usesUnicode,"
-            "DataSource/subset", name_process)
+            "DataSource/subset,"
+            "DataSource/jsonRootPointer,"
+            "DataSource/jsonVariableMapping", name_process)
+
         response = self._rest.GET(url, **kwargs)
         return Process.from_dict(response.json())
 
@@ -72,7 +75,9 @@ class ProcessService(ObjectService):
               "DataSource/userName," \
               "DataSource/password," \
               "DataSource/usesUnicode," \
-              "DataSource/subset{}".format(model_process_filter if skip_control_processes else "")
+              "DataSource/subset," \
+              "DataSource/jsonRootPointer," \
+              "DataSource/jsonVariableMapping{}".format(model_process_filter if skip_control_processes else "")
 
         response = self._rest.GET(url, **kwargs)
         response_as_dict = response.json()

--- a/Tests/ProcessService_test.py
+++ b/Tests/ProcessService_test.py
@@ -52,6 +52,17 @@ class TestProcessService(unittest.TestCase):
                      datasource_password='password',
                      datasource_user_name='user')
 
+    p_json = Process(name=prefix + '_json_' + some_name,
+                     datasource_type='JSON',
+                     datasource_json_root_pointer='data',
+                     datasource_json_variable_mapping='{}',
+                     prolog_procedure="sTestProlog = 'test prolog procedure';",
+                     metadata_procedure="sTestMeta = 'test metadata procedure';",
+                     data_procedure="sTestData =  'test data procedure';",
+                     epilog_procedure="sTestEpilog = 'test epilog procedure';",
+                     datasource_data_source_name_for_server=r'C:\Data\file.json',
+                     datasource_data_source_name_for_client=r'C:\Data\file.json')
+    
     p_debug = Process(
         name=prefix + "_debug",
         datasource_type="None",
@@ -101,6 +112,7 @@ class TestProcessService(unittest.TestCase):
         self.tm1.processes.update_or_create(self.p_ascii)
         self.tm1.processes.update_or_create(self.p_view)
         self.tm1.processes.update_or_create(self.p_odbc)
+        self.tm1.processes.update_or_create(self.p_json)
         self.tm1.processes.update_or_create(self.p_subset)
         self.tm1.processes.update_or_create(self.p_debug)
         self.tm1.processes.update_or_create(self.p_error)
@@ -110,6 +122,7 @@ class TestProcessService(unittest.TestCase):
         self.tm1.processes.delete(self.p_ascii.name)
         self.tm1.processes.delete(self.p_view.name)
         self.tm1.processes.delete(self.p_odbc.name)
+        self.tm1.processes.delete(self.p_json.name)
         self.tm1.processes.delete(self.p_subset.name)
         self.tm1.processes.delete(self.p_debug.name)
         self.tm1.processes.delete(self.p_error.name)
@@ -391,6 +404,14 @@ class TestProcessService(unittest.TestCase):
         p_odbc_orig._ui_data = p._ui_data = None
 
         self.assertEqual(p.body, p_odbc_orig.body)
+
+    @skip_if_version_lower_than(version="12")
+    def test_get_process_json(self):
+        p_json_orig = copy.deepcopy(self.p_json)
+
+        p = self.tm1.processes.get(p_json_orig.name)
+        p._ui_data = p_json_orig._ui_data = None
+        self.assertEqual(p.body, p_json_orig.body)
 
     def test_update_process(self):
         # get


### PR DESCRIPTION
Note:
1. The addition of `"DataSource/jsonRootPointer,"
            "DataSource/jsonVariableMapping"` in the get process URL may affect backwards compatibility. Has not been tested for V11.
2. Added property `body_as_dict` to Process Object.