### PR TITLE
feat: raise TM1pyNetworkException for HTML/Cloudflare responses

### DIFF
--- a/TM1py/Exceptions/Exceptions.py
+++ b/TM1py/Exceptions/Exceptions.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # TM1py Exceptions are defined here
+import re
 from typing import List, Mapping
 
 
@@ -171,6 +172,67 @@ class TM1pyRestException(TM1pyException):
         return "Text: '{}' - Status Code: {} - Reason: '{}' - Headers: {}".format(
             self.message, self._status_code, self._reason, self._headers
         )
+
+class TM1pyNetworkException(TM1pyException):
+    """Exception for network/upstream errors where the request never reached TM1.
+
+    Raised when a non-JSON response is received (e.g. an HTML block page from
+    Cloudflare or another WAF/proxy), indicating the issue is infrastructure-level
+    rather than a TM1 REST API error.
+    """
+
+    def __init__(self, response: str, status_code: int, reason: str, headers: Mapping):
+        """
+        :param response: Response text (e.g. raw HTML from a block page)
+        :param status_code: HTTP status code
+        :param reason: Reason phrase
+        :param headers: HTTP headers
+        """
+        super().__init__(response)
+        self._status_code = status_code
+        self._reason = reason
+        self._headers = headers
+        self._ray_id = self._extract_cloudflare_ray_id(response)
+
+    @staticmethod
+    def _extract_cloudflare_ray_id(text: str) -> str:
+        """Extract Cloudflare Ray ID from an HTML block page, if present."""
+        match = re.search(r"Ray ID[:\s]+([a-f0-9]+)", text, re.IGNORECASE)
+        return match.group(1) if match else None
+
+    @property
+    def status_code(self) -> int:
+        """HTTP status code."""
+        return self._status_code
+
+    @property
+    def reason(self) -> str:
+        """Reason phrase."""
+        return self._reason
+
+    @property
+    def response(self) -> str:
+        """Response text."""
+        return self.message
+
+    @property
+    def headers(self) -> Mapping:
+        """HTTP headers."""
+        return self._headers
+
+    @property
+    def ray_id(self):
+        """Cloudflare Ray ID if the block page contained one, else None."""
+        return self._ray_id
+
+    def __str__(self) -> str:
+        msg = (
+            f"Network/upstream error — request was likely blocked before reaching TM1. "
+            f"Status Code: {self._status_code} - Reason: '{self._reason}'"
+        )
+        if self._ray_id:
+            msg += f" - Cloudflare Ray ID: {self._ray_id}"
+        return msg
 
 
 class TM1pyWriteFailureException(TM1pyException):

--- a/TM1py/Exceptions/Exceptions.py
+++ b/TM1py/Exceptions/Exceptions.py
@@ -192,11 +192,14 @@ class TM1pyNetworkException(TM1pyException):
         self._status_code = status_code
         self._reason = reason
         self._headers = headers
-        self._ray_id = self._extract_cloudflare_ray_id(response)
+        self._ray_id = self._extract_cloudflare_ray_id(response, headers)        
 
     @staticmethod
-    def _extract_cloudflare_ray_id(text: str) -> str:
+    def _extract_cloudflare_ray_id(text: str, headers: Mapping) -> str:
         """Extract Cloudflare Ray ID from an HTML block page, if present."""
+        ray_id = headers.get("CF-RAY", "")
+        if ray_id:
+            return ray_id
         match = re.search(r"Ray ID[:\s]+([a-f0-9]+)", text, re.IGNORECASE)
         return match.group(1) if match else None
 

--- a/TM1py/Exceptions/Exceptions.py
+++ b/TM1py/Exceptions/Exceptions.py
@@ -2,7 +2,7 @@
 
 # TM1py Exceptions are defined here
 import re
-from typing import List, Mapping
+from typing import List, Mapping, Optional
 
 
 class TM1pyTimeout(Exception):
@@ -173,12 +173,17 @@ class TM1pyRestException(TM1pyException):
             self.message, self._status_code, self._reason, self._headers
         )
 
