### PR TITLE
Update RestService.py to allow "user" or "username" param

### DIFF
--- a/TM1py/Services/RestService.py
+++ b/TM1py/Services/RestService.py
@@ -142,7 +142,7 @@ class RestService:
         self._pa_url = kwargs.get('pa_url', None)
         self._cpd_url = kwargs.get('cpd_url', None)
         self._tenant = kwargs.get('tenant', None)
-        self._user = kwargs.get('user', None)
+        self._user = kwargs.get('user', kwargs.get('username', None))
 
         # other arguments
         self._auth_mode = self._determine_auth_mode()


### PR DESCRIPTION
Can use parameter "user" or "username" as discussed in TM1py weekly meeting :)