### PR TITLE
Fix error message formatting in _handle_proxies and grammatical error

### DIFF
--- a/TM1py/Services/RestService.py
+++ b/TM1py/Services/RestService.py
@@ -257,7 +257,7 @@ class RestService:
             try:
                 return json.loads(proxies)
             except JSONDecodeError:
-                raise ValueError("Invalid JSON passed for argument 'proxies': %s", proxies)
+                raise ValueError(f"Invalid JSON passed for argument 'proxies': {proxies}")
 
         # handle invalid type
         raise ValueError("Argument of 'proxies' must be None, dictionary or JSON string")
@@ -1133,7 +1133,7 @@ class RestService:
         elif isinstance(value, str):
             return value.replace(" ", "").lower() == "true"
         else:
-            raise ValueError("Invalid argument: '" + value + "'. Must be to be of type 'bool' or 'str'")
+            raise ValueError("Invalid argument: '" + value + "'. Must be of type 'bool' or 'str'")
 
     @staticmethod
     def b64_decode_password(encrypted_password: str) -> str:


### PR DESCRIPTION
Python doesn't allow `"%s", ` in exceptions, this will raise the exception as a tuple with `"Invalid JSON passed for argument 'proxies': %s"` as a literal string and `proxies` as the other element in the tuple. I have changed it to an f string in this case rather than adapting it to `"%s" % proxies` because TM1py is targeting Python 3.7 and f strings are faster and more readable. I tested this and it does indeed just raise that tuple.

That being said, feel free to change this to "%s" % proxies if the consistency of it is important.

I also spotted a minor grammatical error while reading through the rest of the code with the line `Must be to be of type 'bool' or 'str'"`.