+
 class TM1pyNetworkException(TM1pyException):
     """Exception for network/upstream errors where the request never reached TM1.
 
     Raised when a non-JSON response is received (e.g. an HTML block page from
     Cloudflare or another WAF/proxy), indicating the issue is infrastructure-level
     rather than a TM1 REST API error.
+
+    Intentionally does NOT subclass TM1pyRestException so that existing
+    `except TM1pyRestException` handlers do not swallow infrastructure-level
+    failures. Both remain siblings under TM1pyException.
     """
 
     def __init__(self, response: str, status_code: int, reason: str, headers: Mapping):
@@ -192,10 +197,10 @@ class TM1pyNetworkException(TM1pyException):
         self._status_code = status_code
         self._reason = reason
         self._headers = headers
-        self._ray_id = self._extract_cloudflare_ray_id(response, headers)        
+        self._ray_id = self._extract_cloudflare_ray_id(response, headers)
 
     @staticmethod
-    def _extract_cloudflare_ray_id(text: str, headers: Mapping) -> str:
+    def _extract_cloudflare_ray_id(text: str, headers: Mapping) -> Optional[str]:
         """Extract Cloudflare Ray ID from an HTML block page, if present."""
         ray_id = headers.get("CF-RAY", "")
         if ray_id:
@@ -224,7 +229,7 @@ class TM1pyNetworkException(TM1pyException):
         return self._headers
 
     @property
-    def ray_id(self):
+    def ray_id(self) -> Optional[str]:
         """Cloudflare Ray ID if the block page contained one, else None."""
         return self._ray_id
 

--- a/TM1py/Exceptions/__init__.py
+++ b/TM1py/Exceptions/__init__.py
@@ -1,11 +1,12 @@
 # ruff: noqa: F401
 from TM1py.Exceptions.Exceptions import (
     TM1pyException,
+    TM1pyNetworkException,
     TM1pyNotAdminException,
     TM1pyRestException,
     TM1pyTimeout,
+    TM1pyVersionDeprecationException,
     TM1pyVersionException,
     TM1pyWriteFailureException,
     TM1pyWritePartialFailureException,
-    TM1pyNetworkException, 
 )

--- a/TM1py/Exceptions/__init__.py
+++ b/TM1py/Exceptions/__init__.py
@@ -7,4 +7,5 @@ from TM1py.Exceptions.Exceptions import (
     TM1pyVersionException,
     TM1pyWriteFailureException,
     TM1pyWritePartialFailureException,
+    TM1pyNetworkException, 
 )

--- a/TM1py/Services/RestService.py
+++ b/TM1py/Services/RestService.py
@@ -34,7 +34,12 @@ except ImportError:
 
 import http.client as http_client
 
-from TM1py.Exceptions import TM1pyTimeout, TM1pyVersionDeprecationException, TM1pyNetworkException, TM1pyRestException
+from TM1py.Exceptions import (
+    TM1pyNetworkException,
+    TM1pyRestException,
+    TM1pyTimeout,
+    TM1pyVersionDeprecationException,
+)
 
 
 class AuthenticationMode(Enum):
