### PR TITLE
Add opt-in gzip compression of request bodies at the transport seam

### DIFF
--- a/TM1py/Services/RestService.py
+++ b/TM1py/Services/RestService.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import gzip
 import json
 import re
 import socket
@@ -135,6 +136,9 @@ class RestService:
         - **proxies** (dict): Dictionary with proxies, e.g. {'http': 'http://proxy.example.com:8080', 'https': 'http://secureproxy.example.com:8090'}.
         - **ssl_context**: User-defined SSL context.
         - **cert** (str|tuple): (Optional) If string, path to SSL client cert file (.pem). If tuple, ('cert', 'key') pair.
+        - **compress_request_body** (bool): Gzip-compress request bodies at the transport seam. Opt-in. Default: False.
+        - **gzip_min_bytes** (int): Minimum (encoded) request body size in bytes to compress. Default: 1024.
+        - **gzip_compress_level** (int): Gzip compression level, 1 (fastest) to 9 (smallest). Default: 6.
 
         :param kwargs: See description above for all supported arguments
         """
@@ -172,6 +176,10 @@ class RestService:
         self._async_polling_initial_delay = float(kwargs.get("async_polling_initial_delay", 0.1))
         self._async_polling_max_delay = float(kwargs.get("async_polling_max_delay", 1.0))
         self._async_polling_backoff_factor = float(kwargs.get("async_polling_backoff_factor", 2))
+        # gzip compression of the request body (opt-in)
+        self._compress_request_body = self.translate_to_boolean(kwargs.get("compress_request_body", False))
+        self._gzip_min_bytes = int(kwargs.get("gzip_min_bytes", 1024))
+        self._gzip_compress_level = int(kwargs.get("gzip_compress_level", 6))
         # is retrieved on demand and then cached
         self._sandboxing_disabled = None
         # optional verbose logging to stdout
@@ -280,6 +288,11 @@ class RestService:
         Execute a request to TM1 REST API
         """
         url, data = self._url_and_body(url=url, data=data, encoding=encoding)
+
+        # Compress the request body once, before any retry path, so that the sync, async and
+        # reconnect/retry code paths all re-send the same compressed bytes (no double-compression).
+        if self._compress_request_body:
+            data, kwargs["headers"] = self._maybe_compress_body(data, kwargs.get("headers") or {})
 
         timeout = timeout if timeout else self._timeout
 
@@ -1030,6 +1043,43 @@ class RestService:
         if isinstance(data, str):
             data = data.encode(encoding)
         return url, data
