### PR TITLE
Fix _build_cube_to_blob_process

### DIFF
--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -1651,6 +1651,7 @@ class CellService(ObjectService):
         ViewExtractSkipZeroesSet('{cube}', '{view_name}', {'1' if skip_zeros else '0'});
         DatasourceAsciiDelimiter='{value_separator}';
         DatasourceAsciiQuoteCharacter='{quote_character}';
+        DatasourceASCIIDecimalSeparator='.';
         nRecord=0;
         """
 


### PR DESCRIPTION
Explicitly set decimal character in prolog

Fixes #1296