### PR TITLE
reorder_with_priority: revised code after Copilot suggestions

### DIFF
--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -1745,6 +1745,26 @@ def utc_localize_time(timestamp):
     return timestamp_utc
 
 
+def reorder_with_priority(original_items: List[Any], priority_items: List[Any] = None, exclude_items: List[Any] = None, sort_remaining: bool = True, **kwargs) -> List[Any]:
+    """
+    Reorder a list of original items so that items in 'priority_items' list appear first (in specified order),
+    followed by the remaining items of original items. The order of the remaining items depends on the 
+    'sort_remaining' parameter: if True, the original order is preserved; if False, the items 
+    are sorted alphabetically. Items in the 'exclude_items' list are omitted. Missing priority items 
+    and exclude items are ignored.
+
+    Example case: hierarchy names
+    "correct" order: first the main hierarchy name (matching the dimension name), 
+    then the Leaves hierarchy, then the other hierarchy names (sorted or not).
+    When trying to create the Leaves hierarchy when it already exists (because of creating a different alternate hierarchy),
+    an error pops up. Set exclude_items equal to ['Leaves'].
+    """
+    result = [s for s in priority_items if s in original_items]
+    remaining = [s for s in original_items if (s not in result) and (s not in exclude_items)]
+    result += sorted(remaining) if sort_remaining else remaining
+    return result
+
+
 class HTTPAdapterWithSocketOptions(HTTPAdapter):
     def __init__(self, *args, **kwargs):
         self.socket_options = kwargs.pop("socket_options", None)

--- a/Tests/Utils_test.py
+++ b/Tests/Utils_test.py
@@ -608,6 +608,18 @@ class TestUtilsMethods(unittest.TestCase):
             expected_mdx,
             drop_dimension_properties(mdx))
 
+    def test_reorder_with_priority(self):
+        original_items = ['Customer by Budget holder', 'Customer by Segment', 'Customer List', 'Leaves', 'Customer', 'Customer by Region']
+        priority_items = ['Customer', 'Customer List']
+        exclude_items = ['Leaves']
+        sort_remaining = True
+
+        expected_outcome = ['Customer', 'Customer List', 'Customer by Budget holder', 'Customer by Region', 'Customer by Segment']
+
+        self.assertEqual(
+            expected_outcome,
+            reorder_with_priority(original_items, priority_items, exclude_items, sort_remaining))
+    
     @classmethod
     def tearDownClass(cls):
         cls.tm1.logout()


### PR DESCRIPTION
Adding a short function to sort lists. Use case (for me) is sorting of hierarchy names within dimensions, excluding certain hierarchies, such that these hierarchies could be migrated.