### PR TITLE
Fix trailing slash in base_url causing doubled /api/v1 path

### DIFF
--- a/TM1py/Services/RestService.py
+++ b/TM1py/Services/RestService.py
@@ -602,8 +602,9 @@ class RestService:
         if self._address is not None:
             raise ValueError("Base URL and Address can not be specified at the same time")
 
+        self._base_url = self._base_url.rstrip("/")
         # v12 requires an auth URL be provided if a base URL is specified
-        elif "api/v1/Databases" in self._base_url:
+        if "api/v1/Databases" in self._base_url:
             if not self._auth_url:
                 raise ValueError(
                     "Auth_url missing, when connecting to planning analytics engine and using the "


### PR DESCRIPTION
# Problem
When `base_url` is given by the user with a trailing slash (i.e. ending with `/api/v1/`) the base URL ends up getting `/api/v1` appended to it again, ending in a URL such as `https://server/tm1/server_name/api/v1/api/v1/Configuration` and therefore throwing an error of `'api' resource can not be resolved on type 'EntityContainer'`. There is no real indication to users that the trailing slash is the cause of this, making it difficult to debug

# Fix
Strip the trailing slashes from `base_url` before the `endswith` check.

# Tested against
IBM Planning Analytics Local (PAW) acting as a reverse proxy, TM1 version 11.8.03100.4.

# Note
The `elif "api/v1/Databases"` has been changed to an `if` statement. This is safe because the previous `if` statement never falls through as it raises a `ValueError`.