@@ -1151,10 +1156,10 @@ class RestService:
         :Exceptions:
             TM1pyException, raises TM1pyException when Code is not 200, 204 etc.
         """
-              
         if not response.ok:
             content_type = response.headers.get("Content-Type", "")
-            if "text/html" in content_type.lower() or response.text.lstrip().startswith("<!DOCTYPE"):
+            body_start = response.text.lstrip().lower()
+            if "text/html" in content_type.lower() or body_start.startswith(("<!doctype", "<html")):
                 raise TM1pyNetworkException(
                     response.text,
                     status_code=response.status_code,

--- a/TM1py/Services/RestService.py
+++ b/TM1py/Services/RestService.py
@@ -20,7 +20,6 @@ from requests.adapters import HTTPAdapter
 from requests.auth import HTTPBasicAuth
 from urllib3._collections import HTTPHeaderDict
 
-from TM1py.Exceptions.Exceptions import TM1pyTimeout, TM1pyVersionDeprecationException, TM1pyNetworkException
 from TM1py.Utils import (
     CaseAndSpaceInsensitiveSet,
     HTTPAdapterWithSocketOptions,
@@ -35,7 +34,7 @@ except ImportError:
 
 import http.client as http_client
 
-from TM1py.Exceptions import TM1pyRestException
+from TM1py.Exceptions import TM1pyTimeout, TM1pyVersionDeprecationException, TM1pyNetworkException, TM1pyRestException
 
 
 class AuthenticationMode(Enum):
@@ -507,7 +506,7 @@ class RestService:
             except TM1pyTimeout:
                 # Re-raise timeout exceptions as-is
                 raise
-            except TM1pyRestException:
+            except (TM1pyRestException, TM1pyNetworkException):
                 # Re-raise TM1 exceptions as-is
                 raise
             except Exception as retry_error:
@@ -1155,7 +1154,7 @@ class RestService:
               
         if not response.ok:
             content_type = response.headers.get("Content-Type", "")
-            if "text/html" in content_type or response.text.lstrip().startswith("<!DOCTYPE"):
+            if "text/html" in content_type.lower() or response.text.lstrip().startswith("<!DOCTYPE"):
                 raise TM1pyNetworkException(
                     response.text,
                     status_code=response.status_code,

--- a/TM1py/Services/RestService.py
+++ b/TM1py/Services/RestService.py
@@ -20,7 +20,7 @@ from requests.adapters import HTTPAdapter
 from requests.auth import HTTPBasicAuth
 from urllib3._collections import HTTPHeaderDict
 
-from TM1py.Exceptions.Exceptions import TM1pyTimeout, TM1pyVersionDeprecationException
+from TM1py.Exceptions.Exceptions import TM1pyTimeout, TM1pyVersionDeprecationException, TM1pyNetworkException
 from TM1py.Utils import (
     CaseAndSpaceInsensitiveSet,
     HTTPAdapterWithSocketOptions,
@@ -1152,9 +1152,21 @@ class RestService:
         :Exceptions:
             TM1pyException, raises TM1pyException when Code is not 200, 204 etc.
         """
+              
         if not response.ok:
+            content_type = response.headers.get("Content-Type", "")
+            if "text/html" in content_type or response.text.lstrip().startswith("<!DOCTYPE"):
+                raise TM1pyNetworkException(
+                    response.text,
+                    status_code=response.status_code,
+                    reason=response.reason,
+                    headers=response.headers
+                )
             raise TM1pyRestException(
-                response.text, status_code=response.status_code, reason=response.reason, headers=response.headers
+                response.text,
+                status_code=response.status_code,
+                reason=response.reason,
+                headers=response.headers
             )
 
     @staticmethod

--- a/TM1py/Services/RestService.py
+++ b/TM1py/Services/RestService.py
@@ -1161,16 +1161,10 @@ class RestService:
             body_start = response.text.lstrip().lower()
             if "text/html" in content_type.lower() or body_start.startswith(("<!doctype", "<html")):
                 raise TM1pyNetworkException(
-                    response.text,
-                    status_code=response.status_code,
-                    reason=response.reason,
-                    headers=response.headers
+                    response.text, status_code=response.status_code, reason=response.reason, headers=response.headers
                 )
             raise TM1pyRestException(
-                response.text,
-                status_code=response.status_code,
-                reason=response.reason,
-                headers=response.headers
+                response.text, status_code=response.status_code, reason=response.reason, headers=response.headers
             )
 
     @staticmethod

--- a/Tests/NetworkException_test.py
+++ b/Tests/NetworkException_test.py
@@ -46,9 +46,10 @@ GENERIC_HTML_NO_RAY_ID = """<!DOCTYPE html>
 
 SAMPLE_HEADERS = {"Content-Type": "text/html", "Connection": "keep-alive"}
 
+
 class TestNetworkException(unittest.TestCase):
 
-    # Instantiation & properties                                
+    # Instantiation & properties
     def test_status_code_property(self):
         exc = TM1pyNetworkException(
             response=GENERIC_HTML_NO_RAY_ID,
@@ -112,8 +113,7 @@ class TestNetworkException(unittest.TestCase):
         self.assertIn("9ef02047ab37aac9", result)
         self.assertIn("Cloudflare Ray ID", result)
 
-
-    # Ray ID extraction                                            
+    # Ray ID extraction
     def test_ray_id_extracted_with_colon_format(self):
         exc = TM1pyNetworkException(
             response=CLOUDFLARE_HTML_COLON_FORMAT,
@@ -159,8 +159,7 @@ class TestNetworkException(unittest.TestCase):
         )
         self.assertIsNone(exc.ray_id)
 
-
-    # Inheritance test         
+    # Inheritance test
     def test_is_instance_of_tm1py_exception(self):
         exc = TM1pyNetworkException(
             response=GENERIC_HTML_NO_RAY_ID,

--- a/Tests/NetworkException_test.py
+++ b/Tests/NetworkException_test.py
@@ -2,10 +2,14 @@
 
 import unittest
 
-from TM1py.Exceptions.Exceptions import TM1pyException, TM1pyNetworkException, TM1pyRestException
 from requests import Response
-from TM1py.Services.RestService import RestService
 
+from TM1py.Exceptions.Exceptions import (
+    TM1pyException,
+    TM1pyNetworkException,
+    TM1pyRestException,
+)
+from TM1py.Services.RestService import RestService
 
 CLOUDFLARE_HTML_WITH_RAY_ID = """<!DOCTYPE html>
 <html>
