### PR TITLE
Improve comments for legacy subset_name support (to close #1302)

### DIFF
--- a/TM1py/Services/SubsetService.py
+++ b/TM1py/Services/SubsetService.py
@@ -214,11 +214,12 @@ class SubsetService(ObjectService):
         :param dimension_name: Name of the dimension.
         :param hierarchy_name: Name of the hierarchy.
         :param subset: Subset name (str) or Subset object.
+        :param subset_name: (legacy) subset name, supported for backwards compatibility.
         :param private: Whether the subset is private.
         :param kwargs: Additional arguments.
         :return: List of element names.
         """
-        # backward compatibility for subset_name
+        # backward compatibility for legacy 'subset_name' parameter (Issue #1302)
         if "subset_name" in kwargs:
             if subset is not None:
                 raise ValueError("Only one parameter 'subset' or 'subset_name' may be provided.")


### PR DESCRIPTION
This PR is intended to close Issue #1302 (legacy subset_name parameter was no longer supported in SubsetService.get_element_names()) for which it appears a fix (and unit testing) is already in place. 

I amended some commentary relating to subnet_name and provide the push to close the issue.

