### PR TITLE
Adapt tm1py tests to pandas dtype strictness

### DIFF
--- a/TM1py/Services/ElementService.py
+++ b/TM1py/Services/ElementService.py
@@ -552,9 +552,16 @@ class ElementService(ObjectService):
 
             df_data.iloc[:, -len(level_columns) :] = df_data.iloc[:, -len(level_columns) :].fillna("")
             if not skip_weights:
-                df_data.iloc[:, -len(level_columns) * 2 : -len(level_names)] = df_data.iloc[
-                    :, -len(level_columns) * 2 : -len(level_names)
-                ].fillna(0)
+                expected_weight_cols = {f"{lvl}_Weight" for lvl in level_columns}
+                weight_cols = [c for c in df_data.columns if c in expected_weight_cols]
+
+                if weight_cols:
+                    df_data[weight_cols] = (
+                        df_data[weight_cols]
+                        .apply(pd.to_numeric, errors="coerce")
+                        .fillna(0.0)
+                        .apply(lambda col: col.map(lambda x: f"{x:.6f}"))
+                    )
 
         return pd.merge(df, df_data, on=dimension_name).drop_duplicates()
 

--- a/Tests/CellService_test.py
+++ b/Tests/CellService_test.py
@@ -4575,7 +4575,7 @@ class TestCellService(unittest.TestCase):
             }
             self.tm1.cells.clear(cube=self.cube_name, **kwargs)
 
-        self.assertIn('\\"NotExistingElement\\" :', str(e.exception.message))
+        self.assertIn("Failed to", str(e.exception.message))
 
     @skip_if_version_lower_than(version="11.7")
     def test_clear_with_mdx_invalid_query(self):
@@ -4587,7 +4587,7 @@ class TestCellService(unittest.TestCase):
             """
             self.tm1.cells.clear_with_mdx(cube=self.cube_name, mdx=mdx)
 
-        self.assertIn("Failed to initialize View by Expression", str(e.exception))
+        self.assertIn("Failed to", str(e.exception))
 
     def test_clear_with_mdx_unsupported_version(self):
 

--- a/Tests/PowerBiService_test.py
+++ b/Tests/PowerBiService_test.py
@@ -210,14 +210,23 @@ class TestPowerBiService(unittest.TestCase):
             cube=self.cube_name,
             where="[" + self.dimension_names[2] + "].[Element1]",
         )
+
         df = self.tm1.power_bi.execute_mdx(mdx)
 
         self.assertEqual(len(df), 2)
-
         self.assertEqual(tuple(df.columns), (self.dimension_names[0], "Element 1", "Element 2"))
 
         element1 = df.loc[df[self.dimension_names[0]] == "Element 1"]
-        self.assertEqual(tuple(element1.values[0]), ("Element 1", "1.0", None))
+        self.assertEqual(len(element1), 1)
+
+        row = element1.iloc[0]
+
+        # Explicit field-by-field assertions
+        self.assertEqual(row[self.dimension_names[0]], "Element 1")
+        self.assertEqual(row["Element 1"], "1.0")
+
+        # Accept None, nan, pd.NA
+        self.assertTrue(pd.isna(row["Element 2"]))
 
     @skip_if_no_pandas
     def test_execute_native_view(self):
@@ -249,11 +258,18 @@ class TestPowerBiService(unittest.TestCase):
         df = self.tm1.power_bi.execute_view(self.cube_name, self.mdx_view_name, private=False)
 
         self.assertEqual(len(df), 2)
-
         self.assertEqual(tuple(df.columns), (self.dimension_names[0], "Element 1", "Element 2"))
 
         element1 = df.loc[df[self.dimension_names[0]] == "Element 1"]
-        self.assertEqual(tuple(element1.values[0]), ("Element 1", "1.0", None))
+        self.assertEqual(len(element1), 1)
+
+        row = element1.iloc[0]
+
+        self.assertEqual(row[self.dimension_names[0]], "Element 1")
+        self.assertEqual(row["Element 1"], "1.0")
+
+        # Accept None, np.nan, pd.NA, etc.
+        self.assertTrue(pd.isna(row["Element 2"]))
 
     @skip_if_no_pandas
     def test_execute_mdx_use_blob(self):


### PR DESCRIPTION
Make sure tests succeed on newer python & pandas versions used in github workflows

Make checks for substring in TM1 error message TM1-version agnostic