+
+    def _maybe_compress_body(self, data: Union[bytes, BytesIO], headers: Dict) -> Tuple[Union[bytes, BytesIO], Dict]:
+        """Gzip-compress the request body at the transport seam.
+
+        Called exactly once per request (from `request`, before any retry path) so the sync,
+        async and reconnect/retry code paths all re-send the same compressed bytes. Returns the
+        (possibly compressed) body together with the (possibly updated) headers.
+
+        The body is left untouched - and no `Content-Encoding` header is added - when the body
+        is empty or smaller than `gzip_min_bytes`, or when a `Content-Encoding` header is already
+        present (so a caller can pre-encode a body or opt a single request out). Compressing the
+        body and stamping the header are a single atomic decision.
+        """
+        # Normalize the body to bytes for the size check and compression. `_url_and_body` already
+        # encodes str -> bytes; bytes and BytesIO bodies (binary uploads) pass through to here.
+        if isinstance(data, BytesIO):
+            # getvalue() does not consume the stream, so the original `data` stays usable
+            raw = data.getvalue()
+        elif isinstance(data, (bytes, bytearray)):
+            raw = bytes(data)
+        else:
+            return data, headers
+
+        # skip empty / tiny bodies: gzip framing overhead outweighs the benefit
+        if not raw or len(raw) < self._gzip_min_bytes:
+            return data, headers
+
+        # never double-encode an already-encoded body
+        if any(key.lower() == "content-encoding" for key in headers):
+            return data, headers
+
+        compressed = gzip.compress(raw, compresslevel=self._gzip_compress_level)
+        # build a fresh headers dict; never mutate self._headers or the caller's dict.
+        # drop any stale Content-Length so the transport recomputes it from the compressed bytes.
+        new_headers = {key: value for key, value in headers.items() if key.lower() != "content-length"}
+        new_headers["Content-Encoding"] = "gzip"
+        return compressed, new_headers
 
     def is_connected(self) -> bool:
         """Check if Connection to TM1 Server is established.

--- a/TM1py/Services/RestService.py
+++ b/TM1py/Services/RestService.py
@@ -178,8 +178,10 @@ class RestService:
         self._async_polling_backoff_factor = float(kwargs.get("async_polling_backoff_factor", 2))
         # gzip compression of the request body (opt-in)
         self._compress_request_body = self.translate_to_boolean(kwargs.get("compress_request_body", False))
-        self._gzip_min_bytes = int(kwargs.get("gzip_min_bytes", 1024))
+        self._gzip_min_bytes = max(0, int(kwargs.get("gzip_min_bytes", 1024)))
         self._gzip_compress_level = int(kwargs.get("gzip_compress_level", 6))
+        if not 1 <= self._gzip_compress_level <= 9:
+            raise ValueError("'gzip_compress_level' must be an int between 1 and 9")
         # is retrieved on demand and then cached
         self._sandboxing_disabled = None
         # optional verbose logging to stdout

--- a/TM1py/Services/RestService.py
+++ b/TM1py/Services/RestService.py
@@ -180,6 +180,8 @@ class RestService:
         self._compress_request_body = self.translate_to_boolean(kwargs.get("compress_request_body", False))
         self._gzip_min_bytes = max(0, int(kwargs.get("gzip_min_bytes", 1024)))
         self._gzip_compress_level = int(kwargs.get("gzip_compress_level", 6))
+        # validate the level up front: an out-of-range value otherwise raises a zlib.error deep
+        # inside gzip.compress at request time, which is harder to trace back to this kwarg.
         if not 1 <= self._gzip_compress_level <= 9:
             raise ValueError("'gzip_compress_level' must be an int between 1 and 9")
         # is retrieved on demand and then cached
@@ -1061,8 +1063,12 @@ class RestService:
         # Normalize the body to bytes for the size check and compression. `_url_and_body` already
         # encodes str -> bytes; bytes and BytesIO bodies (binary uploads) pass through to here.
         if isinstance(data, BytesIO):
-            # getvalue() does not consume the stream, so the original `data` stays usable
-            raw = data.getvalue()
+            # read from the stream's current position to EOF - exactly what the transport would
+            # upload for the uncompressed body - then restore the pointer so the original `data`
+            # stays usable (a caller may have intentionally seeked it).
+            pos = data.tell()
+            raw = data.read()
+            data.seek(pos)
         elif isinstance(data, (bytes, bytearray)):
             raw = bytes(data)
         else:

--- a/TM1py/Services/TM1Service.py
+++ b/TM1py/Services/TM1Service.py
@@ -91,6 +91,9 @@ class TM1Service:
         - **proxies** (dict): Dictionary of proxies, e.g., {'http': 'http://proxy.example.com:8080'}.
         - **ssl_context**: User-defined SSL context.
         - **cert** (str or tuple): Path to SSL client cert file or ('cert', 'key') pair.
+        - **compress_request_body** (bool): Gzip-compress request bodies at the transport seam. Opt-in. Default: False.
+        - **gzip_min_bytes** (int): Minimum (encoded) request body size in bytes to compress. Default: 1024.
+        - **gzip_compress_level** (int): Gzip compression level, 1 (fastest) to 9 (smallest). Default: 6.
 
         :param kwargs: See description above for all supported arguments
 

--- a/Tests/RestService_test.py
+++ b/Tests/RestService_test.py
@@ -1,8 +1,12 @@
 import configparser
+import gzip
 import unittest
+import uuid
+from io import BytesIO
 from pathlib import Path
 
 from TM1py import TM1Service
+from TM1py.Objects import Process
 from TM1py.Services.RestService import RestService
 
 
@@ -207,6 +211,186 @@ class TestRestService(unittest.TestCase):
             '{"error":{"code":"278","message":"\'dummy\' ' "can not be found in collection of type 'Process'.\"}}",
         )
 
+    def test_live_request_body_compression_roundtrip(self):
+        """End-to-end: a gzip-compressed request body is accepted by the live server and
+        round-trips correctly. Creates a process with a body well above the default threshold,
+        reads it back, and confirms our marker survived server-side decompression."""
+        config = dict(self.config["tm1srv01"])
+        config["compress_request_body"] = "True"
+        config["gzip_min_bytes"] = "1"
+
+        process_name = "TM1py_Tests_gzip_" + str(uuid.uuid4()).replace("-", "")
+        marker = "sMarker = '" + process_name + "';"
+        # build a prolog comfortably larger than the default 1024-byte threshold
+        prolog = marker + "\r\n" + "\r\n".join(f"sFiller{i} = '{i}';" for i in range(300))
+
+        with TM1Service(**config) as tm1:
+            self.assertTrue(tm1._tm1_rest._compress_request_body)
+            process = Process(name=process_name, datasource_type="None", prolog_procedure=prolog)
+            try:
+                tm1.processes.create(process)
+                retrieved = tm1.processes.get(process_name)
+                self.assertEqual(process_name, retrieved.name)
+                self.assertIn(marker, retrieved.prolog_procedure)
+            finally:
+                if tm1.processes.exists(process_name):
+                    tm1.processes.delete(process_name)
+
     @classmethod
     def tearDownClass(cls):
         cls.tm1.logout()
+
+
+class _FakeResponse:
+    """Minimal stand-in for a requests.Response used by the seam-level unit tests."""
+
+    def __init__(self, status_code: int, headers: dict = None, text: str = ""):
+        self.status_code = status_code
+        self.ok = 200 <= status_code < 300
+        self.headers = headers or {}
+        self.text = text
+        self.reason = "OK" if self.ok else "ERROR"
+        self.encoding = None
+        self.content = text.encode("utf-8") if isinstance(text, str) else text
+
+
+class _RecordingSession:
+    """Captures the (data, headers) handed to the transport so tests can assert on the wire bytes."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = []
+
+    def request(self, method, url, data=None, verify=None, timeout=None, **kwargs):
+        self.calls.append({"method": method, "url": url, "data": data, "headers": kwargs.get("headers")})
+        return self._responses.pop(0)
+
+    def close(self):
+        pass
+
+
+class TestRequestBodyCompressionHelper(unittest.TestCase):
+    """Unit tests for RestService._maybe_compress_body (no server connection)."""
+
+    @staticmethod
+    def _rest(min_bytes: int = 1024, level: int = 6) -> RestService:
+        rest = object.__new__(RestService)
+        rest._compress_request_body = True
+        rest._gzip_min_bytes = min_bytes
+        rest._gzip_compress_level = level
+        return rest
+
+    def test_compress_roundtrip_sets_header(self):
+        rest = self._rest(min_bytes=1)
+        body = b'{"value": "' + b"x" * 2000 + b'"}'
+        data, headers = rest._maybe_compress_body(body, {"Content-Type": "application/json"})
+        self.assertEqual(headers["Content-Encoding"], "gzip")
+        self.assertEqual(headers["Content-Type"], "application/json")
+        self.assertEqual(gzip.decompress(data), body)
+        self.assertLess(len(data), len(body))
+
+    def test_below_threshold_not_compressed(self):
+        rest = self._rest(min_bytes=1024)
+        body = b'{"a": 1}'
+        data, headers = rest._maybe_compress_body(body, {"Content-Type": "application/json"})
+        self.assertEqual(data, body)
+        self.assertNotIn("Content-Encoding", headers)
+
+    def test_empty_body_not_compressed(self):
+        rest = self._rest(min_bytes=1)
+        data, headers = rest._maybe_compress_body(b"", {})
+        self.assertEqual(data, b"")
+        self.assertNotIn("Content-Encoding", headers)
+
+    def test_bytes_path_compressed(self):
+        rest = self._rest(min_bytes=1)
+        body = b"binary-content-" + b"\x00\x01\x02" * 1000
+        data, headers = rest._maybe_compress_body(body, {})
+        self.assertEqual(headers["Content-Encoding"], "gzip")
+        self.assertEqual(gzip.decompress(data), body)
+
+    def test_bytesio_path_compressed_and_not_consumed(self):
+        rest = self._rest(min_bytes=1)
+        raw = b"stream-content-" + b"abc" * 1000
+        stream = BytesIO(raw)
+        data, headers = rest._maybe_compress_body(stream, {})
+        self.assertEqual(headers["Content-Encoding"], "gzip")
+        self.assertEqual(gzip.decompress(data), raw)
+        # the original BytesIO must remain intact (getvalue does not consume it)
+        self.assertEqual(stream.getvalue(), raw)
+
+    def test_preexisting_content_encoding_not_recompressed(self):
+        rest = self._rest(min_bytes=1)
+        already = gzip.compress(b"x" * 2000)
+        data, headers = rest._maybe_compress_body(already, {"Content-Encoding": "gzip"})
+        self.assertEqual(data, already)
+        # body is returned untouched - not gzipped a second time
+        self.assertEqual(gzip.decompress(data), b"x" * 2000)
+
+    def test_preexisting_content_encoding_case_insensitive(self):
+        rest = self._rest(min_bytes=1)
+        body = b"y" * 2000
+        data, headers = rest._maybe_compress_body(body, {"content-encoding": "identity"})
+        self.assertEqual(data, body)
+
+    def test_content_length_dropped_on_compression(self):
+        rest = self._rest(min_bytes=1)
+        body = b"z" * 2000
+        data, headers = rest._maybe_compress_body(body, {"Content-Length": "2000", "Content-Type": "text/plain"})
+        self.assertEqual(headers["Content-Encoding"], "gzip")
+        self.assertNotIn("Content-Length", headers)
+        self.assertEqual(headers["Content-Type"], "text/plain")
+
+
+class TestRequestBodyCompressionSeam(unittest.TestCase):
+    """Tests that compression is applied once at request() and survives the retry path."""
+
+    @staticmethod
+    def _rest(responses, compress=True, min_bytes=1) -> RestService:
+        rest = object.__new__(RestService)
+        rest._base_url = "https://tm1.example/api/v1"
+        rest._headers = {"Content-Type": "application/json; charset=utf-8"}
+        rest._compress_request_body = compress
+        rest._gzip_min_bytes = min_bytes
+        rest._gzip_compress_level = 6
+        rest._timeout = None
+        rest._cancel_at_timeout = False
+        rest._async_requests_mode = False
+        rest._re_connect_on_session_timeout = True
+        rest._verify = False
+        rest._s = _RecordingSession(responses)
+        rest.connect = lambda: None
+        return rest
+
+    def test_post_stamps_content_encoding_and_compresses(self):
+        rest = self._rest([_FakeResponse(200)])
+        body = '{"value": "' + "x" * 2000 + '"}'
+        rest.POST(url="/Cubes", data=body)
+
+        self.assertEqual(len(rest._s.calls), 1)
+        call = rest._s.calls[0]
+        self.assertEqual(call["headers"]["Content-Encoding"], "gzip")
+        self.assertEqual(gzip.decompress(call["data"]), body.encode("utf-8"))
+
+    def test_default_off_sends_raw_body(self):
+        rest = self._rest([_FakeResponse(200)], compress=False)
+        body = '{"value": "' + "x" * 2000 + '"}'
+        rest.POST(url="/Cubes", data=body)
+
+        call = rest._s.calls[0]
+        self.assertNotIn("Content-Encoding", call["headers"])
+        self.assertEqual(call["data"], body.encode("utf-8"))
+
+    def test_retry_after_401_not_double_compressed(self):
+        rest = self._rest([_FakeResponse(401), _FakeResponse(200)])
+        body = '{"value": "' + "x" * 2000 + '"}'
+        rest.POST(url="/Cubes", data=body)
+
+        # initial send + one retry after reconnect
+        self.assertEqual(len(rest._s.calls), 2)
+        first, second = rest._s.calls
+        # both sends carry the identical, single-member gzip body and exactly one Content-Encoding
+        self.assertEqual(first["data"], second["data"])
+        self.assertEqual(gzip.decompress(second["data"]), body.encode("utf-8"))
+        self.assertEqual(first["headers"]["Content-Encoding"], "gzip")
+        self.assertEqual(second["headers"]["Content-Encoding"], "gzip")

