### PR TITLE
Refactor new parameter names

### DIFF
--- a/TM1py/Services/ProcessService.py
+++ b/TM1py/Services/ProcessService.py
@@ -264,14 +264,14 @@ class ProcessService(ObjectService):
 
     @require_version(version="11.3")
     def execute_process_with_return(self, process: Process, timeout: float = None, cancel_at_timeout: bool = False,
-                                    return_async_id: bool = False, safe_to_retry: bool = False, **kwargs) -> Tuple[bool, str, str]:
+                                    return_async_id: bool = False, retry_on_disconnect: bool = False, **kwargs) -> Tuple[bool, str, str]:
         """Run unbound TI code directly.
 
         :param process: a TI Process Object
         :param timeout: Number of seconds that the client will wait to receive the first byte.
         :param cancel_at_timeout: Abort operation in TM1 when timeout is reached
         :param return_async_id: return async_id instead of (success, status, error_log_file)
-        :param safe_to_retry: bool, indicates that the operation is idempotent and can be safely retried on connection errors
+        :param retry_on_disconnect: bool, indicates that the operation is idempotent and can be safely retried on connection errors
         :param kwargs: dictionary of process parameters and values
         :return: success (boolean), status (String), error_log_file (String)
         """
@@ -291,7 +291,7 @@ class ProcessService(ObjectService):
             timeout=timeout,
             cancel_at_timeout=cancel_at_timeout,
             return_async_id=return_async_id,
-            idempotent=safe_to_retry,
+            idempotent=retry_on_disconnect,
             **kwargs)
 
         if return_async_id:
@@ -300,7 +300,7 @@ class ProcessService(ObjectService):
         return self._execute_with_return_parse_response(response)
 
     def execute_with_return(self, process_name: str = None, timeout: float = None, cancel_at_timeout: bool = False,
-                            return_async_id: bool = False, safe_to_retry: bool = False, **kwargs) -> Tuple[bool, str, str]:
+                            return_async_id: bool = False, retry_on_disconnect: bool = False, **kwargs) -> Tuple[bool, str, str]:
         """ Ask TM1 Server to execute a process.
         pass process parameters as keyword arguments to this function. E.g:
 
@@ -312,7 +312,7 @@ class ProcessService(ObjectService):
         :param timeout: Number of seconds that the client will wait to receive the first byte.
         :param cancel_at_timeout: Abort operation in TM1 when timeout is reached
         :param return_async_id: return async_id instead of (success, status, error_log_file)
-        :param safe_to_retry: bool, indicates that the operation is idempotent and can be safely retried on connection errors
+        :param retry_on_disconnect: bool, indicates that the operation is idempotent and can be safely retried on connection errors
         :param kwargs: dictionary of process parameters and values
         :return: success (boolean), status (String), error_log_file (String)
         """
@@ -330,7 +330,7 @@ class ProcessService(ObjectService):
             timeout=timeout,
             cancel_at_timeout=cancel_at_timeout,
             return_async_id=return_async_id,
-            idempotent=safe_to_retry,
+            idempotent=retry_on_disconnect,
             **kwargs)
 
         if return_async_id:


### PR DESCRIPTION
changed the name of the newly introduced parameters in execute_with_return functions to support disconnect handling