### PR TITLE
feat: Add automatic reconnection handling for RemoteDisconnected errors

### DIFF
--- a/TM1py/Services/ProcessService.py
+++ b/TM1py/Services/ProcessService.py
@@ -264,13 +264,14 @@ class ProcessService(ObjectService):
 
     @require_version(version="11.3")
     def execute_process_with_return(self, process: Process, timeout: float = None, cancel_at_timeout: bool = False,
-                                    return_async_id: bool = False, **kwargs) -> Tuple[bool, str, str]:
+                                    return_async_id: bool = False, safe_to_retry: bool = False, **kwargs) -> Tuple[bool, str, str]:
         """Run unbound TI code directly.
 
         :param process: a TI Process Object
         :param timeout: Number of seconds that the client will wait to receive the first byte.
         :param cancel_at_timeout: Abort operation in TM1 when timeout is reached
         :param return_async_id: return async_id instead of (success, status, error_log_file)
+        :param safe_to_retry: bool, indicates that the operation is idempotent and can be safely retried on connection errors
         :param kwargs: dictionary of process parameters and values
         :return: success (boolean), status (String), error_log_file (String)
         """
@@ -290,6 +291,7 @@ class ProcessService(ObjectService):
             timeout=timeout,
             cancel_at_timeout=cancel_at_timeout,
             return_async_id=return_async_id,
+            idempotent=safe_to_retry,
             **kwargs)
 
         if return_async_id:
@@ -298,7 +300,7 @@ class ProcessService(ObjectService):
         return self._execute_with_return_parse_response(response)
 
     def execute_with_return(self, process_name: str = None, timeout: float = None, cancel_at_timeout: bool = False,
-                            return_async_id: bool = False, **kwargs) -> Tuple[bool, str, str]:
+                            return_async_id: bool = False, safe_to_retry: bool = False, **kwargs) -> Tuple[bool, str, str]:
         """ Ask TM1 Server to execute a process.
         pass process parameters as keyword arguments to this function. E.g:
 
@@ -310,6 +312,7 @@ class ProcessService(ObjectService):
         :param timeout: Number of seconds that the client will wait to receive the first byte.
         :param cancel_at_timeout: Abort operation in TM1 when timeout is reached
         :param return_async_id: return async_id instead of (success, status, error_log_file)
+        :param safe_to_retry: bool, indicates that the operation is idempotent and can be safely retried on connection errors
         :param kwargs: dictionary of process parameters and values
         :return: success (boolean), status (String), error_log_file (String)
         """
@@ -327,6 +330,7 @@ class ProcessService(ObjectService):
             timeout=timeout,
             cancel_at_timeout=cancel_at_timeout,
             return_async_id=return_async_id,
+            idempotent=safe_to_retry,
             **kwargs)
 
         if return_async_id:

--- a/TM1py/Services/TM1Service.py
+++ b/TM1py/Services/TM1Service.py
@@ -45,8 +45,9 @@ class TM1Service:
         :param timeout: Float - Number of seconds that the client will wait to receive the first byte.
         :param cancel_at_timeout: Abort operation in TM1 when timeout is reached
         :param async_requests_mode: changes internal REST execution mode to avoid 60s timeout on IBM cloud
-        :param connection_pool_size - In a multi threaded environment, you should set this value to a
-                higher number, such as the number of threads
+        :param connection_pool_size - Maximum number of connections to save in the pool (default: 10).
+                In a multi threaded environment, you should set this value to a higher number, such as the number of threads
+        :param pool_connections: Number of connection pools to cache (default: 1 for a single TM1 instance)
         :param integrated_login: True for IntegratedSecurityMode3
         :param integrated_login_domain: NT Domain name.
                 Default: '.' for local account.
@@ -58,6 +59,7 @@ class TM1Service:
                 Default: False
         :param impersonate: Name of user to impersonate
         :param re_connect_on_session_timeout: attempt to reconnect once if session is timed out
+        :param re_connect_on_remote_disconnect: attempt to reconnect once if connection is aborted by remote end
         :param proxies: pass a dictionary with proxies e.g.
                 {'http': 'http://proxy.example.com:8080', 'https': 'http://secureproxy.example.com:8090'}
         """


### PR DESCRIPTION
- Add re_connect_on_remote_disconnect parameter to TM1Service constructor
- Implement automatic reconnection logic when server closes connection
- Add idempotent/safe_to_retry parameter to process execution methods
- Refactor RestService.request() to eliminate code duplication by extracting:
  - _execute_sync_request() for synchronous requests
  - _execute_async_request() for asynchronous requests
  - _poll_async_response() for async polling logic
  - _transform_async_response() for version-specific transformations
  - _handle_remote_disconnect() for reconnection and retry logic
- Only retry requests marked as idempotent to prevent data corruption
- Preserve session state (cookies, auth tokens) during reconnection
- Maintain compatibility with async operation tracking

These fixes attempt to remeidate or mitigate a recurrent problem in RushTI when executeed against IBM PAoC from a machine within clients internal network.