--- a/Tests/RestService_test.py
+++ b/Tests/RestService_test.py
@@ -316,8 +316,23 @@ class TestRequestBodyCompressionHelper(unittest.TestCase):
         data, headers = rest._maybe_compress_body(stream, {})
         self.assertEqual(headers["Content-Encoding"], "gzip")
         self.assertEqual(gzip.decompress(data), raw)
-        # the original BytesIO must remain intact (getvalue does not consume it)
+        # the original BytesIO must remain intact (reading it does not consume it)
         self.assertEqual(stream.getvalue(), raw)
+
+    def test_bytesio_path_reads_from_current_position(self):
+        # a caller may hand in a partially-read stream; we must compress exactly what the
+        # transport would otherwise upload (current position -> EOF) and leave the pointer put
+        rest = self._rest(min_bytes=1)
+        raw = b"header-to-skip-" + b"payload" * 1000
+        offset = len(b"header-to-skip-")
+        stream = BytesIO(raw)
+        stream.seek(offset)
+        data, headers = rest._maybe_compress_body(stream, {})
+        self.assertEqual(headers["Content-Encoding"], "gzip")
+        # only the bytes from the current position onward are compressed
+        self.assertEqual(gzip.decompress(data), raw[offset:])
+        # the stream pointer is restored so the original stays usable
+        self.assertEqual(stream.tell(), offset)
 
     def test_preexisting_content_encoding_not_recompressed(self):
         rest = self._rest(min_bytes=1)
