### PR TITLE
Return type hint for 'body_as_dict' for Process

### DIFF
--- a/TM1py/Objects/Process.py
+++ b/TM1py/Objects/Process.py
@@ -178,7 +178,7 @@ class Process(TM1Object):
         return self._construct_body()
 
     @property
-    def body_as_dict(self) -> str:
+    def body_as_dict(self) -> Dict:
         return self._construct_body_as_dict()
 
     @property


### PR DESCRIPTION
for `Process` the return type hint of `body_as_dict` was `str` but it should be `Dict`.