### PR TITLE
Bug? Element Information loss when getting NativeView

### DIFF
--- a/TM1py/Objects/Subset.py
+++ b/TM1py/Objects/Subset.py
@@ -115,7 +115,7 @@ class Subset(TM1Object):
                    alias=subset_as_dict.get('Alias'),
                    expression=subset_as_dict.get('Expression'),
                    elements=[element['Name'] for element in subset_as_dict.get('Elements', [])]
-                   if not subset_as_dict.get('Expression') else None)
+                   if subset_as_dict.get('Elements') else None)
 
     @property
     def body(self) -> str:


### PR DESCRIPTION
**Describe the bug**
Significant information loss when getting NativeView from TM1py

**To Reproduce (AND SEE)**
1. (For Visibility) Modify ViewService.py, add the following the lines of code to Line 99, in between the `native_view = NativeView.from_json(response.text, cube_name)` and `return native_view` lines:
```
print(json.dumps(json.loads(response.text), indent=2))
print('-'*50)
print(json.dumps(json.loads(native_view.body), indent=2))
```
2. Create a Native View in TM1
3. Get the View
4. Compare printed outputs. Although all the element names have been retrieved from TM1, they are not added into the NativeView/AxisSelection/Subset and therefore lost.


**Expected behavior**
Elements list to be added to the NativeView's Subsets

**Version**
TM1py [2.1]
TM1 Server Version: [12.4]