@@ -394,3 +409,17 @@ class TestRequestBodyCompressionSeam(unittest.TestCase):
         self.assertEqual(gzip.decompress(second["data"]), body.encode("utf-8"))
         self.assertEqual(first["headers"]["Content-Encoding"], "gzip")
         self.assertEqual(second["headers"]["Content-Encoding"], "gzip")
+
+
+class TestRequestBodyCompressionInitValidation(unittest.TestCase):
+    """gzip_compress_level is validated at construction, before any network call."""
+
+    def test_out_of_range_level_raises_value_error(self):
+        # values outside 1..9 would otherwise raise a zlib.error deep inside gzip.compress
+        # at request time; we fail fast in __init__ with a clear message instead. The check
+        # runs before connect(), so no live server is required.
+        for level in (0, 10, -1):
+            with self.subTest(level=level):
+                with self.assertRaises(ValueError) as ctx:
+                    RestService(gzip_compress_level=level)
+                self.assertIn("gzip_compress_level", str(ctx.exception))


### PR DESCRIPTION
## Summary

Adds **opt-in** gzip compression of request bodies, applied uniformly at the single transport seam (`RestService.request` → `_url_and_body`). With the flag off (the default) behavior is completely unchanged.

When enabled, compression covers every data-API call across all services, in both sync and async request modes, and across all retry/reconnect paths.

