### PR TITLE
fix: make v12 integration tests optional in nightly release

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -49,14 +49,11 @@ jobs:
             echo "⏭️  No new commits since last release, skipping"
           fi
 
-  run-tests:
+  run-tests-v11:
     needs: check-for-changes
     if: needs.check-for-changes.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        environment: ["tm1-12-cloud", "tm1-11-cloud"]
-    environment: ${{ matrix.environment }}
+    environment: tm1-11-cloud
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -90,12 +87,55 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results-${{ matrix.environment }}
+          name: test-results-tm1-11-cloud
+          path: Tests/test-reports/
+          retention-days: 7
+
+  run-tests-v12:
+    needs: check-for-changes
+    if: needs.check-for-changes.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    environment: tm1-12-cloud
+    continue-on-error: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install -e .[pandas,dev]
+
+      - name: Retrieve TM1 Connection Details
+        run: echo "Retrieving TM1 connection details"
+        env:
+          TM1_CONNECTION: ${{ vars.TM1_CONNECTION }}
+          TM1_CONNECTION_SECRET: ${{ secrets.TM1_CONNECTION_SECRET }}
+
+      - name: Generate config.ini
+        run: |
+          python Tests/resources/generate_config.py
+        env:
+          TM1_CONNECTION: ${{ vars.TM1_CONNECTION }}
+          TM1_CONNECTION_SECRET: ${{ secrets.TM1_CONNECTION_SECRET }}
+
+      - name: Run integration tests
+        run: pytest Tests/
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-tm1-12-cloud
           path: Tests/test-reports/
           retention-days: 7
 
   determine-version:
-    needs: [check-for-changes, run-tests]
+    needs: [check-for-changes, run-tests-v11]
     runs-on: ubuntu-latest
     outputs:
       new_version: ${{ steps.version.outputs.new_version }}
@@ -340,7 +380,7 @@ jobs:
           echo "Or use 'skip-release' label to explicitly skip a PR"
 
   notify-on-failure:
-    needs: [run-tests, determine-version]
+    needs: [run-tests-v11, determine-version]
     if: ${{ always() && failure() }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Split the `run-tests` matrix job into two separate jobs: `run-tests-v11` (mandatory) and `run-tests-v12` (optional)
- v12 job uses `continue-on-error: true` so its failure no longer blocks the release pipeline
- `determine-version` and downstream release jobs now only depend on v11 passing
- v12 tests still run nightly for visibility — results are uploaded as artifacts

## Context
The v12 integration tests randomly fail due to Cloudflare interference, which has been blocking all nightly releases since both v11 and v12 were required to pass.

## Test plan
- [ ] Trigger workflow manually and verify v11 success proceeds to `determine-version` even if v12 fails
- [ ] Verify v12 test artifacts are still uploaded on both success and failure
- [ ] Verify `notify-on-failure` only triggers on v11 or release pipeline failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)