@@ -207,9 +211,58 @@ class TestNetworkException(unittest.TestCase):
         response._content = CLOUDFLARE_HTML_WITH_RAY_ID.encode("utf-8")
         response.headers = {"Content-Type": "text/html"}
         response.reason = "Forbidden"
-        
+
         with self.assertRaises(TM1pyNetworkException):
             RestService.verify_response(response)
+
+    def test_verify_response_raises_network_exception_for_html_body_without_html_content_type(self):
+        """HTML body detected via the <!DOCTYPE signature even when Content-Type is not text/html."""
+        response = Response()
+        response.status_code = 502
+        response._content = GENERIC_HTML_NO_RAY_ID.encode("utf-8")
+        response.headers = {"Content-Type": "application/octet-stream"}
+        response.reason = "Bad Gateway"
+
+        with self.assertRaises(TM1pyNetworkException):
+            RestService.verify_response(response)
+
+    def test_verify_response_raises_network_exception_for_html_content_type_without_doctype(self):
+        """text/html Content-Type (with charset) detected even when the body has no <!DOCTYPE prefix."""
+        response = Response()
+        response.status_code = 403
+        response._content = b"<html><body>blocked</body></html>"
+        response.headers = {"Content-Type": "text/html; charset=utf-8"}
+        response.reason = "Forbidden"
+
+        with self.assertRaises(TM1pyNetworkException):
+            RestService.verify_response(response)
+
+    def test_verify_response_raises_rest_exception_for_json_error(self):
+        """Genuine TM1 REST errors (JSON, non-HTML) must still raise TM1pyRestException."""
+        response = Response()
+        response.status_code = 400
+        response._content = b'{"error":{"message":"Invalid MDX statement"}}'
+        response.headers = {"Content-Type": "application/json"}
+        response.reason = "Bad Request"
+
+        with self.assertRaises(TM1pyRestException):
+            RestService.verify_response(response)
+
+        try:
+            RestService.verify_response(response)
+        except TM1pyRestException as exc:
+            self.assertNotIsInstance(exc, TM1pyNetworkException)
+
+    def test_verify_response_does_not_raise_for_ok_response(self):
+        """A successful response must pass through without raising, even with an HTML-ish body."""
+        response = Response()
+        response.status_code = 200
+        response._content = b"<!DOCTYPE html><html></html>"
+        response.headers = {"Content-Type": "text/html"}
+        response.reason = "OK"
+
+        self.assertIsNone(RestService.verify_response(response))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Tests/NetworkException_test.py
+++ b/Tests/NetworkException_test.py
@@ -1,0 +1,215 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+
+from TM1py.Exceptions.Exceptions import TM1pyException, TM1pyNetworkException, TM1pyRestException
+from requests import Response
+from TM1py.Services.RestService import RestService
+
+
+CLOUDFLARE_HTML_WITH_RAY_ID = """<!DOCTYPE html>
+<html>
+<head><title>Attention Required! | Cloudflare</title></head>
+<body>
+<h1>You have been blocked</h1>
+<p>Sorry, you have been blocked from accessing this resource.</p>
+<p>Cloudflare Ray ID: 9ef02047ab37aac9</p>
+</body>
+</html>"""
+
+CLOUDFLARE_HTML_COLON_FORMAT = """<!DOCTYPE html>
+<html>
+<body>
+<p>Ray ID: abc123def456</p>
+</body>
+</html>"""
+
+CLOUDFLARE_HTML_SPACE_FORMAT = """<!DOCTYPE html>
+<html>
+<body>
+<p>Ray ID abc123def456</p>
+</body>
+</html>"""
+
+GENERIC_HTML_NO_RAY_ID = """<!DOCTYPE html>
+<html>
+<head><title>502 Bad Gateway</title></head>
+<body>
+<h1>502 Bad Gateway</h1>
+<p>nginx</p>
+</body>
+</html>"""
+
+SAMPLE_HEADERS = {"Content-Type": "text/html", "Connection": "keep-alive"}
+
+class TestNetworkException(unittest.TestCase):
+
+    # Instantiation & properties                                
+    def test_status_code_property(self):
+        exc = TM1pyNetworkException(
+            response=GENERIC_HTML_NO_RAY_ID,
+            status_code=403,
+            reason="Forbidden",
+            headers=SAMPLE_HEADERS,
+        )
+        self.assertEqual(exc.status_code, 403)
+
+    def test_reason_property(self):
+        exc = TM1pyNetworkException(
+            response=GENERIC_HTML_NO_RAY_ID,
+            status_code=403,
+            reason="Forbidden",
+            headers=SAMPLE_HEADERS,
+        )
+        self.assertEqual(exc.reason, "Forbidden")
+
+    def test_headers_property(self):
+        exc = TM1pyNetworkException(
+            response=GENERIC_HTML_NO_RAY_ID,
+            status_code=403,
+            reason="Forbidden",
+            headers=SAMPLE_HEADERS,
+        )
+        self.assertEqual(exc.headers, SAMPLE_HEADERS)
+
+    def test_response_property_mirrors_message(self):
+        exc = TM1pyNetworkException(
+            response=GENERIC_HTML_NO_RAY_ID,
+            status_code=403,
+            reason="Forbidden",
+            headers=SAMPLE_HEADERS,
+        )
+        self.assertEqual(exc.response, exc.message)
+        self.assertEqual(exc.response, GENERIC_HTML_NO_RAY_ID)
+
+    # __str__test
+    def test_str_without_ray_id(self):
+        exc = TM1pyNetworkException(
+            response=GENERIC_HTML_NO_RAY_ID,
+            status_code=502,
+            reason="Bad Gateway",
+            headers=SAMPLE_HEADERS,
+        )
+        result = str(exc)
+        self.assertIn("502", result)
+        self.assertIn("Bad Gateway", result)
+        self.assertNotIn("Cloudflare Ray ID", result)
+
+    def test_str_with_ray_id(self):
+        exc = TM1pyNetworkException(
+            response=CLOUDFLARE_HTML_WITH_RAY_ID,
+            status_code=403,
+            reason="Forbidden",
+            headers=SAMPLE_HEADERS,
+        )
+        result = str(exc)
+        self.assertIn("403", result)
+        self.assertIn("Forbidden", result)
+        self.assertIn("9ef02047ab37aac9", result)
+        self.assertIn("Cloudflare Ray ID", result)
+
+
+    # Ray ID extraction                                            
+    def test_ray_id_extracted_with_colon_format(self):
+        exc = TM1pyNetworkException(
+            response=CLOUDFLARE_HTML_COLON_FORMAT,
+            status_code=403,
+            reason="Forbidden",
+            headers=SAMPLE_HEADERS,
+        )
+        self.assertEqual(exc.ray_id, "abc123def456")
+
+    def test_ray_id_extracted_with_space_format(self):
+        exc = TM1pyNetworkException(
+            response=CLOUDFLARE_HTML_SPACE_FORMAT,
+            status_code=403,
+            reason="Forbidden",
+            headers=SAMPLE_HEADERS,
+        )
+        self.assertEqual(exc.ray_id, "abc123def456")
+
+    def test_ray_id_extracted_from_real_cloudflare_html(self):
+        exc = TM1pyNetworkException(
+            response=CLOUDFLARE_HTML_WITH_RAY_ID,
+            status_code=403,
+            reason="Forbidden",
+            headers=SAMPLE_HEADERS,
+        )
+        self.assertEqual(exc.ray_id, "9ef02047ab37aac9")
+
+    def test_ray_id_is_none_for_generic_html(self):
+        exc = TM1pyNetworkException(
+            response=GENERIC_HTML_NO_RAY_ID,
+            status_code=502,
+            reason="Bad Gateway",
+            headers=SAMPLE_HEADERS,
+        )
+        self.assertIsNone(exc.ray_id)
+
+    def test_ray_id_is_none_for_empty_response(self):
+        exc = TM1pyNetworkException(
+            response="",
+            status_code=403,
+            reason="Forbidden",
+            headers=SAMPLE_HEADERS,
+        )
+        self.assertIsNone(exc.ray_id)
+
+
+    # Inheritance test         
+    def test_is_instance_of_tm1py_exception(self):
+        exc = TM1pyNetworkException(
+            response=GENERIC_HTML_NO_RAY_ID,
+            status_code=403,
+            reason="Forbidden",
+            headers=SAMPLE_HEADERS,
+        )
+        self.assertIsInstance(exc, TM1pyException)
+
+    def test_is_not_instance_of_tm1py_rest_exception(self):
+        exc = TM1pyNetworkException(
+            response=GENERIC_HTML_NO_RAY_ID,
+            status_code=403,
+            reason="Forbidden",
+            headers=SAMPLE_HEADERS,
+        )
+        self.assertNotIsInstance(exc, TM1pyRestException)
+
+    def test_can_be_raised_and_caught_as_tm1py_exception(self):
+        with self.assertRaises(TM1pyException):
+            raise TM1pyNetworkException(
+                response=GENERIC_HTML_NO_RAY_ID,
+                status_code=403,
+                reason="Forbidden",
+                headers=SAMPLE_HEADERS,
+            )
+
+    def test_not_caught_by_tm1py_rest_exception_handler(self):
+        """Existing except TM1pyRestException blocks must NOT swallow this exception."""
+        caught_as_rest = False
+        try:
+            raise TM1pyNetworkException(
+                response=GENERIC_HTML_NO_RAY_ID,
+                status_code=403,
+                reason="Forbidden",
+                headers=SAMPLE_HEADERS,
+            )
+        except TM1pyRestException:
+            caught_as_rest = True
+        except TM1pyException:
+            pass
+
+        self.assertFalse(caught_as_rest, "TM1pyNetworkException must not be caught by TM1pyRestException handler")
+
+    def test_verify_response_raises_network_exception_for_html(self):
+        response = Response()
+        response.status_code = 403
+        response._content = CLOUDFLARE_HTML_WITH_RAY_ID.encode("utf-8")
+        response.headers = {"Content-Type": "text/html"}
+        response.reason = "Forbidden"
+        
+        with self.assertRaises(TM1pyNetworkException):
+            RestService.verify_response(response)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**PR: Raise TM1pyNetworkException for HTML / Cloudflare responses**