## New kwargs (on `TM1Service` / `RestService`)

| kwarg | type | default | meaning |
|-------|------|---------|---------|
| `compress_request_body` | bool | `False` | Gzip-compress request bodies at the transport seam (opt-in). |
| `gzip_min_bytes` | int | `1024` | Minimum (encoded) body size in bytes before compressing. |
| `gzip_compress_level` | int | `6` | Gzip level, 1 (fastest) … 9 (smallest). |

## Behavior

- Compression is applied **exactly once** in `request()`, before any retry path, so the sync, async, 401-reconnect, and remote-disconnect retries all re-send the same compressed bytes (no double-compression).
- The helper normalizes `str`/`bytes`/`BytesIO` bodies, skips empty / sub-threshold bodies, skips bodies that already carry a `Content-Encoding` (so a caller can pre-encode or opt a single request out), drops any stale `Content-Length`, and stamps `Content-Encoding: gzip` atomically with the compression.
- Auth bootstrap, `ManageService`, and `Utils` adminhost calls bypass `request()` and are intentionally left uncompressed.

## Testing

- Added unit tests (mocked, no server) for the helper, the transport seam, and the no-double-compress-on-retry path.
- Verified end-to-end against live TM1 **v11 (11.8)** and **v12 (PA Engine)**.
- `black --check .` and `ruff check .` both pass.

## Compatibility

Fully backward compatible — the feature is off by default and the default code path is byte-for-byte unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