**Summary**
This PR adds a new exception type, TM1pyNetworkException, to handle network/WAF/Cloudflare HTML error pages that are not valid TM1 REST responses, and misleading as TM1 has not received any message. These responses previously caused TM1pyRestException to be raised with confusing error messages.

**Problem**
When TM1 is fronted by Cloudflare, load balancers, proxies, or WAFs, upstream failures often return HTML pages, not JSON.
RestService.verify_response attempted to parse these as TM1 REST errors, resulting in:

- misleading exception messages
- JSON decode errors
- exceptions being caught incorrectly by except TM1pyRestException blocks

_This behaviour is tracked in Issue #1393._

**Solution**
1. Added new exception: TM1pyNetworkException
2. Extracts Cloudflare Ray ID when present
3. Provides clearer error messages for HTML responses
4. Is not a subclass of TM1pyRestException

Updated RestService.verify_response:

1. Detects HTML responses via Content-Type or <html> signature
2. Raises TM1pyNetworkException instead of TM1pyRestException

Added unit tests:
1. Exception properties and formatting
2. Ray ID extraction (colon, space, Cloudflare formats)
3. Inheritance behaviour
4. Integration test for verify_response raising the new exception

**Impact**
- No breaking changes for existing TM1 REST workflows
- Existing except TM1pyRestException blocks continue to behave correctly
- HTML/WAF/Cloudflare failures now produce clear, actionable errors
- Fully backwards‑compatible for environments not using Cloudflare

**Fixes**
Fixes #1393